### PR TITLE
💄 Rediseño Mesas — Fase A (reestilizado barra lateral)

### DIFF
--- a/apps/appEventos/components/Mesas/BlockInvitados.tsx
+++ b/apps/appEventos/components/Mesas/BlockInvitados.tsx
@@ -34,7 +34,7 @@ const BlockInvitados: FC<propsBlockInvitados> = ({ set, setEditInv, editInv, set
                     <div className="flex justify-center">
                         <h2 className="font-display text-xl font-semibold text-gray-500">{t("Invitados")}</h2>
                     </div>
-                    <button onClick={() => !isAllowed() ? ht() : ConditionalAction()} className="w-full focus:outline-none bg-primary px-3 text-white font-display text-medium flex items-center justify-center gap-2 rounded-lg text-sm absolute inset-x-0 mx-auto z-10">
+                    <button onClick={() => !isAllowed() ? ht() : ConditionalAction()} className="w-full focus:outline-none bg-primary hover:opacity-95 shadow-sm transition px-3 text-white font-display text-medium flex items-center justify-center gap-2 rounded-full text-sm absolute inset-x-0 mx-auto z-10">
                         <PlusIcon className="text-white w-3 " />
                         <p>{t("addguests")}</p>
                     </button>

--- a/apps/appEventos/components/Mesas/BlockPlanos.tsx
+++ b/apps/appEventos/components/Mesas/BlockPlanos.tsx
@@ -27,11 +27,12 @@ export const BlockPlanos: FC = () => {
   return (
     <BlockDefault listaLength={event?.planSpace?.length}>
       {event?.planSpace?.map((item, idx) => {
+        const active = planSpaceSelect === item?._id
         return (
-          <div onClick={() => handleClick(item)} key={idx} className="w-20 h-20 p-2 flex-col justify-center items-center cursor-pointer">
-            <div key={idx} className={`${planSpaceSelect === item?._id ? "bg-gray-200" : "bg-none"} rounded-lg flex flex-col w-full h-full transform hover:scale-105 transition justify-center items-center`}>
-              <VscLayoutMenubar className={`text-primary w-8 h-8 2xl:w-12 2xl:h-12 `} />
-              <span className='text-gray-700 capitalize text-[10px]'> {t(item?.title)}</span>
+          <div onClick={() => handleClick(item)} key={idx} className="w-20 h-20 p-1 cursor-pointer">
+            <div key={idx} className={`rounded-xl border flex flex-col gap-1 w-full h-full transform hover:scale-105 transition justify-center items-center ${active ? "border-primary bg-primary/5 shadow-sm" : "border-gray-200 bg-white hover:border-gray-300"}`}>
+              <VscLayoutMenubar className={`w-7 h-7 2xl:w-9 2xl:h-9 ${active ? "text-primary" : "text-gray-400"}`} />
+              <span className={`capitalize text-[10px] leading-none truncate max-w-full px-1 ${active ? "text-primary font-medium" : "text-gray-500"}`}>{t(item?.title)}</span>
             </div>
           </div>)
       })

--- a/apps/appEventos/components/Mesas/BlockResumen.tsx
+++ b/apps/appEventos/components/Mesas/BlockResumen.tsx
@@ -21,42 +21,29 @@ const BlockResumen: FC<propsBlockResumen> = ({ InvitadoSentados }) => {
         { title: `${InvitadoSentados?.length} de ${event?.invitados_array?.length}`, subtitle: t("seatedguests") },
     ]
     return (
-        <div className="bg-primary w-[calc(100%-16px)] h-[calc(100%-6px)] m-auto flex flex-col rounded-lg overflow-y-auto pt-2">
+        <div className="w-[calc(100%-16px)] h-[calc(100%-6px)] m-auto flex flex-col gap-2 rounded-lg overflow-y-auto p-1">
             {
                 event.planSpace.map((item, idx) => {
+                    const totalInvitados = event?.invitados_array?.length || 0
+                    const sentados = item?.tables?.length
+                        ? item.tables.map((tb) => tb.guests).flat().filter(Boolean).length
+                        : 0
+                    const pct = totalInvitados ? Math.round((sentados / totalInvitados) * 100) : 0
                     return (
-                        <div key={idx} className="md:mb-3 px-2">
-                            <h2 className="text-tertiary font-display text-medium md:text-lg capitalize -mb-1">{t(item?.title)}</h2>
-                            <div className="flex flex-wrap items-center">
-                                <div className="flex w-28 items-center ml-2">
-                                    <MesaIcon className="text-white w-6 h-6" />
-                                    <p className="text-white m-1 font-display font-semibold text-lg leading-4 text-[12px]">
-                                        {item?.tables?.length} {/* <span className="text-xs md:text-sm m- font-light text-right"> */} {t("table")}{/* </span> */}
-                                    </p>
-                                </div>
-                                <div className="flex w-max items-center">
-                                    <InvitadosIcon className="text-white w-6 h-6 ml-2 mr-1" />
-                                    {(() => {
-                                        if (item.tables.length != 0) {
-                                            const invi = item.tables.map((item) => {
-                                                return item.guests
-                                            })
-                                            const inviReduce = invi.flat()
-                                            return (
-                                                < p key={idx} className="text-white m-1 leading-4 text-[12px]" >
-                                                    {inviReduce.length} de {event?.invitados_array?.length}
-                                                    {/* <span className="text-xs md:text-sm m- font-light text-right"> */} {t("seatedguests")}{/* </span> */}
-                                                </p>
-                                            )
-                                        } else {
-                                            return (
-                                                <p className="text-white font-display leading-4 text-[12px] ">
-                                                    {t("zeroof")} {event?.invitados_array?.length} {/* <span className=" md:text-[10px] text-right"> */} {t("seatedguests")}{/* </span> */}
-                                                </p>
-                                            )
-                                        }
-                                    })()}
-                                </div>
+                        <div key={idx} className="bg-white rounded-xl border border-gray-100 shadow-sm p-3">
+                            <h2 className="text-gray-700 font-display font-semibold capitalize text-sm mb-2">{t(item?.title)}</h2>
+                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mb-2 text-[12px] text-gray-500">
+                                <span className="flex items-center gap-1">
+                                    <MesaIcon className="text-primary w-4 h-4" />
+                                    <span className="font-semibold text-gray-700">{item?.tables?.length}</span> {t("table")}
+                                </span>
+                                <span className="flex items-center gap-1">
+                                    <InvitadosIcon className="text-primary w-4 h-4" />
+                                    <span className="font-semibold text-gray-700">{sentados}</span> de {totalInvitados} {t("seatedguests")}
+                                </span>
+                            </div>
+                            <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                                <div className="h-full bg-primary rounded-full transition-all duration-500" style={{ width: `${pct}%` }} />
                             </div>
                         </div>
                     )

--- a/apps/appEventos/components/Mesas/DragInvitado.tsx
+++ b/apps/appEventos/components/Mesas/DragInvitado.tsx
@@ -11,7 +11,7 @@ const DragInvitado = (props) => {
 
   return (
     <>
-      <div className="w-full flex justify-between items-center px-5 py-1 hover:bg-base transition">
+      <div className="w-full flex justify-between items-center gap-1 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition">
         {
           invitado.father && invitado.isChild && (
             <div className=" flex items-center pl-2 py-1  -mt-[11px]">
@@ -66,7 +66,7 @@ const DragInvitado = (props) => {
               element && rootElement.removeChild(document.getElementById(`dragM${invitado._id}`))
             }}>
             <img
-              className="w-7 h-7 rounded-full mr-2 text-gray-700 border-gray-300"
+              className="w-7 h-7 rounded-full mr-2 object-cover ring-1 ring-gray-200 text-gray-700"
               src={ImageProfile[invitado.sexo]?.image}
               alt={ImageProfile[invitado.sexo]?.alt}
             />

--- a/apps/appEventos/components/Utils/SubMenu.tsx
+++ b/apps/appEventos/components/Utils/SubMenu.tsx
@@ -1,38 +1,32 @@
 import { InvitadosIcon, MesaIcon } from "../icons"
 import { GiGrandPiano } from 'react-icons/gi';
-import { BsIntersect } from 'react-icons/bs';
-import { ImInsertTemplate } from 'react-icons/im';
 import { HiDocumentReport, HiTemplate } from 'react-icons/hi';
 import { useTranslation } from "react-i18next";
 
+// Barra de pestañas del módulo Mesas. Rediseño Fase A1 (16-jul): pastillas de texto
+// limpias (activo = pastilla blanca con texto rosa marca; inactivo = texto blanco).
+// IMPORTANTE: NO cambiar los valores `title` (son los `itemSelect==` que enrutan el
+// panel en pages/mesas.tsx) ni la altura (el contenedor h-10 alimenta el calc del panel).
 const sutMenus = [
   {
     title: "invitados",
-    icon: <InvitadosIcon className="w-6 h-6" />,
+    icon: <InvitadosIcon className="w-4 h-4" />,
   },
   {
     title: "planos",
-    icon: <HiTemplate className="w-6 h-6" />,
+    icon: <HiTemplate className="w-4 h-4" />,
   },
   {
     title: "mesas",
-    icon: <MesaIcon className="w-6 h-6" />,
+    icon: <MesaIcon className="w-4 h-4" />,
   },
   {
     title: "mobiliario",
-    icon: <GiGrandPiano className="w-6 h-6" />,
+    icon: <GiGrandPiano className="w-4 h-4" />,
   },
-  /*  {
-     title: "zonas",
-     icon: <BsIntersect className="w-6 h-6" />,
-   },
-   {
-     title: "plantillas",
-     icon: <ImInsertTemplate className="w-6 h-6" />,
-   }, */
   {
     title: "resumen",
-    icon: <HiDocumentReport className="w-6 h-6" />,
+    icon: <HiDocumentReport className="w-4 h-4" />,
   },
 ]
 
@@ -45,16 +39,24 @@ export const SubMenu = ({ itemSelect, setItemSelect }) => {
   }
 
   return (
-    <div className="w-full h-full px-2 py-[1px] flex justify-between">
+    <div className="w-full h-full flex items-center gap-1 px-1.5">
       {sutMenus.map((elem: any, idx: number) => {
+        const active = elem.title === itemSelect
         return (
-          <div key={idx} onClick={() => handleClick(elem)} className={`w-1/4 h-full flex flex-col items-center justify-center rounded-lg ${elem.title == itemSelect ? "bg-base text-primary font-semibold" : "bg-primary text-white"} ${elem?.title == "invitados" && "md:hidden"}`}>
-            {elem?.icon}
-            <span className={`capitalize text-[9.5px] leading-none`}>{t(elem?.title)}</span>
-          </div>
+          <button
+            key={idx}
+            type="button"
+            onClick={() => handleClick(elem)}
+            title={t(elem?.title)}
+            className={`flex-1 min-w-0 h-[30px] flex items-center justify-center gap-1.5 rounded-full font-medium capitalize transition-colors
+              ${active ? "bg-white text-primary shadow-sm" : "text-white/90 hover:bg-white/10"}
+              ${elem?.title === "invitados" ? "md:hidden" : ""}`}
+          >
+            <span className="shrink-0">{elem?.icon}</span>
+            <span className="text-[11px] leading-none truncate">{t(elem?.title)}</span>
+          </button>
         )
       })}
-
     </div>
   )
 }


### PR DESCRIPTION
Fase A del plan `docs/PLAN-REDISENO-MESAS-2026-07-16.md`. **Puro reestilizado de bajo riesgo**, reusando componentes y estado existentes. **No toca** interact.js, ids/clases de arrastre, modelo de datos ni mutaciones.

## Cambios
- **A1 `SubMenu`**: pastillas de texto (activo = pastilla blanca + texto rosa marca). Mantiene `title`/`itemSelect` y la altura `h-10` del contenedor.
- **A2 `BlockPlanos`**: tarjetas con marco; plano activo con borde/tinte rosa marca (antes gris).
- **A4 `BlockResumen`**: tarjetas blancas + barra de progreso sentados/total por plano (conserva la derivación de datos original).
- **A5 `BlockInvitados`/`DragInvitado`**: botón "Añadir invitados" en pastilla ovalada; fila de invitado con avatar en aro y hover suave. **Intactos** `id="dragN${_id}"`, clase `js-dragInvitadoN` y todos los handlers de arrastre.

## Verificación
- ESLint: 0 errores en los 5 archivos.
- `/mesas` compila y responde 200 en dev local.
- Sin cambios en `LienzoDragable`/`FuntionsDragable`/`Chair`/`MesaComponent` (checklist "NO ROMPER").

Siguientes fases (no en este PR): B (creación unificada de mesa con `createTable`), C (lienzo UX), D (PDF). "Añadir plano" queda bloqueado a la espera de backend (`createPlanSpace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)