### PR TITLE
A2 prep: soportar campos nuevos Track B en conversaciones

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ChannelSidebar.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ChannelSidebar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { useAuthCheck } from '@/hooks/useAuthCheck';
 import { useChatStore } from '@/store/chat';
 import { api2Client } from '@/services/api2/client';
 import { getUnreadNotificationsCount } from '@/services/api2/notifications';
@@ -38,6 +39,8 @@ interface ChannelSidebarProps {
   /** Compact mode: panel fijo de 320px en desktop layout. Full: pantalla completa mobile. */
   compact?: boolean;
 }
+
+type InboxView = 'all' | 'mine' | 'unassigned' | 'closed';
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -351,6 +354,8 @@ function ChannelRow({ channel, onClick }: { channel: InboxChannel; onClick: () =
 export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
   const router = useRouter();
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const { checkAuth } = useAuthCheck();
+  const { userId } = checkAuth();
 
   // Data hooks
   const { summaries: events, loading: eventsLoading } = useEventSummaries();
@@ -378,6 +383,30 @@ export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
   // Search & filter state
   const [search, setSearch] = useState('');
   const [channelFilter, setChannelFilter] = useState<ChannelFilter>('all');
+  const [activeView, setActiveView] = useState<InboxView>('all');
+
+  const isClosed = useCallback((status?: string) => {
+    const s = (status || '').toString().toUpperCase();
+    return s === 'CLOSED' || s === 'ARCHIVED';
+  }, []);
+
+  const viewCounts = useMemo(() => {
+    let mine = 0;
+    let unassigned = 0;
+    let closed = 0;
+    for (const c of recentConvs) {
+      if (isClosed(c.status)) {
+        closed++;
+        continue;
+      }
+      if (!c.assignedToUserId) {
+        unassigned++;
+        continue;
+      }
+      if (userId && c.assignedToUserId === userId) mine++;
+    }
+    return { closed, mine, unassigned };
+  }, [isClosed, recentConvs, userId]);
 
   // Notification count
   const [unreadNotifs, setUnreadNotifs] = useState(0);
@@ -396,6 +425,11 @@ export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
   // Filtered conversations
   const filteredConvs = useMemo(() => {
     let list = recentConvs;
+    if (activeView !== 'all') {
+      if (activeView === 'mine') list = list.filter((c) => !!userId && c.assignedToUserId === userId);
+      else if (activeView === 'unassigned') list = list.filter((c) => !c.assignedToUserId);
+      else if (activeView === 'closed') list = list.filter((c) => isClosed(c.status));
+    }
     if (channelFilter !== 'all') {
       list = list.filter((c) => c.kind === channelFilter);
     }
@@ -406,7 +440,7 @@ export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
       );
     }
     return list;
-  }, [recentConvs, channelFilter, search]);
+  }, [recentConvs, activeView, channelFilter, isClosed, search, userId]);
 
   // Filtered tasks
   const filteredTasks = useMemo(() => {
@@ -550,6 +584,44 @@ export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
             </div>
           </div>
         )}
