### PR TITLE
🐛 fix(appEventos): foto del evento no persiste tras editar (falta eventUpdate imgEvento)

### DIFF
--- a/apps/appEventos/components/Forms/FormCrearEvento.tsx
+++ b/apps/appEventos/components/Forms/FormCrearEvento.tsx
@@ -268,6 +268,13 @@ const FormCrearEvento: FC<propsFromCrearEvento> = ({ state, set, EditEvent, even
       if (imagePreviewUrl?.file) {
         const imgEvento = await subir_archivo({ imagePreviewUrl, event, use: "imgEvento" })
         if (imgEvento) {
+          // Persistir la portada en el evento (BD): subir_archivo SOLO sube el fichero a R2,
+          // NO asocia imgEvento al evento (a diferencia de nombre/tipo/fecha arriba, que sí
+          // hacen eventUpdate). Sin esto la nueva foto se veía local pero se PERDÍA al recargar.
+          await fetchApiBodas({
+            query: queries.eventUpdate,
+            variables: { idEvento: values._id, input: { imgEvento } }, token: null
+          })
           updatedValues = { ...updatedValues, imgEvento }
         }
       }


### PR DESCRIPTION
updateEvent persistía nombre/tipo/fecha pero NO imgEvento (subir_archivo solo sube a R2 + setEvent local). Fix: eventUpdate({input:{imgEvento}}) tras upload. CAVEAT: verificar shape EventoUpdateInput.imgEvento + posible cache CDN.