### PR TITLE
💄 Rediseño Mesas — barra lateral fiel al prototipo

### DIFF
--- a/apps/appEventos/components/Mesas/BlockPlanos.tsx
+++ b/apps/appEventos/components/Mesas/BlockPlanos.tsx
@@ -1,11 +1,13 @@
 import { FC } from 'react';
-import BlockDefault from './BlockDefault';
 import { AuthContextProvider, EventContextProvider } from '../../context';
-import { VscLayoutMenubar } from 'react-icons/vsc';
+import { HiTemplate } from 'react-icons/hi';
 import { planSpace } from '../../utils/Interfaces';
 import { fetchApiEventos, queries } from '../../utils/Fetching';
 import { useTranslation } from 'react-i18next';
 
+// Rediseño fiel al prototipo (MESAS.dc.html): lista vertical "Espacios del evento".
+// Fila = icono en cuadrado + nombre + nº de mesas + check del espacio activo.
+// NO cambia la lógica de selección (setPlanSpaceSelect + fetchApiEventos).
 export const BlockPlanos: FC = () => {
   const { t } = useTranslation();
   const { event, planSpaceSelect, setPlanSpaceSelect } = EventContextProvider()
@@ -25,18 +27,34 @@ export const BlockPlanos: FC = () => {
     }
   }
   return (
-    <BlockDefault listaLength={event?.planSpace?.length}>
-      {event?.planSpace?.map((item, idx) => {
-        const active = planSpaceSelect === item?._id
-        return (
-          <div onClick={() => handleClick(item)} key={idx} className="w-20 h-20 p-1 cursor-pointer">
-            <div key={idx} className={`rounded-xl border flex flex-col gap-1 w-full h-full transform hover:scale-105 transition justify-center items-center ${active ? "border-primary bg-primary/5 shadow-sm" : "border-gray-200 bg-white hover:border-gray-300"}`}>
-              <VscLayoutMenubar className={`w-7 h-7 2xl:w-9 2xl:h-9 ${active ? "text-primary" : "text-gray-400"}`} />
-              <span className={`capitalize text-[10px] leading-none truncate max-w-full px-1 ${active ? "text-primary font-medium" : "text-gray-500"}`}>{t(item?.title)}</span>
+    <div className="w-full h-full overflow-auto flex flex-col gap-2.5 p-1">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba]">{t("eventspaces") || "Espacios del evento"}</span>
+        <span className="text-[11px] font-semibold text-[#EF5B94]">{event?.planSpace?.length}</span>
+      </div>
+      <div className="flex flex-col gap-[7px]">
+        {event?.planSpace?.map((item, idx) => {
+          const active = planSpaceSelect === item?._id
+          return (
+            <div
+              key={idx}
+              onClick={() => handleClick(item)}
+              className={`flex items-center gap-[11px] px-3 py-2.5 rounded-[11px] cursor-pointer border transition ${active ? "bg-[#FCF2F6] border-[#f7c2da]" : "bg-white border-[#f0f0f2] hover:border-[#e2e2e6]"}`}
+            >
+              <div className={`w-[30px] h-[30px] rounded-[9px] flex-none flex items-center justify-center ${active ? "bg-[#EF5B94] text-white" : "bg-[#f0f0f2] text-[#a0a0a8]"}`}>
+                <HiTemplate className="w-[17px] h-[17px]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-[12.5px] font-semibold text-[#3A3A42] truncate capitalize">{t(item?.title)}</div>
+                <div className="text-[10.5px] font-medium text-[#a0a0a8]">{item?.tables?.length || 0} {(t("table") || "mesas").toLowerCase()}</div>
+              </div>
+              {active &&
+                <div className="w-[18px] h-[18px] rounded-full flex-none bg-[#EF5B94] text-white flex items-center justify-center text-[11px] font-bold">✓</div>
+              }
             </div>
-          </div>)
-      })
-      }
-    </BlockDefault>
+          )
+        })}
+      </div>
+    </div>
   )
 }

--- a/apps/appEventos/components/Mesas/BlockResumen.tsx
+++ b/apps/appEventos/components/Mesas/BlockResumen.tsx
@@ -1,55 +1,73 @@
-import { FC, useEffect, useState } from "react"
+import { FC } from "react"
 import { EventContextProvider } from "../../context"