+
+        <div className="shrink-0 px-2 pt-2">
+          <div className="flex gap-1">
+            <button
+              className={`flex-1 rounded-md px-2 py-1.5 text-[10px] font-semibold transition-colors ${
+                activeView === 'mine'
+                  ? 'bg-blue-50 text-blue-700'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+              onClick={() => setActiveView(activeView === 'mine' ? 'all' : 'mine')}
+              type="button"
+            >
+              Mis asignadas{viewCounts.mine > 0 ? ` · ${viewCounts.mine}` : ''}
+            </button>
+            <button
+              className={`flex-1 rounded-md px-2 py-1.5 text-[10px] font-semibold transition-colors ${
+                activeView === 'unassigned'
+                  ? 'bg-amber-50 text-amber-800'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+              onClick={() => setActiveView(activeView === 'unassigned' ? 'all' : 'unassigned')}
+              type="button"
+            >
+              Sin asignar{viewCounts.unassigned > 0 ? ` · ${viewCounts.unassigned}` : ''}
+            </button>
+            <button
+              className={`flex-1 rounded-md px-2 py-1.5 text-[10px] font-semibold transition-colors ${
+                activeView === 'closed'
+                  ? 'bg-gray-200 text-gray-800'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+              onClick={() => setActiveView(activeView === 'closed' ? 'all' : 'closed')}
+              type="button"
+            >
+              Cerradas{viewCounts.closed > 0 ? ` · ${viewCounts.closed}` : ''}
+            </button>
+          </div>
+        </div>
 
         {/* ── Search ── */}
         <div className="shrink-0 px-2 pt-2">

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useConversations.ts
@@ -5,6 +5,7 @@ import { useAuthCheck } from '@/hooks/useAuthCheck';
 import { buildHeaders } from '../utils/auth';
 
 export interface Conversation {
+  assignedToUserId?: string | null;
   channel: 'whatsapp' | 'instagram' | 'telegram' | 'email' | 'web' | 'facebook';
   contact: {
     avatar?: string;
@@ -18,7 +19,14 @@ export interface Conversation {
     text: string;
     timestamp: string;
   };
+  lastInboundAt?: string;
+  lastOutboundAt?: string;
+  labels?: any[];
+  linkedContactId?: string | null;
+  linkedEventId?: string | null;
+  status?: string;
   unreadCount: number;
+  unreadCountForAgent?: number;
 }
 
 export function useConversations(channel: string | null) {
@@ -55,6 +63,7 @@ export function useConversations(channel: string | null) {
         const data = await response.json();
         const rawList = Array.isArray(data) ? data : data.conversations || [];
         const normalized: Conversation[] = rawList.map((c: any) => ({
+          assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
           channel: (c.channel || c.platform || channel || 'whatsapp') as Conversation['channel'],
           contact: {
             name: c.displayName || c.phoneNumber || 'Desconocido',
@@ -66,7 +75,14 @@ export function useConversations(channel: string | null) {
             text: c.lastMessage || '',
             timestamp: c.lastMessageAt || c.updatedAt || new Date().toISOString(),
           },
+          lastInboundAt: c.lastInboundAt ?? c.last_inbound_at ?? undefined,
+          lastOutboundAt: c.lastOutboundAt ?? c.last_outbound_at ?? undefined,
+          labels: c.labels ?? c.labelIds ?? c.label_ids ?? undefined,
+          linkedContactId: c.linkedContactId ?? c.linked_contact_id ?? null,
+          linkedEventId: c.linkedEventId ?? c.linked_event_id ?? null,
+          status: c.status ?? c.conversationStatus ?? undefined,
           unreadCount: c.unreadCount || 0,
+          unreadCountForAgent: c.unreadCountForAgent ?? c.unread_count_for_agent ?? undefined,
         }));
         const filtered = channel ? normalized.filter((c) => c.channel === channel) : normalized;
         setConversations(filtered);

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useRecentConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useRecentConversations.ts
@@ -17,11 +17,19 @@ export interface RecentConversation {
   channelParam: string;
   /** Conversation id used as the second URL segment */
   conversationId: string;
+  assignedToUserId?: string | null;
   kind: ChannelKind;
   lastMessage: string;
   lastMessageAt: string;
+  lastInboundAt?: string;
+  lastOutboundAt?: string;
+  labels?: any[];
+  linkedContactId?: string | null;
+  linkedEventId?: string | null;
   name: string;
   unreadCount: number;
+  unreadCountForAgent?: number;
+  status?: string;
 }
 
 const CHANNEL_BADGE: Record<ChannelKind, { bg: string; label: string; text: string }> = {
@@ -90,14 +98,22 @@ export function useRecentConversations(max = 50, refreshKey = 0) {
               const channelParam = matchedChannel ? `wa-${matchedChannel.id}` : defaultWaParam;
               const channelLabel = matchedChannel ? channelLabelMap.get(matchedChannel.id) : undefined;
               return {
+                assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
                 channelLabel,
                 channelParam,
                 conversationId: c.conversationId || c.id || '',
                 kind: 'whatsapp' as const,
                 lastMessage: c.lastMessage || '',
                 lastMessageAt: c.lastMessageAt || c.updatedAt || '',
+                lastInboundAt: c.lastInboundAt ?? c.last_inbound_at ?? undefined,
+                lastOutboundAt: c.lastOutboundAt ?? c.last_outbound_at ?? undefined,
+                labels: c.labels ?? c.labelIds ?? c.label_ids ?? undefined,
+                linkedContactId: c.linkedContactId ?? c.linked_contact_id ?? null,
+                linkedEventId: c.linkedEventId ?? c.linked_event_id ?? null,
                 name: c.displayName || c.phoneNumber || 'Desconocido',
                 unreadCount: c.unreadCount || 0,
+                unreadCountForAgent: c.unreadCountForAgent ?? c.unread_count_for_agent ?? undefined,
+                status: c.status ?? c.conversationStatus ?? undefined,
               };
             });
           })
@@ -131,13 +147,21 @@ export function useRecentConversations(max = 50, refreshKey = 0) {
               const kind = (c.channel || c.platform || 'web') as ChannelKind;
               const isKnown = otherChannels.includes(kind);
               return {
+                assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
                 channelParam: isKnown ? kind : 'web',
                 conversationId: c.conversationId || c.id || '',
                 kind: isKnown ? kind : ('web' as const),
                 lastMessage: c.lastMessage || '',
                 lastMessageAt: c.lastMessageAt || c.updatedAt || '',
+                lastInboundAt: c.lastInboundAt ?? c.last_inbound_at ?? undefined,
+                lastOutboundAt: c.lastOutboundAt ?? c.last_outbound_at ?? undefined,
+                labels: c.labels ?? c.labelIds ?? c.label_ids ?? undefined,
+                linkedContactId: c.linkedContactId ?? c.linked_contact_id ?? null,
+                linkedEventId: c.linkedEventId ?? c.linked_event_id ?? null,
                 name: c.displayName || c.contactName || c.username || 'Desconocido',
                 unreadCount: c.unreadCount || 0,
+                unreadCountForAgent: c.unreadCountForAgent ?? c.unread_count_for_agent ?? undefined,
+                status: c.status ?? c.conversationStatus ?? undefined,
               };
             });
           })


### PR DESCRIPTION
Prepara frontend para Track B (sin depender de backend desplegado):

- Extiende tipos/mapeos de conversaciones para aceptar campos opcionales (status, assigned_to, labels, linked_event/contact, last_inbound/outbound, unread_count_for_agent).
- No cambia comportamiento/UX si backend aún no los envía.

Commit: 31693bcf