### PR TITLE
fix(appEventos): tarjetas de eventos se solapan al abrir Copilot — grid por contenedor

### DIFF
--- a/apps/appEventos/pages/index.tsx
+++ b/apps/appEventos/pages/index.tsx
@@ -598,7 +598,7 @@ const GridCards: FC<propsGridCards> = ({
           </div>
         </div>
       </div>
-      <div className="flex flex-col md:flex-1 overflow-x-scroll md:overflow-clip pt-4">
+      <div className="flex flex-col md:flex-1 min-w-0 overflow-x-scroll md:overflow-clip pt-4">
         {displayedTabsGroup.map((group, idx) => {
           if (orderAndDirection?.order) {
             group?.data?.sort((a, b) => {
@@ -614,14 +614,14 @@ const GridCards: FC<propsGridCards> = ({
             });
           }
           return (
-            <div key={idx} className={`${isActiveStateSwiper !== idx && "hidden"} mb-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-x-4 gap-y-3`}>
+            <div key={idx} className={`${isActiveStateSwiper !== idx && "hidden"} mb-6 grid min-w-0 grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] gap-x-4 gap-y-3`}>
               {isActiveStateSwiper == idx ? (
                 <>
                   {group?.data?.map((evento, idx) => {
                     return (
                       <div
                         key={idx}
-                        className="flex items-center justify-center my-3"
+                        className="flex items-center justify-center my-3 min-w-0"
                       >
                         <Card data={group.data} grupoStatus={group.status} idx={idx} onSelect={() => setIdxGroupEvent({ idx, isActiveStateSwiper, event_id: evento._id })} />
                       </div>


### PR DESCRIPTION
El grid usaba breakpoints de viewport (2xl:grid-cols-5); al abrir Copilot el contenedor se encoge pero mantenia 5 columnas -> solape. Fix: grid-cols-[repeat(auto-fill,minmax(18rem,1fr))] (columnas por contenedor, reflow automatico) + min-w-0 en la cadena flex.