### PR TITLE
fix(appEventos): hueco inferior en vistas de altura fija (Mesas/Itinerario/Tareas/Invitaciones)

### DIFF
--- a/apps/appEventos/components/Itinerario/BoddyIter.tsx
+++ b/apps/appEventos/components/Itinerario/BoddyIter.tsx
@@ -360,7 +360,7 @@ export const BoddyIter = () => {
         <PermissionWrapper>
             <div
                 className={`bg-white ${view === "cards" ? "max-w-[1050px] mx-auto" : "w-auto"
-                    } md:h-[calc(100vh-212px)] flex flex-col items-center rounded-t-lg mt-3 relative overflow-hidden`}
+                    } md:h-[calc(100vh-244px)] flex flex-col items-center rounded-t-lg mt-3 relative overflow-hidden`}
             >
                 {
                     modal.state &&

--- a/apps/appEventos/pages/invitaciones.tsx
+++ b/apps/appEventos/pages/invitaciones.tsx
@@ -254,7 +254,7 @@ const Invitaciones = () => {
                 id="enviados-container"
                 ref={enviadosContainerRef}
                 onClick={handleScrollToEnviados}
-                className={`flex w-full border ${stateConfi ? "h-[calc(100vh-616px)]" : "h-[calc(100vh-260px)]"}`}
+                className={`flex w-full border ${stateConfi ? "h-[calc(100vh-648px)]" : "h-[calc(100vh-292px)]"}`}
               >
                 <EnviadosComponent stateConfi={stateConfi} />
               </div>

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -249,7 +249,7 @@ const Mesas: FC = () => {
               <CopilotFilterBar entity={['tables', 'guests']} />
               <BlockTitle title={"Mesas y asientos"} />
             </motion.div>
-            <div className={`${fullScreen || forCms ? "absolute z-[50] w-[100vw] h-[100vh] top-0 left-0" : "w-full h-[calc(100vh-208px)] md:h-[calc(100vh-210px)] md:mt-2"}`}>
+            <div className={`${fullScreen || forCms ? "absolute z-[50] w-[100vw] h-[100vh] top-0 left-0" : "w-full h-[calc(100vh-240px)] md:h-[calc(100vh-242px)] md:mt-2"}`}>
               <div className={`flex flex-col md:flex-row w-full items-center h-full`}>
                 <div className={`w-[calc(100%-0px)] mt-2 md:mt-0 ${fullScreen ? " md:w-[23%] h-[calc(30%-8px)]" : " md:w-[25%] h-[calc(30%-8px)]"} md:h-[100%] flex flex-col items-center`}>
                   <div className="bg-primary rounded-t-lg md:rounded-none w-[100%] ] h-10 ">


### PR DESCRIPTION
Estas vistas usan h-[calc(100vh-N)] fija que ignora el pb del main (#189). Fix: +32px a cada N para que dejen el hueco inferior visible. Mesas 208/210->240/242, BoddyIter 212->244, Invitaciones 616/260->648/292.