### PR TITLE
fix(appEventos): editar tarea (FormTask) — fallo silencioso al guardar

### DIFF
--- a/apps/appEventos/components/Forms/FormTask.tsx
+++ b/apps/appEventos/components/Forms/FormTask.tsx
@@ -56,7 +56,9 @@ const FormTask: FC<propsFormTask> = ({ showEditTask, setShowEditTask, itinerario
       };
       delete dataSend.hora;
       delete dataSend.duracionUnidad;
-      fetchApiEventos({
+      // await: sin él, si fetchApiEventos rechaza (error), el .then se salta y el catch
+      // NO lo captura (promesa async sin await) → fallo silencioso (ni éxito ni error).
+      await fetchApiEventos({
         query: queries.editTask,
         variables: {
           eventID: event._id,


### PR DESCRIPTION
fetchApiEventos(...).then(...) sin await = si rechaza, el catch no lo captura (promesa async) -> fallo silencioso (ni exito ni error). Fix: await. Auditados los 6 forms candidatos: los otros 5 son seguros (fetchApiEventos LANZA en error, distinto de fetchApiBodas). Solo FormTask tenia bug.