### PR TITLE
🐛 fix(appEventos): crear Grupo/Menú — success-check (mismo patrón que Invitado)

### DIFF
--- a/apps/appEventos/components/Forms/FormCrearGrupo.tsx
+++ b/apps/appEventos/components/Forms/FormCrearGrupo.tsx
@@ -21,16 +21,23 @@ const FormCrearGrupo = ({ set, state }) => {
 
   const handleSubmit = async (values, actions) => {
     try {
-      const { evento }: any = await fetchApiBodas({
+      const result: any = await fetchApiBodas({
         query: queries.createGroup,
         variables: {
           eventID: event._id,
           grupo: values.nombre,
         },
       });
+      // fetchApiBodas devuelve null en error GraphQL (NO lanza). No destructurar {evento}
+      // directo (lanzaría en null) y confirmar éxito REAL antes del toast + actualizar lista.
+      if (!result?.success || (result?.errors?.length ?? 0) > 0) {
+        const backendMsg = result?.errors?.[0]?.message;
+        toast("error", `${t("Ha ocurrido un error al crear el grupo")}${backendMsg ? `: ${backendMsg}` : ""}`);
+        return;
+      }
       setEvent((old) => ({
         ...old,
-        grupos_array: evento?.grupos_array || old?.grupos_array,
+        grupos_array: result?.evento?.grupos_array ?? old?.grupos_array,
       }));
       toast("success", t("Grupo creado con exito"));
     } catch (error) {

--- a/apps/appEventos/components/Forms/FormCrearMenu.tsx
+++ b/apps/appEventos/components/Forms/FormCrearMenu.tsx
@@ -24,20 +24,27 @@ const FormCrearMenu = ({ set, state }) => {
 
   const handleSubmit = async (values, actions) => {
     try {
-      const { evento }: any = await fetchApiBodas({
+      const result: any = await fetchApiBodas({
         query: queries.createMenu,
         variables: {
           eventID: event._id,
           menu: { title: values.nombre, nombre: values.nombre, nombre_menu: values.nombre, precio: 0 },
         },
       });
+      // fetchApiBodas devuelve null en error GraphQL (NO lanza). No destructurar {evento}
+      // directo (lanzaría en null) y confirmar éxito REAL antes del toast + actualizar lista.
+      if (!result?.success || (result?.errors?.length ?? 0) > 0) {
+        const backendMsg = result?.errors?.[0]?.message;
+        toast("error", `${t("Ha ocurrido un error al crear el menú")}${backendMsg ? `: ${backendMsg}` : ""}`);
+        return;
+      }
       setEvent((old) => ({
         ...old,
-        menus_array: normalizeMenus(evento?.menus_array),
+        menus_array: normalizeMenus(result?.evento?.menus_array),
       }));
       toast("success", t("Menú creado con exito"));
     } catch (error) {
-      toast("error", t("Ha ocurrido un error al crear el grupo"));
+      toast("error", t("Ha ocurrido un error al crear el menú"));
     } finally {
       actions.resetForm()
     }


### PR DESCRIPTION
Invitados: FormCrearGrupo/Menu destructuraban {evento} (lanza si fetchApiBodas devuelve null en error) y no comprobaban success (falso éxito). Fix consistente con FormInvitado. Causa raíz compartida = fetchApiBodas traga errores GraphQL.