-import { InvitadosIcon, MesaIcon } from "../icons"
 import { guests } from '../../utils/Interfaces';
 import { useTranslation } from 'react-i18next';
 
+// Rediseño fiel al prototipo (MESAS.dc.html): tarjeta de resumen (% ocupado + 3 stats)
+// + lista "Por espacio" con barra de progreso. Conserva la derivación de datos real
+// (sentados por planSpace a partir de tables[].guests).
 interface propsBlockResumen {
     InvitadoSentados: guests[]
 }
 const BlockResumen: FC<propsBlockResumen> = ({ InvitadoSentados }) => {
     const { t } = useTranslation();
-    const { event } = EventContextProvider()
-    const [totalMesas, setTotalMesas] = useState<number | null>(event?.mesas_array?.length)
+    const { event, planSpaceSelect } = EventContextProvider()
 
-    useEffect(() => {
-        setTotalMesas(event?.mesas_array?.length)
-    }, [event?.mesas_array])
+    const totalInvitados = event?.invitados_array?.length || 0
+    const perSpace = (event?.planSpace || []).map((ps) => {
+        const sentados = ps?.tables?.length
+            ? ps.tables.map((tb) => tb.guests).flat().filter(Boolean).length
+            : 0
+        return { _id: ps?._id, title: ps?.title, sentados, pct: totalInvitados ? Math.round((sentados / totalInvitados) * 100) : 0 }
+    })
+    const totalSentados = perSpace.reduce((a, p) => a + p.sentados, 0)
+    const totalMesas = event?.mesas_array?.length || 0
+    const overallPct = totalInvitados ? Math.round((totalSentados / totalInvitados) * 100) : 0
 
-    const Datos = [
-        { title: totalMesas, subtitle: t("totaltables") },
-        { title: `${InvitadoSentados?.length} de ${event?.invitados_array?.length}`, subtitle: t("seatedguests") },
+    const stats = [
+        { n: totalMesas, l: t("tables") || "Mesas" },
+        { n: totalInvitados, l: t("guests") || "Invitados" },
+        { n: totalSentados, l: t("seated") || "Sentados" },
     ]
+
     return (
-        <div className="w-[calc(100%-16px)] h-[calc(100%-6px)] m-auto flex flex-col gap-2 rounded-lg overflow-y-auto p-1">
-            {
-                event.planSpace.map((item, idx) => {
-                    const totalInvitados = event?.invitados_array?.length || 0
-                    const sentados = item?.tables?.length
-                        ? item.tables.map((tb) => tb.guests).flat().filter(Boolean).length
-                        : 0
-                    const pct = totalInvitados ? Math.round((sentados / totalInvitados) * 100) : 0
-                    return (
-                        <div key={idx} className="bg-white rounded-xl border border-gray-100 shadow-sm p-3">
-                            <h2 className="text-gray-700 font-display font-semibold capitalize text-sm mb-2">{t(item?.title)}</h2>
-                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mb-2 text-[12px] text-gray-500">
-                                <span className="flex items-center gap-1">
-                                    <MesaIcon className="text-primary w-4 h-4" />
-                                    <span className="font-semibold text-gray-700">{item?.tables?.length}</span> {t("table")}
-                                </span>
-                                <span className="flex items-center gap-1">
-                                    <InvitadosIcon className="text-primary w-4 h-4" />
-                                    <span className="font-semibold text-gray-700">{sentados}</span> de {totalInvitados} {t("seatedguests")}
-                                </span>
-                            </div>
-                            <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
-                                <div className="h-full bg-primary rounded-full transition-all duration-500" style={{ width: `${pct}%` }} />
-                            </div>
+        <div className="w-full h-full overflow-auto flex flex-col gap-[11px] p-1">
+            <div className="rounded-[13px] p-3.5 bg-white border border-[#f0f0f2] shadow-[0_3px_10px_rgba(0,0,0,.04)]">
+                <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-baseline gap-1.5">
+                        <span className="text-2xl font-bold leading-none text-[#EF5B94]">{overallPct}%</span>
+                        <span className="text-[10.5px] font-semibold text-[#8a8a90]">{t("occupied") || "ocupado"}</span>
+                    </div>
+                    <span className="text-[9px] font-bold tracking-wider uppercase text-[#b3b3ba]">{t("eventsummary") || "Resumen del evento"}</span>
+                </div>
+                <div className="flex gap-2">
+                    {stats.map((s, i) => (
+                        <div key={i} className="flex-1 bg-[#faf9fb] border border-[#f0f0f2] rounded-[9px] px-2.5 py-[7px]">
+                            <div className="text-[15px] font-bold text-[#3A3A42]">{s.n}</div>
+                            <div className="text-[9.5px] font-medium text-[#a0a0a8]">{s.l}</div>
                         </div>
-                    )
-                })
-            }
-        </div >
+                    ))}
+                </div>
+            </div>
+            <div className="text-[10px] font-bold tracking-wider uppercase text-[#b3b3ba]">{t("perspace") || "Por espacio"}</div>
+            {perSpace.map((r, idx) => {
+                const active = planSpaceSelect === r._id
+                return (
+                    <div key={idx} className={`rounded-[11px] px-3 py-[11px] border ${active ? "bg-[#FCF2F6] border-[#f7c2da]" : "bg-white border-[#f0f0f2]"}`}>
+                        <div className="flex items-center justify-between mb-2">
+                            <div className="flex items-center gap-2">
+                                <span className="w-2 h-2 rounded-full bg-[#EF5B94]" />
+                                <span className="text-[12.5px] font-semibold text-[#3A3A42] capitalize">{t(r.title)}</span>
+                            </div>
+                            <div className="text-[11px] font-semibold text-[#EF5B94]">{r.sentados} · {r.pct}%</div>
+                        </div>
+                        <div className="h-[7px] rounded-[7px] bg-[#ececed] overflow-hidden">
+                            <div className="h-full rounded-[7px] bg-[#EF5B94] transition-all duration-300" style={{ width: `${r.pct}%` }} />
+                        </div>
+                    </div>
+                )
+            })}
+        </div>
     )
 }
 

--- a/apps/appEventos/components/Utils/SubMenu.tsx
+++ b/apps/appEventos/components/Utils/SubMenu.tsx
@@ -3,30 +3,30 @@ import { GiGrandPiano } from 'react-icons/gi';
 import { HiDocumentReport, HiTemplate } from 'react-icons/hi';
 import { useTranslation } from "react-i18next";
 
-// Barra de pestañas del módulo Mesas. Rediseño Fase A1 (16-jul): pastillas de texto
-// limpias (activo = pastilla blanca con texto rosa marca; inactivo = texto blanco).
-// IMPORTANTE: NO cambiar los valores `title` (son los `itemSelect==` que enrutan el
-// panel en pages/mesas.tsx) ni la altura (el contenedor h-10 alimenta el calc del panel).
+// Barra de pestañas del módulo Mesas. Rediseño fiel al prototipo (MESAS.dc.html):
+// tabs de icono + texto sobre fondo blanco, la activa con subrayado rosa marca.
+// IMPORTANTE: NO cambiar los `title` (son los `itemSelect==` que enrutan el panel
+// en pages/mesas.tsx) ni la altura del contenedor (h-10 alimenta el calc del panel).
 const sutMenus = [
   {
     title: "invitados",
-    icon: <InvitadosIcon className="w-4 h-4" />,
+    icon: <InvitadosIcon className="w-[18px] h-[18px]" />,
   },
   {
     title: "planos",
-    icon: <HiTemplate className="w-4 h-4" />,
+    icon: <HiTemplate className="w-[18px] h-[18px]" />,
   },
   {
     title: "mesas",
-    icon: <MesaIcon className="w-4 h-4" />,
+    icon: <MesaIcon className="w-[18px] h-[18px]" />,
   },
   {
     title: "mobiliario",
-    icon: <GiGrandPiano className="w-4 h-4" />,
+    icon: <GiGrandPiano className="w-[18px] h-[18px]" />,
   },
   {
     title: "resumen",
-    icon: <HiDocumentReport className="w-4 h-4" />,
+    icon: <HiDocumentReport className="w-[18px] h-[18px]" />,
   },
 ]
 
@@ -39,7 +39,7 @@ export const SubMenu = ({ itemSelect, setItemSelect }) => {
   }
 
   return (
-    <div className="w-full h-full flex items-center gap-1 px-1.5">
+    <div className="w-full h-full flex items-stretch px-2 bg-white border-b border-[#f0f0f2]">
       {sutMenus.map((elem: any, idx: number) => {
         const active = elem.title === itemSelect
         return (
@@ -48,12 +48,12 @@ export const SubMenu = ({ itemSelect, setItemSelect }) => {
             type="button"
             onClick={() => handleClick(elem)}
             title={t(elem?.title)}
-            className={`flex-1 min-w-0 h-[30px] flex items-center justify-center gap-1.5 rounded-full font-medium capitalize transition-colors
-              ${active ? "bg-white text-primary shadow-sm" : "text-white/90 hover:bg-white/10"}
+            className={`flex-1 min-w-0 flex flex-col items-center justify-center gap-0.5 border-b-[2.5px] -mb-px transition-colors
+              ${active ? "border-[#EF5B94]" : "border-transparent"}
               ${elem?.title === "invitados" ? "md:hidden" : ""}`}
           >
-            <span className="shrink-0">{elem?.icon}</span>
-            <span className="text-[11px] leading-none truncate">{t(elem?.title)}</span>
+            <span className={active ? "text-[#EF5B94]" : "text-[#a0a0a8]"}>{elem?.icon}</span>
+            <span className={`text-[10px] font-semibold capitalize leading-none truncate max-w-full ${active ? "text-[#EF5B94]" : "text-[#6b6b72]"}`}>{t(elem?.title)}</span>
           </button>
         )
       })}

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -252,10 +252,10 @@ const Mesas: FC = () => {
             <div className={`${fullScreen || forCms ? "absolute z-[50] w-[100vw] h-[100vh] top-0 left-0" : "w-full h-[calc(100vh-240px)] md:h-[calc(100vh-242px)] md:mt-2"}`}>
               <div className={`flex flex-col md:flex-row w-full items-center h-full`}>
                 <div className={`w-[calc(100%-0px)] mt-2 md:mt-0 ${fullScreen ? " md:w-[23%] h-[calc(30%-8px)]" : " md:w-[25%] h-[calc(30%-8px)]"} md:h-[100%] flex flex-col items-center`}>
-                  <div className="bg-primary rounded-t-lg md:rounded-none w-[100%] ] h-10 ">
+                  <div className="bg-white rounded-t-lg md:rounded-none w-[100%] h-10 ">
                     <SubMenu itemSelect={itemSelect} setItemSelect={setItemSelect} />
                   </div>
-                  <div className={`bg-base flex w-[100%] h-[calc(100%-40px)]`} >
+                  <div className={`bg-white flex w-[100%] h-[calc(100%-40px)]`} >
                     <div className="flex flex-col h-[100%] w-full md:px-2 justify-start transform transition duration-700">
                       {/* BUG-18 (informe QA 21-jun): el panel con `h-[40%]` (md+ no full) cortaba los
                           últimos items de ListTables (banco/bancos quedaban fuera del área visible


### PR DESCRIPTION
Afina la barra lateral de Mesas al prototipo aprobado (`MESAS.dc.html`). Puro reestilizado; **no toca** interact.js, drag ni mutaciones.

- **SubMenu**: tabs icono+texto sobre fondo **blanco** con **subrayado rosa** en la activa (antes pastillas).
- **BlockPlanos**: lista vertical **"Espacios del evento"** (icono cuadrado + nombre + nº mesas + check activo).
- **BlockResumen**: tarjeta **"% ocupado"** + 3 stats + lista "Por espacio" con barra de progreso (conserva la derivación de datos).
- **mesas.tsx**: fondos de la columna izquierda a **blanco**.

Paleta exacta del prototipo (#EF5B94, #3A3A42, #f0f0f2, #FCF2F6…). ESLint 0, `/mesas` 200.

Siguiente: filtros de Invitados (Todos/Por sentar/Sentados), controles del lienzo y alinear "Añadir mesa" (rosa) + panel "Diseñar mesa" al prototipo. `TableConfiguratorFloating` + `createTable` ya existen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)