### PR TITLE
💄 Rediseño Mesas — lienzo Fase C (Añadir mesa rosa + estado vacío) + fix i18n

### DIFF
--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -54,6 +54,14 @@ export function TableConfiguratorFloating() {
   const { event, setEvent, planSpaceActive, setPlanSpaceActive, planSpaceSelect } = EventContextProvider();
   const toast = useToast();
 
+  // El estado vacío del lienzo (ComponenteTransformWrapper) abre este panel disparando
+  // un evento global — así no hay que subir el estado `open` ni acoplar componentes.
+  useEffect(() => {
+    const openDesigner = () => setOpen(true);
+    window.addEventListener('open-table-designer', openDesigner);
+    return () => window.removeEventListener('open-table-designer', openDesigner);
+  }, []);
+
   if (!event || !planSpaceActive) return null;
 
   const handleConfirm = async (config: TableConfig, svgString: string) => {
@@ -194,21 +202,21 @@ export function TableConfiguratorFloating() {
           bottom: 24,
           right: 24,
           zIndex: 200,
-          background: '#8B6914',
+          background: '#EF5B94',
           color: '#fff',
           border: 'none',
-          borderRadius: 40,
-          padding: '10px 18px',
+          borderRadius: 10,
+          padding: '13px 20px',
           fontSize: 13,
           fontWeight: 600,
           cursor: 'pointer',
-          boxShadow: '0 4px 16px rgba(139,105,20,0.35)',
+          boxShadow: '0 8px 20px rgba(239,91,148,0.4)',
           display: 'flex',
           alignItems: 'center',
           gap: 6,
         }}
       >
-        ✦ Diseñar mesa
+        ＋ Añadir mesa
       </button>
 
       <button
@@ -217,20 +225,20 @@ export function TableConfiguratorFloating() {
         style={{
           position: 'fixed',
           bottom: 24,
-          right: 152,
+          right: 188,
           zIndex: 200,
-          background: '#111827',
-          color: '#fff',
-          border: 'none',
-          borderRadius: 40,
-          padding: '10px 14px',
+          background: '#fff',
+          color: '#EF5B94',
+          border: '1.5px solid #f0aecb',
+          borderRadius: 10,
+          padding: '12px 16px',
           fontSize: 13,
           fontWeight: 600,
           cursor: 'pointer',
-          boxShadow: '0 4px 16px rgba(17,24,39,0.25)',
+          boxShadow: '0 4px 14px rgba(0,0,0,0.08)',
         }}
       >
-        + Bancos
+        ＋ Bancos
       </button>
 
       {/* Modal configurador */}

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -213,6 +213,28 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
           <LiezoDragable scale={state.scale} lienzo={lienzo} setDisableWrapper={setDisableWrapper} disableDrag={disableDrag} setShowFormEditar={setShowFormEditar} />
         </div>
       </TransformComponent>
+      {/* Estado vacío (rediseño Fase C, fiel a MESAS.dc.html): cuando el plano no tiene
+          mesas. El CTA abre el panel "Diseñar mesa" disparando el evento global que
+          escucha TableConfiguratorFloating. pointer-events-none salvo el botón, para no
+          bloquear el dropzone js-dropTables. */}
+      {(planSpaceActive?.tables?.length ?? 0) === 0 && (
+        <div className="absolute inset-0 z-[15] flex flex-col items-center justify-center gap-3.5 pointer-events-none px-4">
+          <div className="w-16 h-16 rounded-full bg-white border-2 border-dashed border-[#f0aecb] flex items-center justify-center text-[#EF5B94] shadow-[0_6px_18px_rgba(0,0,0,.06)]">
+            <svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6"><ellipse cx="12" cy="9" rx="8" ry="3"></ellipse><path d="M6 10v8M18 10v8"></path></svg>
+          </div>
+          <div className="text-center">
+            <div className="text-[16px] font-bold text-[#3A3A42]">{t("notablesyet") || "Aún no hay mesas"}</div>
+            <div className="text-[12.5px] font-medium text-[#8a8a90] mt-0.5">{t("startcreatingtable") || "Empieza creando tu primera mesa para este espacio."}</div>
+          </div>
+          <button
+            type="button"
+            onClick={() => window.dispatchEvent(new CustomEvent('open-table-designer'))}
+            className="pointer-events-auto px-[22px] py-[13px] rounded-[10px] bg-[#EF5B94] text-white text-[13.5px] font-semibold shadow-[0_8px_20px_rgba(239,91,148,.35)]"
+          >
+            ＋ {t("createfirsttable") || "Crea tu primera mesa"}
+          </button>
+        </div>
+      )}
       <style >
         {`
           .lienzo {

--- a/apps/appEventos/locales/en.ts
+++ b/apps/appEventos/locales/en.ts
@@ -1,5 +1,15 @@
 export const en = {
   translation: {
+    'eventspaces': "Event spaces",
+    'occupied': "occupied",
+    'perspace': "Per space",
+    'eventsummary': "Event summary",
+    'tables': "Tables",
+    'seated': "Seated",
+    'guests': "Guests",
+    'notablesyet': "No tables yet",
+    'startcreatingtable': "Start by creating your first table for this space.",
+    'createfirsttable': "Create your first table",
     'about': "About",
     'aboutmyevent': "About my event",
     'accept': "Accept",

--- a/apps/appEventos/locales/es.ts
+++ b/apps/appEventos/locales/es.ts
@@ -1,5 +1,15 @@
 export const es = {
   translation: {
+    'eventspaces': 'Espacios del evento',
+    'occupied': 'ocupado',
+    'perspace': 'Por espacio',
+    'eventsummary': 'Resumen del evento',
+    'tables': 'Mesas',
+    'seated': 'Sentados',
+    'guests': 'Invitados',
+    'notablesyet': 'Aún no hay mesas',
+    'startcreatingtable': 'Empieza creando tu primera mesa para este espacio.',
+    'createfirsttable': 'Crea tu primera mesa',
     'about': 'Acerca de',
     'aboutmyevent': 'Sobre mi evento',
     'accept': 'Aceptar',


### PR DESCRIPTION
Fase C (parcial) del rediseño de Mesas, fiel a `MESAS.dc.html`. **No toca** interact.js.

- **Botón «＋ Añadir mesa»** rosa marca (antes dorado `✦ Diseñar mesa`). «＋ Bancos» → secundario blanco/rosa.
- **Estado vacío** del lienzo (sin mesas): círculo punteado + textos + CTA «Crea tu primera mesa». CTA abre el panel vía evento global `open-table-designer` (sin acoplar componentes).
- **fix i18n**: añadidas claves a `es.ts`/`en.ts`. **Corrige** que Resumen/Planos (PR #193) mostraban la clave cruda (`occupied`, `eventspaces`…) porque `t(key)||def` no cae cuando la clave falta.

ESLint 0, `/mesas` 200. Pendiente: controles del lienzo (zoom/lock/fit/PDF en pills), panel «Diseñar mesa» al prototipo, filtros de Invitados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)