### PR TITLE
💄 Rediseño Mesas — resaltar sillas libres al arrastrar (solo CSS)

### DIFF
--- a/apps/appEventos/components/Mesas/LienzoDragable.tsx
+++ b/apps/appEventos/components/Mesas/LienzoDragable.tsx
@@ -447,6 +447,15 @@ export const LiezoDragable: FC<propsLienzoDragable> = ({ scale, lienzo, setDisab
           .js-dropListInvitados.-drop-possibleHover:hover {
             background-color: orange;
           }
+          /* Rediseño Fase C (fiel a MESAS.dc.html): resalta en rosa las sillas LIBRES
+             (bg-white) mientras se arrastra un invitado. interact ya añade -drop-possible
+             a las sillas dropzone en dropactivate; las ocupadas (bg-primary) no se resaltan.
+             Solo CSS — no toca el motor de arrastre. */
+          .silla.bg-white.-drop-possible {
+            border-color: #EF5B94 !important;
+            background-color: #FCE7F0 !important;
+            box-shadow: 0 0 0 3px rgba(239, 91, 148, 0.25);
+          }
           .js-dragInvitadoN {
             touch-action: none;
             user-select: none;


### PR DESCRIPTION
Regla CSS que resalta en rosa las sillas **libres** (`.silla.bg-white`) al arrastrar un invitado, usando la clase `-drop-possible` que interact YA añade en `dropactivate`. Las ocupadas no se resaltan. **0 cambios de lógica** — no toca el motor de arrastre.

ESLint 0, /mesas 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)