### PR TITLE
Update PDF generation to use URL and optional format parameter

### DIFF
--- a/components/Servicios/Utils/SubHeader.tsx
+++ b/components/Servicios/Utils/SubHeader.tsx
@@ -55,7 +55,8 @@ export const SubHeader: FC<props> = ({ view, itinerario, editTitle, setEditTitle
         try {
             setLoading(true);
             const response = await axios.post('/api/generate-pdf', {
-                html: `${window.location.origin}/public-itinerary/itinerary-${event._id}-${itinerario._id}`
+                url: `${window.location.origin}/public-itinerary/itinerary-${event._id}-${itinerario._id}`,
+                // format: "legal"
             });
             const blob = new Blob([Uint8Array.from(atob(response.data.base64), c => c.charCodeAt(0))], { type: 'application/pdf' });
             const url = window.URL.createObjectURL(blob);

--- a/pages/api/generate-pdf.ts
+++ b/pages/api/generate-pdf.ts
@@ -3,11 +3,14 @@ import { generatePdf } from './services/pdfGenerator';
 import axios from 'axios';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { html } = req.body;
+  const { url, format } = req.body;
   try {
     const response = await axios.post(
-      "https://api-convert.bodasdehoy.com/html-to-pdf",
-      { html },
+      "https://api-convert.bodasdehoy.com/url-to-pdf",
+      {
+        url,
+        format
+      },
       { responseType: "arraybuffer" }
     );
     const base64 = btoa(


### PR DESCRIPTION
- Changed the PDF generation request in SubHeader to send a URL instead of HTML.
- Updated the API handler to accept a format parameter for flexibility in PDF generation.
- Enhanced the integration with the external PDF conversion service for improved functionality.