### PR TITLE
💄 Rediseño Mesas — Invitados con filtro (Todos/Por sentar/Sentados)

### DIFF
--- a/apps/appEventos/components/Mesas/BlockInvitados.tsx
+++ b/apps/appEventos/components/Mesas/BlockInvitados.tsx
@@ -1,10 +1,10 @@
-import { Dispatch, FC, SetStateAction } from 'react';
-import { guests } from "../../utils/Interfaces"
+import { Dispatch, FC, SetStateAction, useState } from 'react';
 import { PlusIcon } from "../icons"
 import ListInvitados from "./ListInvitados"
 import { useAllowed } from '../../hooks/useAllowed';
 import { AuthContextProvider, EventContextProvider } from '../../context';
 import { useTranslation } from 'react-i18next';
+import { HiChevronDown } from 'react-icons/hi';
 
 interface propsBlockInvitados {
     set: Dispatch<SetStateAction<boolean>>
@@ -13,11 +13,22 @@ interface propsBlockInvitados {
     setSelected: any
 }
 
+export type GuestFilter = 'todos' | 'porsentar' | 'sentados'
+
+// Rediseño fiel al prototipo (MESAS.dc.html): cabecera colapsable + filtro segmentado
+// (Todos/Por sentar/Sentados) + botón "Añadir invitados" en pastilla punteada.
+// IMPORTANTE: el contenedor de la lista mantiene `js-dropGuests` (dropzone para devolver
+// invitados) e id `listInvitados`. Las filas arrastrables NO se desmontan al filtrar
+// (ListInvitados las oculta por CSS) para no romper interact.js.
 const BlockInvitados: FC<propsBlockInvitados> = ({ set, setEditInv, editInv, setSelected }) => {
     const { t } = useTranslation();
     const [isAllowed, ht] = useAllowed()
-    const { event } = EventContextProvider()
+    const { event, filterGuests } = EventContextProvider()
     const { actionModals, setActionModals } = AuthContextProvider()
+    const [open, setOpen] = useState(true)
+    const [filter, setFilter] = useState<GuestFilter>('todos')
+
+    const sentadosCount = filterGuests?.sentados?.length ?? 0
 
     const ConditionalAction = () => {
         if (event.invitados_array.length >= 5) {
@@ -27,29 +38,63 @@ const BlockInvitados: FC<propsBlockInvitados> = ({ set, setEditInv, editInv, set
         }
     }
 
+    const tabs: { key: GuestFilter, label: string }[] = [
+        { key: 'todos', label: t('all') },
+        { key: 'porsentar', label: t('tobeseated') },
+        { key: 'sentados', label: t('seated') },
+    ]
+
     return (
-        <>
-            <div className="w-full h-[100%] shadow-lg relative">
-                <div className="hidden md:block bg-white pb-2 rounded-t-lg relative ">
-                    <div className="flex justify-center">
-                        <h2 className="font-display text-xl font-semibold text-gray-500">{t("Invitados")}</h2>
-                    </div>
-                    <button onClick={() => !isAllowed() ? ht() : ConditionalAction()} className="w-full focus:outline-none bg-primary hover:opacity-95 shadow-sm transition px-3 text-white font-display text-medium flex items-center justify-center gap-2 rounded-full text-sm absolute inset-x-0 mx-auto z-10">
-                        <PlusIcon className="text-white w-3 " />
-                        <p>{t("addguests")}</p>
+        <div className="w-full h-full flex flex-col bg-white relative">
+            <div onClick={() => setOpen(!open)} className="flex items-center justify-between px-3 pt-2 pb-1 cursor-pointer select-none flex-none">
+                <div className="flex items-center gap-1.5">
+                    <HiChevronDown className={`w-4 h-4 text-[#6b6b72] transition-transform ${open ? '' : '-rotate-90'}`} />
+                    <span className="text-[12px] font-bold text-[#3A3A42]">{t('Invitados')}</span>
+                </div>
+                <span className="text-[10px] font-semibold text-[#a0a0a8]">{t('seated')} <span className="text-[#EF5B94]">{sentadosCount}</span></span>
+            </div>
+
+            {open && (
+                <div className="mx-3 mb-2 flex bg-[#f2f2f4] rounded-[9px] p-[3px] gap-0.5 flex-none">
+                    {tabs.map(tb => {
+                        const active = filter === tb.key
+                        return (
+                            <button
+                                key={tb.key}
+                                type="button"
+                                onClick={() => setFilter(tb.key)}
+                                className={`flex-1 text-center py-1.5 rounded-[7px] text-[10.5px] font-semibold capitalize transition ${active ? 'bg-white text-[#3A3A42] shadow-sm' : 'text-[#8a8a90]'}`}
+                            >
+                                {tb.label}
+                            </button>
+                        )
+                    })}
+                </div>
+            )}
+
+            <div id={"listInvitados"} className={`js-dropGuests flex-1 overflow-auto px-1 ${open ? '' : 'hidden'}`}>
+                <ListInvitados filter={filter} setEditInv={setEditInv} editInv={editInv} setSelected={setSelected} />
+            </div>
+
+            {open && (
+                <div className="p-2 flex-none">
+                    <button
+                        onClick={() => !isAllowed() ? ht() : ConditionalAction()}
+                        className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-[11px] bg-white border-[1.5px] border-dashed border-[#f0aecb] text-[#EF5B94] text-[12.5px] font-semibold focus:outline-none"
+                    >
+                        <PlusIcon className="text-[#EF5B94] w-3" />
+                        {t("addguests")}
                     </button>
                 </div>
-                <div id={"listInvitados"} className='bg-white md:translate-y-3 w-full h-full md:h-[calc(100%-48px)] js-dropGuests  overflow-auto'>
-                    <ListInvitados setEditInv={setEditInv} editInv={editInv} setSelected={setSelected} />
-                </div>
-            </div>
+            )}
+
             <style>{`
             .listInvitados {
                 touch-action: none;
                 user-select: none;
             }
             `}</style>
-        </>
+        </div>
     )
 }
 

--- a/apps/appEventos/components/Mesas/ListInvitados.tsx
+++ b/apps/appEventos/components/Mesas/ListInvitados.tsx
@@ -2,37 +2,42 @@ import React, { FC, useMemo } from "react";
 import { guests } from "../../utils/Interfaces";
 import DragInvitado from "./DragInvitado";
 import { EventContextProvider } from "../../context";
+import { ImageProfile } from "../../utils/Funciones";
+import { useTranslation } from "react-i18next";
+import type { GuestFilter } from "./BlockInvitados";
 
 interface propsListInvitados {
   setEditInv: any
   editInv: any
   setSelected: any
+  filter?: GuestFilter
 }
 
-const ListInvitados: FC<propsListInvitados> = ({ editInv, setEditInv, setSelected }) => {
+const ListInvitados: FC<propsListInvitados> = ({ editInv, setEditInv, setSelected, filter = 'todos' }) => {
+  const { t } = useTranslation()
   const { filterGuests } = EventContextProvider()
 
-  // Función para ordenar invitados agrupando padres e hijos
+  // Función para ordenar invitados agrupando padres e hijos (no sentados)
   const sortedGuests = useMemo(() => {
     if (!filterGuests?.noSentados) return [];
-    
+
     const guests = filterGuests.noSentados.filter((g) => g != null) as guests[];
     const result: any[] = [];
     const processed = new Set();
-    
+
     // Primero agregamos todos los invitados que no tienen padre (raíces)
     guests.forEach(guest => {
       if (!guest.father && !processed.has(guest._id)) {
         result.push(guest);
         processed.add(guest._id);
-        
+
         // Buscamos y agregamos todos los hijos de este invitado
         const addChildren = (parentId: string) => {
           guests.forEach(child => {
             if (child.father === parentId && !processed.has(child._id)) {
               // Agregamos la propiedad isChild y parentName para indicar que está después de su padre
-              const childWithFlag = { 
-                ...child, 
+              const childWithFlag = {
+                ...child,
                 isChild: true,
                 parentName: guest.nombre || 'Sin nombre' // Usando la propiedad correcta 'nombre'
               };
@@ -43,11 +48,11 @@ const ListInvitados: FC<propsListInvitados> = ({ editInv, setEditInv, setSelecte
             }
           });
         };
-        
+
         addChildren(guest._id);
       }
     });
-    
+
     // Agregamos cualquier invitado restante que no haya sido procesado
     guests.forEach(guest => {
       if (!processed.has(guest._id)) {
@@ -55,29 +60,69 @@ const ListInvitados: FC<propsListInvitados> = ({ editInv, setEditInv, setSelecte
         processed.add(guest._id);
       }
     });
-    
+
     return result;
   }, [filterGuests?.noSentados]);
 
+  const seated = useMemo(
+    () => (filterGuests?.sentados ?? []).filter((g) => g != null) as any[],
+    [filterGuests?.sentados]
+  );
+
+  const showPending = filter === 'todos' || filter === 'porsentar'
+  const showSeated = filter === 'todos' || filter === 'sentados'
+
   return (
     <>
-      <div className="w-full" >
-        {sortedGuests.map((invitado, index) => (
-          <div key={invitado._id} className="flex items-center">
-            <DragInvitado
-              key={invitado._id}
-              tipo={"invitado"}
-              index={index}
-              invitado={invitado}
-              editInv={editInv}
-              setEditInv={setEditInv}
-              setSelected={setSelected}
-            />
+      <div className="w-full flex flex-col gap-0.5 py-1">
+        {/* POR SENTAR — arrastrables. Se mantienen SIEMPRE montados (solo se ocultan por
+            CSS) para no romper el binding de interact.js (dragN / js-dragInvitadoN). */}
+        <div className={showPending ? '' : 'hidden'}>
+          {sortedGuests.length > 0 &&
+            <div className="px-3 pt-1 pb-0.5 text-[10px] font-bold uppercase tracking-wide text-[#a0a0a8]">
+              {t('tobeseated')} · {sortedGuests.length}
+            </div>
+          }
+          {sortedGuests.map((invitado, index) => (
+            <div key={invitado._id} className="flex items-center">
+              <DragInvitado
+                key={invitado._id}
+                tipo={"invitado"}
+                index={index}
+                invitado={invitado}
+                editInv={editInv}
+                setEditInv={setEditInv}
+                setSelected={setSelected}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* SENTADOS — solo lectura con etiqueta de asiento (Mesa · A{chair+1}). */}
+        <div className={showSeated ? '' : 'hidden'}>
+          <div className="px-3 pt-2 pb-0.5 text-[10px] font-bold uppercase tracking-wide text-[#EF5B94]">
+            {t('seated')} · {seated.length}
           </div>
-        ))}
+          {seated.length === 0 && showSeated &&
+            <div className="px-3 py-3 text-[11px] text-center text-[#a0a0a8]">{t('nonseatedguests')}</div>
+          }
+          {seated.map((g) => (
+            <div key={g._id} className="w-full flex items-center gap-2.5 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition">
+              <img
+                className="w-7 h-7 rounded-full object-cover ring-1 ring-gray-200"
+                src={ImageProfile[g.sexo]?.image}
+                alt={ImageProfile[g.sexo]?.alt}
+              />
+              <span className="flex-1 min-w-0 font-display text-sm truncate text-gray-600">{g.nombre}</span>
+              <span className="text-[10px] font-semibold text-[#EF5B94] bg-[#FCE7F0] px-2 py-0.5 rounded-md whitespace-nowrap">
+                {g.nombre_mesa ? `${g.nombre_mesa} · ` : ''}A{(g.chair ?? 0) + 1}
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
       <style jsx>
-          {`
+        {`
           ul {
             min-height: 15rem
           }

--- a/apps/appEventos/locales/en.ts
+++ b/apps/appEventos/locales/en.ts
@@ -1,6 +1,8 @@
 export const en = {
   translation: {
     'adjust': "Fit",
+    'all': "All",
+    'tobeseated': "To be seated",
     'eventspaces': "Event spaces",
     'occupied': "occupied",
     'perspace': "Per space",

--- a/apps/appEventos/locales/es.ts
+++ b/apps/appEventos/locales/es.ts
@@ -1,6 +1,8 @@
 export const es = {
   translation: {
     'adjust': 'Ajustar',
+    'all': 'Todos',
+    'tobeseated': 'Por sentar',
     'eventspaces': 'Espacios del evento',
     'occupied': 'ocupado',
     'perspace': 'Por espacio',


### PR DESCRIPTION
Fiel a `MESAS.dc.html`. **NO toca interact.js ni ids/clases de arrastre.**

- Cabecera colapsable + **filtro segmentado** Todos/Por sentar/Sentados + botón "Añadir invitados" en pastilla punteada.
- Sección **Sentados** (solo lectura) con etiqueta de asiento `nombre_mesa · A{chair+1}`.
- Las filas arrastrables **NO se desmontan** (solo se ocultan por CSS) → interact.js intacto. `js-dropGuests`/`dragN` conservados.

ESLint 0, /mesas 200. **Requiere QA de arrastre** (sentar/devolver invitado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)