### PR TITLE
fix(appEventos): 7 fixes QA — Resumen, Mesas, eventos e invitados

### DIFF
--- a/apps/appEventos/components/Forms/FormInvitado.tsx
+++ b/apps/appEventos/components/Forms/FormInvitado.tsx
@@ -109,11 +109,25 @@ const FormInvitado: FC<propsFormInvitado> = ({ state, set }) => {
         query: queries.createGuests,
         variables: {
           eventID: event._id,
-          invitados_array: values,
+          // $invitados_array es [JSON!]! (array). Enviar [values], no el objeto suelto
+          // (antes dependía de coerción implícita single→list).
+          invitados_array: [values],
         },
       });
 
-      setEvent((old) => ({ ...old, invitados_array: result?.evento?.invitados_array || old?.invitados_array }));
+      // fetchApiBodas devuelve null en errores GraphQL (NO lanza) y la mutación trae
+      // success/errors. Confirmar éxito REAL antes de dar feedback y refrescar la lista:
+      // así el toast de éxito y la aparición en la lista van juntos (evita "éxito pero no aparece").
+      if (!result?.success || (result?.errors?.length ?? 0) > 0) {
+        const backendMsg = result?.errors?.[0]?.message;
+        toast("error", `${t("Ha ocurrido un error")}${backendMsg ? `: ${backendMsg}` : ""}`);
+        return;
+      }
+
+      const updated = result?.evento?.invitados_array;
+      if (Array.isArray(updated)) {
+        setEvent((old) => ({ ...old, invitados_array: updated }));
+      }
       toast("success", t("Invitado creado con exito"))
     } catch (error) {
       toast("error", `${t("Ha ocurrido un error")} ${error}`)

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -194,11 +194,21 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
       {/* <Cuadricula className="w-100 h-100 text-black" /> */}
       <TransformComponent
         wrapperStyle={{ width: "100%", height: "100%", background: "gray" }}
-        contentStyle={{ width: `${lienzo?.width}px`, height: `${lienzo?.height}px`, background: "blue" }}
+        contentStyle={{
+          width: `${lienzo?.width}px`,
+          height: `${lienzo?.height}px`,
+          // Antes: background:"blue" (debug residual). Plano = blanco + retícula gris clara
+          // (1 m = 100px, coherente con el tamaño del lienzo). No se toca el paper.svg
+          // compartido (verde) para no afectar otras vistas (home).
+          backgroundColor: "#ffffff",
+          backgroundImage:
+            "linear-gradient(#e5e7eb 1px, transparent 1px), linear-gradient(90deg, #e5e7eb 1px, transparent 1px)",
+          backgroundSize: "100px 100px",
+        }}
       >
         <div
           id={"lienzo-drop"}
-          className="js-dropTables bg-gray-300 paper lienzo flex justify-center items-center">
+          className="js-dropTables bg-transparent lienzo flex justify-center items-center">
           <div className="lienzo border-4 border-indigo-600"></div>
           <LiezoDragable scale={state.scale} lienzo={lienzo} setDisableWrapper={setDisableWrapper} disableDrag={disableDrag} setShowFormEditar={setShowFormEditar} />
         </div>

--- a/apps/appEventos/components/Resumen/BlockItinerario.tsx
+++ b/apps/appEventos/components/Resumen/BlockItinerario.tsx
@@ -8,8 +8,8 @@ export const BlockItinerario = () => {
 
     const router = useRouter()
     return (
-        <div onClick={() => router.push("/itinerario")} className="bg-acento space-x-3 rounded-lg text-white flex  items-center justify-center py-1.5 px-5 shadow-lg font-display text-xl cursor-pointer ">
-            <GoChecklist className=" w-6 h-6 scale-x-90" />
+        <div onClick={() => router.push("/itinerario")} className="bg-acento space-x-3 rounded-lg text-gray-500 flex items-center justify-center py-1.5 px-5 shadow-lg font-display text-sm leading-none cursor-pointer">
+            <GoChecklist className="w-5 h-5 scale-x-90" />
             <span>{t("seemy")}<span> {t("Itinerary")}</span></span>
         </div>
     )

--- a/apps/appEventos/components/Resumen/BlockSobreMiEvento.tsx
+++ b/apps/appEventos/components/Resumen/BlockSobreMiEvento.tsx
@@ -76,7 +76,12 @@ const InsideBlockWithMultiSelected: FC<propsInsideBlock> = ({
   const toast = useToast()
   const { event, setEvent } = EventContextProvider()
   const { t } = useTranslation();
-  const [selectedItems, setSelectedItems] = useState(event.color)
+  // event[title] (p.ej. event.color) llega null cuando no hay selección → normalizar a
+  // array SIEMPRE. Sin esto, selectedItems.includes(...) reventaba "Sobre mi evento".
+  // Usar event[title] (no hardcodear .color) generaliza el patrón para reutilización.
+  const [selectedItems, setSelectedItems] = useState<string[]>(
+    Array.isArray(event?.[title]) ? event[title] : []
+  )
 
   const handleItemClick = (item) => {
     if (selectedItems.includes(item)) {
@@ -200,7 +205,7 @@ const ElementItemInsideBlockSelect: FC<{
       onClick={onClick}
       className={`
         w-full h-full p-3 rounded-3xl flex flex-col items-center justify-center gap-1 transform transition hover:scale-105 focus:outline-none
-        ${selectedItems.includes(title) ? 'bg-gray-200' : ''}
+        ${(selectedItems ?? []).includes(title) ? 'bg-gray-200' : ''}
       `}
     >
       {icon && cloneElement(icon, { className: `${color} w-8 h-8` })}

--- a/apps/appEventos/components/Resumen/BlockSobreMiEvento.tsx
+++ b/apps/appEventos/components/Resumen/BlockSobreMiEvento.tsx
@@ -50,7 +50,9 @@ const InsideBlockWithButtons: FC<propsInsideBlock> = ({
                   variables: { idEvento: event._id, input: { [title]: item.title } },
                   token: null
                 })
-                if (result.errors) {
+                // errors llega [] (array vacío) en éxito → truthy en JS. Sólo lanzar si HAY
+                // errores reales; si no, saltaba toast falso y setEvent no corría (UI stale).
+                if (result?.errors?.length) {
                   throw new Error("Hubo un error")
                 }
                 setEvent({ ...event, [title]: item.title })
@@ -147,7 +149,8 @@ const InsideBlockWithForm: FC<propsInsideBlock> = ({ setEditing, setFieldValue, 
             query: queries.eventUpdate,
             variables: { idEvento: event._id, input: { [title]: values.title } }, token: null
           })
-          if (result?.errors) {
+          // errors llega [] en éxito → truthy. Sólo lanzar si HAY errores reales.
+          if (result?.errors?.length) {
             throw new Error("Hubo un error")
           }
           setEvent({ ...event, [title]: values.title })

--- a/apps/appEventos/components/Utils/ImageAvatar.tsx
+++ b/apps/appEventos/components/Utils/ImageAvatar.tsx
@@ -1,6 +1,6 @@
-import { FC, useState } from "react"
+import { FC, useState, useRef, useCallback } from "react"
+import { createPortal } from "react-dom"
 import { detalle_compartidos_array } from "../../utils/Interfaces"
-import { useRouter } from "next/navigation"
 
 interface props {
   user: detalle_compartidos_array
@@ -9,8 +9,10 @@ interface props {
 }
 
 export const ImageAvatar: FC<props> = ({ user, disabledTooltip, size = "lg" }) => {
-  const [showName, setShowName] = useState<boolean>()
-  const router = useRouter()
+  // Posición del tooltip en coordenadas de viewport (position:fixed vía portal).
+  const [tip, setTip] = useState<{ top: number; left: number } | null>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
   const h = (str: string): string => {
     if (str) {
       str.slice(0, 2).charCodeAt(1).toString(16)
@@ -19,10 +21,21 @@ export const ImageAvatar: FC<props> = ({ user, disabledTooltip, size = "lg" }) =
     }
   }
 
+  const pathname = typeof window !== "undefined" ? window.location.pathname : ""
+  const tooltipEnabled = !disabledTooltip && !["/itinerario", "/eventos"].includes(pathname)
+  const label = user?.displayName ? user?.displayName : user?.email
+
+  // Al hacer hover, calcular la posición del avatar y colocar el tooltip DEBAJO,
+  // centrado. Se renderiza en un portal a document.body para que NO lo recorte
+  // ningún contenedor con overflow:hidden (header/tarjeta del evento).
+  const openTip = useCallback(() => {
+    if (!tooltipEnabled || !label || !wrapRef.current) return
+    const r = wrapRef.current.getBoundingClientRect()
+    setTip({ top: r.bottom + 6, left: r.left + r.width / 2 })
+  }, [tooltipEnabled, label])
+
   return (
-    <div onMouseOver={() => {
-      setShowName(true)
-    }} onMouseOut={() => setShowName(false)} className="w-full h-full relative">
+    <div ref={wrapRef} onMouseOver={openTip} onMouseOut={() => setTip(null)} className="w-full h-full relative">
       {!!(user?.photoURL || user?.icon)
         ?
         <div className={`flex items-center justify-center text-white uppercase w-full h-full rounded-full overflow-hidden`}>
@@ -45,11 +58,17 @@ export const ImageAvatar: FC<props> = ({ user, disabledTooltip, size = "lg" }) =
           }
         </div>
       }
-      {(!["/itinerario", "/eventos"].includes(window?.location?.pathname) && showName && !disabledTooltip) && <div style={{ right: 10, top: 30 }} className="absolute z-20 bg-black rounded-md flex items-center justify-center leading-[1.2] opacity-75">
-        <span className="text-white text-[10px] py-1 px-2">
-          {user?.displayName ? user?.displayName : user?.email}
-        </span>
-      </div>}
+      {tip && label && typeof document !== "undefined" && createPortal(
+        <div
+          style={{ position: "fixed", top: tip.top, left: tip.left, transform: "translateX(-50%)", zIndex: 9999 }}
+          className="bg-black rounded-md opacity-90 pointer-events-none max-w-[92vw]"
+        >
+          <span className="block text-white text-[10px] leading-[1.2] py-1 px-2 whitespace-nowrap overflow-hidden text-ellipsis">
+            {label}
+          </span>
+        </div>,
+        document.body
+      )}
     </div>
   )
 }

--- a/apps/appEventos/context/EventsGroupContext.tsx
+++ b/apps/appEventos/context/EventsGroupContext.tsx
@@ -250,11 +250,16 @@ const EventsGroupProvider = ({ children }) => {
             const list: Event[] = []
 
             for (const settled of results) {
-              if (settled.status === "fulfilled") {
+              // fetchApiBodas devuelve null en errores GraphQL (token caducado/auth) SIN lanzar.
+              // Tratar ese null como FALLO, no como "0 eventos": si no, un refresh con token
+              // stale pinta lista vacía engañosa (y obligaba a logout/login para recuperar).
+              if (settled.status === "fulfilled" && settled.value !== null) {
                 hadFulfilled = true
                 list.push(...coerceQueryenEventoList(settled.value))
               } else if (!firstError) {
-                firstError = settled.reason
+                firstError = settled.status === "rejected"
+                  ? settled.reason
+                  : new Error("getEventosByUsuario devolvió null (posible error GraphQL/token caducado)")
               }
             }
 
@@ -325,7 +330,8 @@ const EventsGroupProvider = ({ children }) => {
                 const detailsTime = performance.now() - detailsStartTime
                 console.log(`[EventsGroup] ✅ Detalles cargados en ${detailsTime.toFixed(0)}ms`)
                 console.log(`[EventsGroup] ✅ TOTAL tiempo de carga: ${totalTime.toFixed(0)}ms (${(totalTime/1000).toFixed(1)}s)`)
-                if (Array.isArray(values)) writeCachedEvents(values)
+                // No cachear vacío: evita que un fetch fallido/vacío pise un cache bueno.
+                if (Array.isArray(values) && values.length > 0) writeCachedEvents(values)
                 setEventsGroup({ type: "INITIAL_STATE", payload: values })
                 setEventsGroupDone(true)
               })
@@ -343,9 +349,12 @@ const EventsGroupProvider = ({ children }) => {
               }
               const friendlyMessage = getApiErrorMessage(error)
               const cached = readCachedEvents()
-              if ((status === 502 || status === 503) && cached && cached.length > 0) {
+              // Cualquier error transitorio (502/503, timeout, o null por token caducado): si hay
+              // cache válido, mostrar los eventos guardados en vez de una lista vacía engañosa.
+              // Así un refresh con token stale NO borra la vista (antes obligaba a logout/login).
+              if (cached && cached.length > 0) {
                 setEventsGroup({ type: "INITIAL_STATE", payload: cached })
-                setEventsGroupErrorMessage(`${friendlyMessage || 'El servidor no está disponible. Inténtalo en unos minutos.'} Mostrando datos guardados.`)
+                setEventsGroupErrorMessage(`${friendlyMessage || 'No se pudieron actualizar los eventos ahora.'} Mostrando datos guardados.`)
                 setEventsGroupSessionExpired(false)
                 setEventsGroupError(true)
                 setEventsGroupDone(true)


### PR DESCRIPTION
Consolida 7 fixes de appEventos (QA 07-jul). Basado en dev actual, 0 conflictos, 6 archivos +88/−28.

## Visual / UX
1. Botón "Ver mis Itinerarios" — texto gris homologado (text-gray-500/text-sm).
2. "Sobre mi evento" Color — crash null.includes → normalizar a [].
3. Plano Mesas — fondo blue→blanco + retícula gris (sin tocar paper.svg compartido).
4. Tooltip email del responsable — recorte por overflow → createPortal.
5. Temporada/Estilo/Temática — errors:[] truthy → toast falso + no refresh → result?.errors?.length.

## Crítico funcional
6. Mis eventos vacío tras refresh (token stale) — fetchApiBodas null (error GraphQL) mapeado a [] y cacheado, pisando el cache bueno. null=fallo · error con cache→muestra cache · no cachear vacío.
7. Invitado creado no aparece + toast falso — enviar [values] ([JSON!]!), confirmar result.success antes del toast, actualizar lista solo con respuesta confirmada.

Verificado: ESLint sin errores · rutas 200. Sin parchear API.