### PR TITLE
💄✨ feat(chat-ia): redesign Comunicaciones (Fase A) + Cowork agentes (Fase B)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
@@ -1,0 +1,603 @@
+'use client';
+
+/**
+ * /agentes — Cowork de Agentes (Pantalla 2 del rediseño 18-jul).
+ *
+ * Vista NUEVA: no existía en el código previo. `grep cowork = 0 hits`
+ * confirmado en inventario baseline. Lo más cercano era `group_chat`
+ * supervisor pero es 1 humano ↔ N agentes IA (no este panel).
+ *
+ * Layout 3 columnas:
+ *   rail 56px  ·  lista agentes 260px  ·  ficha agente flex-1
+ *
+ * FUENTES DE DATOS:
+ *   ✅ Sessions custom del usuario: `sessionSelectors.defaultSessions`
+ *      filtrado por `type === 'agent'` (fuente real, ya cableada).
+ *   ✅ Prompt editable: `useAgentStore.updateAgentConfig({ systemRole })`
+ *      (ya existe, cableado).
+ *   🔵 Estado activo/pausado: `config.disabled?: boolean` — extensión
+ *      pendiente de `LobeAgentConfig`. Persistencia via PATCH
+ *      /chat/sessions/{id}. MOCK con localStorage por ahora.
+ *   🔵 Métricas hoy (replies_count, resolved_percent, avg_response_seconds):
+ *      endpoint /api/backend/chat/agents/{userId}/metrics?period=today
+ *      pendiente backend (Slack ts 1784383734). MOCK por agente.
+ *   🔵 Canales asignados: shape backend pendiente (Slack ts 1784383734).
+ *      MOCK con localStorage.
+ *   🔵 Actividad reciente + evento handoff: SSE type='handoff' pendiente
+ *      backend. MOCK con datos ficticios.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { MessagesRail } from '../messages/components/MessagesRail';
+
+// ⚠️ MOCKS marcados con `TODO: reemplazar cuando backend exponga`.
+// Sin cablear con backend real hasta que api-ia confirme shapes.
+
+interface AgentMetrics {
+  replies_count: number;
+  resolved_percent: number;
+  avg_response_seconds: number;
+}
+
+interface AgentActivity {
+  id: string;
+  timestamp: string;
+  type: 'reply' | 'handoff' | 'config_change' | 'suggestion';
+  description: string;
+}
+
+interface AgentSummary {
+  agentId: string;
+  name: string;
+  description: string;
+  avatar: string; // emoji o inicial
+  disabled: boolean;
+  systemRole: string;
+  channels: string[]; // channelParams asignados
+  metrics: AgentMetrics;
+  activity: AgentActivity[];
+}
+
+// Colores canal (mismos que ConversationItem — coherencia con Fase A)
+const CHANNEL_DOT: Record<string, string> = {
+  whatsapp: '#25D366',
+  instagram: '#E1306C',
+  facebook: '#1877F2',
+  telegram: '#2AABEE',
+  web: '#6B4EFF',
+  email: '#84848F',
+};
+const CHANNEL_LABEL: Record<string, string> = {
+  whatsapp: 'WhatsApp',
+  instagram: 'Instagram',
+  facebook: 'Facebook',
+  telegram: 'Telegram',
+  web: 'Web chat',
+  email: 'Email',
+};
+
+// TODO: reemplazar por sessionSelectors.defaultSessions filtrado por type='agent'
+//       + fusionar con métricas del endpoint pendiente backend.
+const MOCK_AGENTS: AgentSummary[] = [
+  {
+    agentId: 'mock-agent-1',
+    name: 'Ana',
+    description: 'Especialista en atención a invitados',
+    avatar: '✦',
+    disabled: false,
+    systemRole:
+      'Eres Ana, asistente especializada en atención a invitados. Respondes con calidez, confirmas RSVPs y ayudas con dudas de menú, dieta, alojamiento y transporte. No inventes datos del evento — si no sabes, escala al organizador.',
+    channels: ['whatsapp', 'web'],
+    metrics: { replies_count: 47, resolved_percent: 82, avg_response_seconds: 23 },
+    activity: [
+      { id: 'a1', timestamp: '2h', type: 'reply', description: 'Respondió a María sobre menú vegetariano' },
+      { id: 'a2', timestamp: '3h', type: 'suggestion', description: 'Sugirió respuesta a Carlos (aprobada)' },
+      { id: 'a3', timestamp: '5h', type: 'handoff', description: 'Handoff a organizador — pregunta sobre alojamiento' },
+    ],
+  },
+  {
+    agentId: 'mock-agent-2',
+    name: 'Beto',
+    description: 'Comercial · calificación de leads',
+    avatar: '✦',
+    disabled: false,
+    systemRole:
+      'Eres Beto, comercial encargado de calificar leads entrantes. Preguntas por presupuesto, fecha estimada, número de invitados y tipo de evento. Marcas la conversación como calificada cuando tengas los 4 datos.',
+    channels: ['instagram', 'facebook', 'email'],
+    metrics: { replies_count: 12, resolved_percent: 33, avg_response_seconds: 45 },
+    activity: [
+      { id: 'b1', timestamp: '1h', type: 'reply', description: 'Nuevo lead — preguntando por presupuesto' },
+      { id: 'b2', timestamp: '4h', type: 'config_change', description: 'Prompt actualizado por Juan Carlos' },
+    ],
+  },
+  {
+    agentId: 'mock-agent-3',
+    name: 'Ceci',
+    description: 'Soporte técnico web (pausada)',
+    avatar: '✦',
+    disabled: true,
+    systemRole: 'Eres Ceci, encargada de resolver dudas técnicas de la web del evento.',
+    channels: ['web'],
+    metrics: { replies_count: 0, resolved_percent: 0, avg_response_seconds: 0 },
+    activity: [],
+  },
+];
+
+const AGENT_STATE_KEY_PREFIX = 'cowork_agent_state_';
+
+function loadLocalAgentState(agentId: string): Partial<AgentSummary> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(`${AGENT_STATE_KEY_PREFIX}${agentId}`);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveLocalAgentState(agentId: string, patch: Partial<AgentSummary>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const current = loadLocalAgentState(agentId);
+    localStorage.setItem(
+      `${AGENT_STATE_KEY_PREFIX}${agentId}`,
+      JSON.stringify({ ...current, ...patch }),
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function AgentesPage() {
+  // TODO: reemplazar MOCK_AGENTS por sessionSelectors.defaultSessions filtrado
+  //       + fusionar con métricas del endpoint /api/backend/chat/agents/{userId}/metrics
+  const [agents, setAgents] = useState<AgentSummary[]>(MOCK_AGENTS);
+  const [selectedId, setSelectedId] = useState<string>(MOCK_AGENTS[0]?.agentId ?? '');
+
+  // Hidratar estado local (disabled + channels + systemRole editados)
+  useEffect(() => {
+    setAgents((prev) =>
+      prev.map((a) => {
+        const local = loadLocalAgentState(a.agentId);
+        return { ...a, ...local };
+      }),
+    );
+  }, []);
+
+  const selected = useMemo(
+    () => agents.find((a) => a.agentId === selectedId) ?? agents[0],
+    [agents, selectedId],
+  );
+
+  const toggleAgentDisabled = useCallback(
+    (agentId: string) => {
+      setAgents((prev) =>
+        prev.map((a) => {
+          if (a.agentId !== agentId) return a;
+          const next = { ...a, disabled: !a.disabled };
+          saveLocalAgentState(agentId, { disabled: next.disabled });
+          // TODO: cablear PATCH /chat/sessions/{agentId} con { config: { disabled: next.disabled } }
+          //       cuando LobeAgentConfig acepte el campo (Slack ts 1784383734).
+          return next;
+        }),
+      );
+    },
+    [],
+  );
+
+  const toggleChannelAssignment = useCallback(
+    (agentId: string, channel: string) => {
+      setAgents((prev) =>
+        prev.map((a) => {
+          if (a.agentId !== agentId) return a;
+          const has = a.channels.includes(channel);
+          const nextChannels = has ? a.channels.filter((c) => c !== channel) : [...a.channels, channel];
+          saveLocalAgentState(agentId, { channels: nextChannels });
+          // TODO: cablear POST /api/backend/chat/agents/{userId}/channel-assignments
+          //       body { agentId, channels: nextChannels } (Slack ts 1784383734).
+          return { ...a, channels: nextChannels };
+        }),
+      );
+    },
+    [],
+  );
+
+  const updateSystemRole = useCallback((agentId: string, systemRole: string) => {
+    setAgents((prev) =>
+      prev.map((a) => {
+        if (a.agentId !== agentId) return a;
+        saveLocalAgentState(agentId, { systemRole });
+        // ✅ CABLEADO: PATCH /chat/sessions/{agentId} con { config: { systemRole } }
+        //    via useAgentStore.updateAgentConfig — ya existe en el store.
+        //    (implementación real usará el store cuando sustituyamos MOCK_AGENTS
+        //    por sessionSelectors.defaultSessions).
+        return { ...a, systemRole };
+      }),
+    );
+  }, []);
+
+  if (!selected) {
+    return (
+      <div
+        className="flex h-full items-center justify-center px-6"
+        style={{ backgroundColor: '#FCFCFD' }}
+      >
+        <div className="text-center max-w-md">
+          <p className="text-lg font-semibold" style={{ color: '#1C1C22' }}>
+            Aún no tienes agentes creados
+          </p>
+          <p className="mt-2 text-sm" style={{ color: '#84848F' }}>
+            Crea tu primer agente para automatizar respuestas en tus canales.
+          </p>
+          <button
+            className="mt-4 rounded-md px-4 py-2 text-sm font-semibold text-white"
+            style={{ backgroundColor: '#1C1C22' }}
+            type="button"
+          >
+            Crear agente
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden" style={{ backgroundColor: '#FFFFFF' }}>
+      {/* Rail 56px — misma navegación que /messages (coherencia rediseño) */}
+      <MessagesRail />
+
+      {/* Lista agentes 260px */}
+      <aside
+        className="flex w-[260px] shrink-0 flex-col overflow-hidden"
+        style={{ borderRight: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+      >
+        <div
+          className="sticky top-0 z-10 px-4 py-3"
+          style={{ backgroundColor: '#FFFFFF', borderBottom: '1px solid #EDEDF0' }}
+        >
+          <h1 className="text-base font-semibold" style={{ color: '#1C1C22' }}>
+            Tu equipo
+          </h1>
+          <p className="mt-0.5 text-xs" style={{ color: '#84848F' }}>
+            {agents.filter((a) => !a.disabled).length} activos · {agents.length}{' '}
+            {agents.length === 1 ? 'agente' : 'agentes'}
+          </p>
+        </div>
+        <div className="flex-1 overflow-auto">
+          {agents.map((agent) => {
+            const isSelected = agent.agentId === selectedId;
+            return (
+              <button
+                key={agent.agentId}
+                aria-current={isSelected}
+                className="w-full text-left transition-colors"
+                onClick={() => setSelectedId(agent.agentId)}
+                style={{
+                  backgroundColor: isSelected ? '#F2F1F6' : 'transparent',
+                  borderBottom: '1px solid #EDEDF0',
+                }}
+                onMouseEnter={(e) => {
+                  if (!isSelected) e.currentTarget.style.backgroundColor = '#FCFCFD';
+                }}
+                onMouseLeave={(e) => {
+                  if (!isSelected) e.currentTarget.style.backgroundColor = 'transparent';
+                }}
+                type="button"
+              >
+                <div className="flex items-start gap-3 px-3 py-3">
+                  <div className="relative flex-shrink-0">
+                    <div
+                      className="flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold"
+                      style={{
+                        backgroundColor: agent.disabled ? '#F2F1F6' : '#EDE9FE',
+                        color: agent.disabled ? '#84848F' : '#6B4EFF',
+                      }}
+                    >
+                      {agent.avatar}
+                    </div>
+                    <span
+                      aria-label={agent.disabled ? 'Pausado' : 'Activo'}
+                      className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full"
+                      style={{
+                        backgroundColor: agent.disabled ? '#D4D4D8' : '#22C55E',
+                        boxShadow: '0 0 0 2px #FFFFFF',
+                      }}
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                      {agent.name}
+                    </div>
+                    <div className="mt-0.5 truncate text-xs" style={{ color: '#84848F' }}>
+                      {agent.description}
+                    </div>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <div style={{ borderTop: '1px solid #EDEDF0' }}>
+          <button
+            className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium transition-colors"
+            onClick={() => {
+              // TODO: reusar sessionService.createSession({ type: 'agent' })
+              //       cuando sustituyamos MOCK_AGENTS por sessions reales.
+              // eslint-disable-next-line no-alert
+              alert(
+                'Crear agente: aún no cableado. Se conectará con sessionService.createSession cuando sustituyamos MOCK_AGENTS por sessions reales.',
+              );
+            }}
+            style={{ color: '#6B4EFF', backgroundColor: 'transparent' }}
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#F2F1F6')}
+            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+            type="button"
+          >
+            <svg
+              fill="none"
+              height="16"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.8"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            Crear agente
+          </button>
+        </div>
+      </aside>
+
+      {/* Ficha del agente flex-1 */}
+      <section className="flex flex-1 flex-col overflow-auto">
+        {/* Cabecera ficha */}
+        <div
+          className="sticky top-0 z-10 px-6 py-4"
+          style={{ backgroundColor: '#FFFFFF', borderBottom: '1px solid #EDEDF0' }}
+        >
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div
+                className="flex h-11 w-11 items-center justify-center rounded-full text-lg font-semibold"
+                style={{
+                  backgroundColor: selected.disabled ? '#F2F1F6' : '#EDE9FE',
+                  color: selected.disabled ? '#84848F' : '#6B4EFF',
+                }}
+              >
+                {selected.avatar}
+              </div>
+              <div>
+                <div className="flex items-center gap-2">
+                  <h2 className="text-lg font-semibold" style={{ color: '#1C1C22' }}>
+                    {selected.name}
+                  </h2>
+                  <span
+                    className="rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                    style={{
+                      backgroundColor: selected.disabled ? '#F2F1F6' : '#DCFCE7',
+                      color: selected.disabled ? '#84848F' : '#166534',
+                    }}
+                  >
+                    {selected.disabled ? 'Pausado' : 'Activo'}
+                  </span>
+                </div>
+                <p className="mt-0.5 text-xs" style={{ color: '#84848F' }}>
+                  {selected.description}
+                </p>
+              </div>
+            </div>
+            {/* Toggle Encendido/Apagado */}
+            <button
+              aria-pressed={!selected.disabled}
+              className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+              onClick={() => toggleAgentDisabled(selected.agentId)}
+              style={{
+                backgroundColor: selected.disabled ? '#F2F1F6' : '#1C1C22',
+                color: selected.disabled ? '#1C1C22' : '#FFFFFF',
+              }}
+              type="button"
+            >
+              {selected.disabled ? 'Reanudar' : 'Pausar'}
+            </button>
+          </div>
+        </div>
+
+        {/* Contenido ficha */}
+        <div className="flex-1 overflow-auto px-6 py-6">
+          <div className="mx-auto max-w-3xl space-y-6">
+            {/* Rendimiento hoy */}
+            <div
+              className="rounded-lg p-4"
+              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                  Rendimiento hoy
+                </h3>
+                <span
+                  className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                  title="Datos mock — backend pendiente"
+                >
+                  DEMO
+                </span>
+              </div>
+              <div className="grid grid-cols-3 gap-4">
+                <MetricCard
+                  label="Respuestas"
+                  value={selected.metrics.replies_count.toString()}
+                />
+                <MetricCard
+                  label="Resueltas sola"
+                  value={`${selected.metrics.resolved_percent}%`}
+                />
+                <MetricCard
+                  label="Tiempo medio"
+                  value={`${selected.metrics.avg_response_seconds}s`}
+                />
+              </div>
+            </div>
+
+            {/* Canales asignados */}
+            <div
+              className="rounded-lg p-4"
+              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                  Canales asignados
+                </h3>
+                <span
+                  className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                  title="Persistencia local hasta que backend confirme shape"
+                >
+                  BETA
+                </span>
+              </div>
+              <p className="mb-3 text-xs" style={{ color: '#84848F' }}>
+                Cuando llegue un mensaje por uno de estos canales, este agente lo atenderá según su
+                configuración.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {Object.keys(CHANNEL_LABEL).map((ch) => {
+                  const isActive = selected.channels.includes(ch);
+                  return (
+                    <button
+                      key={ch}
+                      aria-pressed={isActive}
+                      className="flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+                      onClick={() => toggleChannelAssignment(selected.agentId, ch)}
+                      style={{
+                        backgroundColor: isActive ? '#EDE9FE' : '#FFFFFF',
+                        border: `1px solid ${isActive ? '#EDE9FE' : '#EDEDF0'}`,
+                        color: isActive ? '#6B4EFF' : '#84848F',
+                      }}
+                      type="button"
+                    >
+                      <span
+                        className="h-2 w-2 rounded-full"
+                        style={{ backgroundColor: CHANNEL_DOT[ch] ?? '#84848F' }}
+                      />
+                      {CHANNEL_LABEL[ch]}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Instrucciones del agente (prompt editable) */}
+            <div
+              className="rounded-lg p-4"
+              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+            >
+              <h3 className="mb-2 text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                Instrucciones del agente
+              </h3>
+              <p className="mb-3 text-xs" style={{ color: '#84848F' }}>
+                Estas son las reglas que sigue el agente al responder. Cámbialas para ajustar tono,
+                límites y comportamiento.
+              </p>
+              <textarea
+                className="w-full rounded-md p-3 text-sm focus:outline-none"
+                onChange={(e) => updateSystemRole(selected.agentId, e.target.value)}
+                rows={6}
+                style={{
+                  backgroundColor: '#F2F1F6',
+                  border: '1px solid transparent',
+                  color: '#1C1C22',
+                  resize: 'vertical',
+                }}
+                onFocus={(e) => {
+                  e.currentTarget.style.backgroundColor = '#FFFFFF';
+                  e.currentTarget.style.borderColor = '#6B4EFF';
+                }}
+                onBlur={(e) => {
+                  e.currentTarget.style.backgroundColor = '#F2F1F6';
+                  e.currentTarget.style.borderColor = 'transparent';
+                }}
+                value={selected.systemRole}
+              />
+            </div>
+
+            {/* Actividad reciente */}
+            <div
+              className="rounded-lg p-4"
+              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                  Actividad reciente
+                </h3>
+                <span
+                  className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                  title="Datos mock — evento handoff pendiente en SSE"
+                >
+                  DEMO
+                </span>
+              </div>
+              {selected.activity.length === 0 ? (
+                <p className="text-xs" style={{ color: '#9A9AA6' }}>
+                  Sin actividad reciente. Cuando el agente responda o se produzca un handoff aparecerá
+                  aquí.
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {selected.activity.map((a) => (
+                    <li key={a.id} className="flex items-start gap-3">
+                      <span
+                        className="mt-1 h-2 w-2 shrink-0 rounded-full"
+                        style={{
+                          backgroundColor:
+                            a.type === 'handoff'
+                              ? '#F59E0B'
+                              : a.type === 'config_change'
+                                ? '#84848F'
+                                : '#6B4EFF',
+                        }}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs" style={{ color: '#1C1C22' }}>
+                          {a.description}
+                        </p>
+                        <p className="mt-0.5 text-[11px]" style={{ color: '#9A9AA6' }}>
+                          hace {a.timestamp}
+                        </p>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {/* Nota mocks */}
+            <p className="text-center text-[11px] italic" style={{ color: '#9A9AA6' }}>
+              Los datos marcados DEMO son mocks. Se cablearán cuando backend confirme shapes
+              (endpoint métricas + asignación canales + evento handoff, Slack ts 1784383734).
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      className="rounded-md px-3 py-2"
+      style={{ backgroundColor: '#F2F1F6' }}
+    >
+      <div className="text-xs" style={{ color: '#84848F' }}>
+        {label}
+      </div>
+      <div className="mt-0.5 text-lg font-semibold" style={{ color: '#1C1C22' }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
@@ -10,54 +10,33 @@
  * Layout 3 columnas:
  *   rail 56px  ·  lista agentes 260px  ·  ficha agente flex-1
  *
- * FUENTES DE DATOS:
- *   ✅ Sessions custom del usuario: `sessionSelectors.defaultSessions`
- *      filtrado por `type === 'agent'` (fuente real, ya cableada).
- *   ✅ Prompt editable: `useAgentStore.updateAgentConfig({ systemRole })`
- *      (ya existe, cableado).
- *   🔵 Estado activo/pausado: `config.disabled?: boolean` — extensión
- *      pendiente de `LobeAgentConfig`. Persistencia via PATCH
- *      /chat/sessions/{id}. MOCK con localStorage por ahora.
+ * FUENTES DE DATOS (actualizado 19-jul — commit "MOCK_AGENTS→sessions reales"):
+ *   ✅ Lista agentes: `sessionSelectors.defaultSessions` filtrado por
+ *      type='agent'. Real, persistido por backend (getSessionsService).
+ *   ✅ Prompt editable (systemRole): cableado con `useAgentStore.updateAgentConfig`
+ *      → internal_updateAgentConfig → sessionService.updateSessionConfig →
+ *      PATCH /chat/sessions/{id}. Persiste entre dispositivos.
+ *   ✅ Avatar / título / descripción: de `session.meta.{avatar,title,description}`.
+ *   🔵 Estado activo/pausado: `config.disabled?: boolean` — campo NO existe
+ *      aún en LobeAgentConfig. MOCK con localStorage hasta que backend lo
+ *      añada (Slack ts 1784383734).
  *   🔵 Métricas hoy (replies_count, resolved_percent, avg_response_seconds):
  *      endpoint /api/backend/chat/agents/{userId}/metrics?period=today
  *      pendiente backend (Slack ts 1784383734). MOCK por agente.
  *   🔵 Canales asignados: shape backend pendiente (Slack ts 1784383734).
  *      MOCK con localStorage.
  *   🔵 Actividad reciente + evento handoff: SSE type='handoff' pendiente
- *      backend. MOCK con datos ficticios.
+ *      backend. Vacía por defecto — sin mocks inventados.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useAgentStore } from '@/store/agent';
+import { useSessionStore } from '@/store/session';
+import { sessionSelectors } from '@/store/session/selectors';
+import { LobeSessionType, type LobeAgentSession } from '@/types/session';
+
 import { MessagesRail } from '../messages/components/MessagesRail';
-
-// ⚠️ MOCKS marcados con `TODO: reemplazar cuando backend exponga`.
-// Sin cablear con backend real hasta que api-ia confirme shapes.
-
-interface AgentMetrics {
-  replies_count: number;
-  resolved_percent: number;
-  avg_response_seconds: number;
-}
-
-interface AgentActivity {
-  id: string;
-  timestamp: string;
-  type: 'reply' | 'handoff' | 'config_change' | 'suggestion';
-  description: string;
-}
-
-interface AgentSummary {
-  agentId: string;
-  name: string;
-  description: string;
-  avatar: string; // emoji o inicial
-  disabled: boolean;
-  systemRole: string;
-  channels: string[]; // channelParams asignados
-  metrics: AgentMetrics;
-  activity: AgentActivity[];
-}
 
 // Colores canal (mismos que ConversationItem — coherencia con Fase A)
 const CHANNEL_DOT: Record<string, string> = {
@@ -77,56 +56,24 @@ const CHANNEL_LABEL: Record<string, string> = {
   email: 'Email',
 };
 
-// TODO: reemplazar por sessionSelectors.defaultSessions filtrado por type='agent'
-//       + fusionar con métricas del endpoint pendiente backend.
-const MOCK_AGENTS: AgentSummary[] = [
-  {
-    agentId: 'mock-agent-1',
-    name: 'Ana',
-    description: 'Especialista en atención a invitados',
-    avatar: '✦',
-    disabled: false,
-    systemRole:
-      'Eres Ana, asistente especializada en atención a invitados. Respondes con calidez, confirmas RSVPs y ayudas con dudas de menú, dieta, alojamiento y transporte. No inventes datos del evento — si no sabes, escala al organizador.',
-    channels: ['whatsapp', 'web'],
-    metrics: { replies_count: 47, resolved_percent: 82, avg_response_seconds: 23 },
-    activity: [
-      { id: 'a1', timestamp: '2h', type: 'reply', description: 'Respondió a María sobre menú vegetariano' },
-      { id: 'a2', timestamp: '3h', type: 'suggestion', description: 'Sugirió respuesta a Carlos (aprobada)' },
-      { id: 'a3', timestamp: '5h', type: 'handoff', description: 'Handoff a organizador — pregunta sobre alojamiento' },
-    ],
-  },
-  {
-    agentId: 'mock-agent-2',
-    name: 'Beto',
-    description: 'Comercial · calificación de leads',
-    avatar: '✦',
-    disabled: false,
-    systemRole:
-      'Eres Beto, comercial encargado de calificar leads entrantes. Preguntas por presupuesto, fecha estimada, número de invitados y tipo de evento. Marcas la conversación como calificada cuando tengas los 4 datos.',
-    channels: ['instagram', 'facebook', 'email'],
-    metrics: { replies_count: 12, resolved_percent: 33, avg_response_seconds: 45 },
-    activity: [
-      { id: 'b1', timestamp: '1h', type: 'reply', description: 'Nuevo lead — preguntando por presupuesto' },
-      { id: 'b2', timestamp: '4h', type: 'config_change', description: 'Prompt actualizado por Juan Carlos' },
-    ],
-  },
-  {
-    agentId: 'mock-agent-3',
-    name: 'Ceci',
-    description: 'Soporte técnico web (pausada)',
-    avatar: '✦',
-    disabled: true,
-    systemRole: 'Eres Ceci, encargada de resolver dudas técnicas de la web del evento.',
-    channels: ['web'],
-    metrics: { replies_count: 0, resolved_percent: 0, avg_response_seconds: 0 },
-    activity: [],
-  },
-];
+interface AgentActivity {
+  id: string;
+  timestamp: string;
+  type: 'reply' | 'handoff' | 'config_change' | 'suggestion';
+  description: string;
+}
+
+// Estado local persistido en localStorage — sólo los 4 mocks pendientes
+// de backend (disabled + channels). Métricas/actividad viven en memoria
+// mientras no lleguen del server (no tiene sentido cachearlos vacíos).
+interface LocalAgentState {
+  disabled?: boolean;
+  channels?: string[];
+}
 
 const AGENT_STATE_KEY_PREFIX = 'cowork_agent_state_';
 
-function loadLocalAgentState(agentId: string): Partial<AgentSummary> {
+function loadLocalAgentState(agentId: string): LocalAgentState {
   if (typeof window === 'undefined') return {};
   try {
     const raw = localStorage.getItem(`${AGENT_STATE_KEY_PREFIX}${agentId}`);
@@ -136,7 +83,7 @@ function loadLocalAgentState(agentId: string): Partial<AgentSummary> {
   }
 }
 
-function saveLocalAgentState(agentId: string, patch: Partial<AgentSummary>): void {
+function saveLocalAgentState(agentId: string, patch: LocalAgentState): void {
   if (typeof window === 'undefined') return;
   try {
     const current = loadLocalAgentState(agentId);
@@ -149,98 +96,170 @@ function saveLocalAgentState(agentId: string, patch: Partial<AgentSummary>): voi
   }
 }
 
-export default function AgentesPage() {
-  // TODO: reemplazar MOCK_AGENTS por sessionSelectors.defaultSessions filtrado
-  //       + fusionar con métricas del endpoint /api/backend/chat/agents/{userId}/metrics
-  const [agents, setAgents] = useState<AgentSummary[]>(MOCK_AGENTS);
-  const [selectedId, setSelectedId] = useState<string>(MOCK_AGENTS[0]?.agentId ?? '');
+// Extrae inicial del meta.title para el avatar cuando no hay meta.avatar.
+function agentInitial(title: string | undefined): string {
+  if (!title) return '✦';
+  const trimmed = title.trim();
+  return trimmed ? trimmed[0]!.toUpperCase() : '✦';
+}
 
-  // Hidratar estado local (disabled + channels + systemRole editados)
-  useEffect(() => {
-    setAgents((prev) =>
-      prev.map((a) => {
-        const local = loadLocalAgentState(a.agentId);
-        return { ...a, ...local };
-      }),
+export default function AgentesPage() {
+  // Sessions reales del store (persistidas por backend).
+  const agentSessions = useSessionStore((s) => {
+    const all = sessionSelectors.defaultSessions(s);
+    return all.filter(
+      (session): session is LobeAgentSession => session.type === LobeSessionType.Agent,
     );
-  }, []);
+  });
+  const switchSession = useSessionStore((s) => s.switchSession);
+  const activeId = useSessionStore((s) => s.activeId);
+  const isSessionListInit = useSessionStore(sessionSelectors.isSessionListInit);
+
+  // Prompt editable → escritura vía useAgentStore.updateAgentConfig
+  // (persiste PATCH /chat/sessions/{id}). Actúa sobre `activeId`, por eso
+  // la selección de la lista hace switchSession(id) antes de editar.
+  const updateAgentConfig = useAgentStore((s) => s.updateAgentConfig);
+
+  // Selección visual local (no cambia el activo hasta que el usuario
+  // interactúa con la ficha → evita side-effect al montar).
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedId && agentSessions.length > 0) {
+      setSelectedId(agentSessions[0].id);
+    }
+  }, [selectedId, agentSessions]);
+
+  // Estado local (disabled + channels) por agente — memoria hasta backend.
+  const [localStates, setLocalStates] = useState<Record<string, LocalAgentState>>({});
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const map: Record<string, LocalAgentState> = {};
+    agentSessions.forEach((a) => {
+      map[a.id] = loadLocalAgentState(a.id);
+    });
+    setLocalStates(map);
+  }, [agentSessions]);
 
   const selected = useMemo(
-    () => agents.find((a) => a.agentId === selectedId) ?? agents[0],
-    [agents, selectedId],
+    () => agentSessions.find((a) => a.id === selectedId) ?? null,
+    [agentSessions, selectedId],
   );
 
-  const toggleAgentDisabled = useCallback(
-    (agentId: string) => {
-      setAgents((prev) =>
-        prev.map((a) => {
-          if (a.agentId !== agentId) return a;
-          const next = { ...a, disabled: !a.disabled };
-          saveLocalAgentState(agentId, { disabled: next.disabled });
-          // TODO: cablear PATCH /chat/sessions/{agentId} con { config: { disabled: next.disabled } }
-          //       cuando LobeAgentConfig acepte el campo (Slack ts 1784383734).
-          return next;
-        }),
-      );
+  const selectedLocal = selected ? (localStates[selected.id] ?? {}) : {};
+  const selectedDisabled = !!selectedLocal.disabled;
+  const selectedChannels = selectedLocal.channels ?? [];
+
+  // Estado del prompt en edición — controlled input con debounce a backend.
+  // Al cambiar de agente se re-hidrata desde session.config.systemRole.
+  const [promptDraft, setPromptDraft] = useState<string>('');
+  useEffect(() => {
+    setPromptDraft(selected?.config.systemRole ?? '');
+  }, [selected?.id, selected?.config.systemRole]);
+
+  const persistPrompt = useCallback(
+    async (systemRole: string) => {
+      if (!selected) return;
+      // updateAgentConfig actúa sobre activeId — cambiarlo primero si no coincide.
+      if (activeId !== selected.id) {
+        switchSession(selected.id);
+        // switchSession es sync, pero updateAgentConfig lee activeId en el instante
+        // siguiente. useEffect en el store actualiza. Pequeño retardo para asegurar.
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      await updateAgentConfig({ systemRole });
     },
-    [],
+    [selected, activeId, switchSession, updateAgentConfig],
   );
 
-  const toggleChannelAssignment = useCallback(
-    (agentId: string, channel: string) => {
-      setAgents((prev) =>
-        prev.map((a) => {
-          if (a.agentId !== agentId) return a;
-          const has = a.channels.includes(channel);
-          const nextChannels = has ? a.channels.filter((c) => c !== channel) : [...a.channels, channel];
-          saveLocalAgentState(agentId, { channels: nextChannels });
-          // TODO: cablear POST /api/backend/chat/agents/{userId}/channel-assignments
-          //       body { agentId, channels: nextChannels } (Slack ts 1784383734).
-          return { ...a, channels: nextChannels };
-        }),
-      );
-    },
-    [],
-  );
+  // Debounce 800ms — al parar de escribir persiste. Coherente con el patrón
+  // de otros settings del propio LobeChat (AgentSetting).
+  useEffect(() => {
+    if (!selected) return;
+    if (promptDraft === (selected.config.systemRole ?? '')) return;
+    const t = setTimeout(() => {
+      void persistPrompt(promptDraft);
+    }, 800);
+    return () => clearTimeout(t);
+  }, [promptDraft, selected, persistPrompt]);
 
-  const updateSystemRole = useCallback((agentId: string, systemRole: string) => {
-    setAgents((prev) =>
-      prev.map((a) => {
-        if (a.agentId !== agentId) return a;
-        saveLocalAgentState(agentId, { systemRole });
-        // ✅ CABLEADO: PATCH /chat/sessions/{agentId} con { config: { systemRole } }
-        //    via useAgentStore.updateAgentConfig — ya existe en el store.
-        //    (implementación real usará el store cuando sustituyamos MOCK_AGENTS
-        //    por sessionSelectors.defaultSessions).
-        return { ...a, systemRole };
-      }),
-    );
+  const toggleAgentDisabled = useCallback((agentId: string) => {
+    setLocalStates((prev) => {
+      const current = prev[agentId] ?? {};
+      const next: LocalAgentState = { ...current, disabled: !current.disabled };
+      saveLocalAgentState(agentId, { disabled: next.disabled });
+      // TODO: cablear PATCH /chat/sessions/{agentId} con { config: { disabled } }
+      //       cuando LobeAgentConfig acepte el campo (Slack ts 1784383734).
+      return { ...prev, [agentId]: next };
+    });
   }, []);
 
-  if (!selected) {
+  const toggleChannelAssignment = useCallback((agentId: string, channel: string) => {
+    setLocalStates((prev) => {
+      const current = prev[agentId] ?? {};
+      const has = (current.channels ?? []).includes(channel);
+      const nextChannels = has
+        ? (current.channels ?? []).filter((c) => c !== channel)
+        : [...(current.channels ?? []), channel];
+      const next: LocalAgentState = { ...current, channels: nextChannels };
+      saveLocalAgentState(agentId, { channels: nextChannels });
+      // TODO: cablear POST /api/backend/chat/agents/{userId}/channel-assignments
+      //       body { agentId, channels: nextChannels } (Slack ts 1784383734).
+      return { ...prev, [agentId]: next };
+    });
+  }, []);
+
+  // === Empty states =========================================================
+
+  // Sessions aún no hidratadas — Redirect.tsx ya evita el fullscreen loader
+  // en /agentes (ROUTES_TO_SKIP). Aquí ponemos placeholder discreto para
+  // evitar mostrar "no tienes agentes" mientras cargan.
+  if (!isSessionListInit) {
     return (
-      <div
-        className="flex h-full items-center justify-center px-6"
-        style={{ backgroundColor: '#FCFCFD' }}
-      >
-        <div className="text-center max-w-md">
-          <p className="text-lg font-semibold" style={{ color: '#1C1C22' }}>
-            Aún no tienes agentes creados
+      <div className="flex h-full" style={{ backgroundColor: '#FFFFFF' }}>
+        <MessagesRail />
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-sm" style={{ color: '#84848F' }}>
+            Cargando tus agentes…
           </p>
-          <p className="mt-2 text-sm" style={{ color: '#84848F' }}>
-            Crea tu primer agente para automatizar respuestas en tus canales.
-          </p>
-          <button
-            className="mt-4 rounded-md px-4 py-2 text-sm font-semibold text-white"
-            style={{ backgroundColor: '#1C1C22' }}
-            type="button"
-          >
-            Crear agente
-          </button>
         </div>
       </div>
     );
   }
+
+  if (agentSessions.length === 0) {
+    return (
+      <div className="flex h-full" style={{ backgroundColor: '#FFFFFF' }}>
+        <MessagesRail />
+        <div className="flex flex-1 items-center justify-center px-6">
+          <div className="max-w-md text-center">
+            <div
+              className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full text-2xl font-semibold"
+              style={{ backgroundColor: '#EDE9FE', color: '#6B4EFF' }}
+            >
+              ✦
+            </div>
+            <p className="text-lg font-semibold" style={{ color: '#1C1C22' }}>
+              Aún no tienes agentes creados
+            </p>
+            <p className="mt-2 text-sm" style={{ color: '#84848F' }}>
+              Crea tu primer agente en Copilot para atender conversaciones por WhatsApp,
+              Instagram, Facebook y otros canales de forma automática.
+            </p>
+            <a
+              className="mt-4 inline-block rounded-md px-4 py-2 text-sm font-semibold text-white transition-colors"
+              href="/chat"
+              style={{ backgroundColor: '#1C1C22' }}
+            >
+              Ir a Copilot
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // === Vista principal ======================================================
 
   return (
     <div className="flex h-full overflow-hidden" style={{ backgroundColor: '#FFFFFF' }}>
@@ -260,19 +279,23 @@ export default function AgentesPage() {
             Tu equipo
           </h1>
           <p className="mt-0.5 text-xs" style={{ color: '#84848F' }}>
-            {agents.filter((a) => !a.disabled).length} activos · {agents.length}{' '}
-            {agents.length === 1 ? 'agente' : 'agentes'}
+            {agentSessions.filter((a) => !localStates[a.id]?.disabled).length} activos ·{' '}
+            {agentSessions.length} {agentSessions.length === 1 ? 'agente' : 'agentes'}
           </p>
         </div>
         <div className="flex-1 overflow-auto">
-          {agents.map((agent) => {
-            const isSelected = agent.agentId === selectedId;
+          {agentSessions.map((agent) => {
+            const isSelected = agent.id === selectedId;
+            const disabled = !!localStates[agent.id]?.disabled;
+            const title = agent.meta.title ?? 'Sin nombre';
+            const description = agent.meta.description ?? '';
+            const avatar = agent.meta.avatar || agentInitial(agent.meta.title);
             return (
               <button
-                key={agent.agentId}
+                key={agent.id}
                 aria-current={isSelected}
                 className="w-full text-left transition-colors"
-                onClick={() => setSelectedId(agent.agentId)}
+                onClick={() => setSelectedId(agent.id)}
                 style={{
                   backgroundColor: isSelected ? '#F2F1F6' : 'transparent',
                   borderBottom: '1px solid #EDEDF0',
@@ -288,30 +311,37 @@ export default function AgentesPage() {
                 <div className="flex items-start gap-3 px-3 py-3">
                   <div className="relative flex-shrink-0">
                     <div
-                      className="flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold"
+                      className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-full text-sm font-semibold"
                       style={{
-                        backgroundColor: agent.disabled ? '#F2F1F6' : '#EDE9FE',
-                        color: agent.disabled ? '#84848F' : '#6B4EFF',
+                        backgroundColor: disabled ? '#F2F1F6' : '#EDE9FE',
+                        color: disabled ? '#84848F' : '#6B4EFF',
                       }}
                     >
-                      {agent.avatar}
+                      {avatar.startsWith('http') || avatar.startsWith('data:') ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img alt="" className="h-full w-full object-cover" src={avatar} />
+                      ) : (
+                        avatar
+                      )}
                     </div>
                     <span
-                      aria-label={agent.disabled ? 'Pausado' : 'Activo'}
+                      aria-label={disabled ? 'Pausado' : 'Activo'}
                       className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full"
                       style={{
-                        backgroundColor: agent.disabled ? '#D4D4D8' : '#22C55E',
+                        backgroundColor: disabled ? '#D4D4D8' : '#22C55E',
                         boxShadow: '0 0 0 2px #FFFFFF',
                       }}
                     />
                   </div>
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-semibold" style={{ color: '#1C1C22' }}>
-                      {agent.name}
+                      {title}
                     </div>
-                    <div className="mt-0.5 truncate text-xs" style={{ color: '#84848F' }}>
-                      {agent.description}
-                    </div>
+                    {description && (
+                      <div className="mt-0.5 truncate text-xs" style={{ color: '#84848F' }}>
+                        {description}
+                      </div>
+                    )}
                   </div>
                 </div>
               </button>
@@ -319,20 +349,12 @@ export default function AgentesPage() {
           })}
         </div>
         <div style={{ borderTop: '1px solid #EDEDF0' }}>
-          <button
+          <a
             className="flex w-full items-center gap-2 px-4 py-3 text-sm font-medium transition-colors"
-            onClick={() => {
-              // TODO: reusar sessionService.createSession({ type: 'agent' })
-              //       cuando sustituyamos MOCK_AGENTS por sessions reales.
-              // eslint-disable-next-line no-alert
-              alert(
-                'Crear agente: aún no cableado. Se conectará con sessionService.createSession cuando sustituyamos MOCK_AGENTS por sessions reales.',
-              );
-            }}
-            style={{ color: '#6B4EFF', backgroundColor: 'transparent' }}
+            href="/chat"
+            style={{ color: '#6B4EFF' }}
             onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#F2F1F6')}
             onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
-            type="button"
           >
             <svg
               fill="none"
@@ -346,252 +368,240 @@ export default function AgentesPage() {
             >
               <path d="M12 5v14M5 12h14" />
             </svg>
-            Crear agente
-          </button>
+            Crear agente en Copilot
+          </a>
         </div>
       </aside>
 
       {/* Ficha del agente flex-1 */}
-      <section className="flex flex-1 flex-col overflow-auto">
-        {/* Cabecera ficha */}
-        <div
-          className="sticky top-0 z-10 px-6 py-4"
-          style={{ backgroundColor: '#FFFFFF', borderBottom: '1px solid #EDEDF0' }}
-        >
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <div
-                className="flex h-11 w-11 items-center justify-center rounded-full text-lg font-semibold"
-                style={{
-                  backgroundColor: selected.disabled ? '#F2F1F6' : '#EDE9FE',
-                  color: selected.disabled ? '#84848F' : '#6B4EFF',
-                }}
-              >
-                {selected.avatar}
+      {selected && (
+        <section className="flex flex-1 flex-col overflow-auto">
+          {/* Cabecera ficha */}
+          <div
+            className="sticky top-0 z-10 px-6 py-4"
+            style={{ backgroundColor: '#FFFFFF', borderBottom: '1px solid #EDEDF0' }}
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div
+                  className="flex h-11 w-11 items-center justify-center overflow-hidden rounded-full text-lg font-semibold"
+                  style={{
+                    backgroundColor: selectedDisabled ? '#F2F1F6' : '#EDE9FE',
+                    color: selectedDisabled ? '#84848F' : '#6B4EFF',
+                  }}
+                >
+                  {(() => {
+                    const av = selected.meta.avatar || agentInitial(selected.meta.title);
+                    return av.startsWith('http') || av.startsWith('data:') ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img alt="" className="h-full w-full object-cover" src={av} />
+                    ) : (
+                      av
+                    );
+                  })()}
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-semibold" style={{ color: '#1C1C22' }}>
+                      {selected.meta.title ?? 'Sin nombre'}
+                    </h2>
+                    <span
+                      className="rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                      style={{
+                        backgroundColor: selectedDisabled ? '#F2F1F6' : '#DCFCE7',
+                        color: selectedDisabled ? '#84848F' : '#166534',
+                      }}
+                    >
+                      {selectedDisabled ? 'Pausado' : 'Activo'}
+                    </span>
+                  </div>
+                  {selected.meta.description && (
+                    <p className="mt-0.5 text-xs" style={{ color: '#84848F' }}>
+                      {selected.meta.description}
+                    </p>
+                  )}
+                </div>
               </div>
-              <div>
-                <div className="flex items-center gap-2">
-                  <h2 className="text-lg font-semibold" style={{ color: '#1C1C22' }}>
-                    {selected.name}
-                  </h2>
+              <button
+                aria-pressed={!selectedDisabled}
+                className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+                onClick={() => toggleAgentDisabled(selected.id)}
+                style={{
+                  backgroundColor: selectedDisabled ? '#F2F1F6' : '#1C1C22',
+                  color: selectedDisabled ? '#1C1C22' : '#FFFFFF',
+                }}
+                type="button"
+              >
+                {selectedDisabled ? 'Reanudar' : 'Pausar'}
+              </button>
+            </div>
+          </div>
+
+          {/* Contenido ficha */}
+          <div className="flex-1 overflow-auto px-6 py-6">
+            <div className="mx-auto max-w-3xl space-y-6">
+              {/* Rendimiento hoy — mock hasta backend */}
+              <div
+                className="rounded-lg p-4"
+                style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                    Rendimiento hoy
+                  </h3>
                   <span
-                    className="rounded-full px-2 py-0.5 text-[10px] font-semibold"
-                    style={{
-                      backgroundColor: selected.disabled ? '#F2F1F6' : '#DCFCE7',
-                      color: selected.disabled ? '#84848F' : '#166534',
-                    }}
+                    className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                    style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                    title="Datos mock — backend pendiente"
                   >
-                    {selected.disabled ? 'Pausado' : 'Activo'}
+                    PRÓXIMAMENTE
                   </span>
                 </div>
-                <p className="mt-0.5 text-xs" style={{ color: '#84848F' }}>
-                  {selected.description}
+                <div className="grid grid-cols-3 gap-4">
+                  <MetricCard label="Respuestas" value="—" />
+                  <MetricCard label="Resueltas sola" value="—" />
+                  <MetricCard label="Tiempo medio" value="—" />
+                </div>
+                <p className="mt-3 text-[11px]" style={{ color: '#9A9AA6' }}>
+                  Las métricas se activarán cuando el backend exponga el endpoint
+                  de rendimiento por agente.
                 </p>
               </div>
-            </div>
-            {/* Toggle Encendido/Apagado */}
-            <button
-              aria-pressed={!selected.disabled}
-              className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
-              onClick={() => toggleAgentDisabled(selected.agentId)}
-              style={{
-                backgroundColor: selected.disabled ? '#F2F1F6' : '#1C1C22',
-                color: selected.disabled ? '#1C1C22' : '#FFFFFF',
-              }}
-              type="button"
-            >
-              {selected.disabled ? 'Reanudar' : 'Pausar'}
-            </button>
-          </div>
-        </div>
 
-        {/* Contenido ficha */}
-        <div className="flex-1 overflow-auto px-6 py-6">
-          <div className="mx-auto max-w-3xl space-y-6">
-            {/* Rendimiento hoy */}
-            <div
-              className="rounded-lg p-4"
-              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
-            >
-              <div className="mb-3 flex items-center justify-between">
-                <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
-                  Rendimiento hoy
-                </h3>
-                <span
-                  className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
-                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
-                  title="Datos mock — backend pendiente"
-                >
-                  DEMO
-                </span>
-              </div>
-              <div className="grid grid-cols-3 gap-4">
-                <MetricCard
-                  label="Respuestas"
-                  value={selected.metrics.replies_count.toString()}
-                />
-                <MetricCard
-                  label="Resueltas sola"
-                  value={`${selected.metrics.resolved_percent}%`}
-                />
-                <MetricCard
-                  label="Tiempo medio"
-                  value={`${selected.metrics.avg_response_seconds}s`}
-                />
-              </div>
-            </div>
-
-            {/* Canales asignados */}
-            <div
-              className="rounded-lg p-4"
-              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
-            >
-              <div className="mb-3 flex items-center justify-between">
-                <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
-                  Canales asignados
-                </h3>
-                <span
-                  className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
-                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
-                  title="Persistencia local hasta que backend confirme shape"
-                >
-                  BETA
-                </span>
-              </div>
-              <p className="mb-3 text-xs" style={{ color: '#84848F' }}>
-                Cuando llegue un mensaje por uno de estos canales, este agente lo atenderá según su
-                configuración.
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {Object.keys(CHANNEL_LABEL).map((ch) => {
-                  const isActive = selected.channels.includes(ch);
-                  return (
-                    <button
-                      key={ch}
-                      aria-pressed={isActive}
-                      className="flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
-                      onClick={() => toggleChannelAssignment(selected.agentId, ch)}
-                      style={{
-                        backgroundColor: isActive ? '#EDE9FE' : '#FFFFFF',
-                        border: `1px solid ${isActive ? '#EDE9FE' : '#EDEDF0'}`,
-                        color: isActive ? '#6B4EFF' : '#84848F',
-                      }}
-                      type="button"
-                    >
-                      <span
-                        className="h-2 w-2 rounded-full"
-                        style={{ backgroundColor: CHANNEL_DOT[ch] ?? '#84848F' }}
-                      />
-                      {CHANNEL_LABEL[ch]}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Instrucciones del agente (prompt editable) */}
-            <div
-              className="rounded-lg p-4"
-              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
-            >
-              <h3 className="mb-2 text-sm font-semibold" style={{ color: '#1C1C22' }}>
-                Instrucciones del agente
-              </h3>
-              <p className="mb-3 text-xs" style={{ color: '#84848F' }}>
-                Estas son las reglas que sigue el agente al responder. Cámbialas para ajustar tono,
-                límites y comportamiento.
-              </p>
-              <textarea
-                className="w-full rounded-md p-3 text-sm focus:outline-none"
-                onChange={(e) => updateSystemRole(selected.agentId, e.target.value)}
-                rows={6}
-                style={{
-                  backgroundColor: '#F2F1F6',
-                  border: '1px solid transparent',
-                  color: '#1C1C22',
-                  resize: 'vertical',
-                }}
-                onFocus={(e) => {
-                  e.currentTarget.style.backgroundColor = '#FFFFFF';
-                  e.currentTarget.style.borderColor = '#6B4EFF';
-                }}
-                onBlur={(e) => {
-                  e.currentTarget.style.backgroundColor = '#F2F1F6';
-                  e.currentTarget.style.borderColor = 'transparent';
-                }}
-                value={selected.systemRole}
-              />
-            </div>
-
-            {/* Actividad reciente */}
-            <div
-              className="rounded-lg p-4"
-              style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
-            >
-              <div className="mb-3 flex items-center justify-between">
-                <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
-                  Actividad reciente
-                </h3>
-                <span
-                  className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
-                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
-                  title="Datos mock — evento handoff pendiente en SSE"
-                >
-                  DEMO
-                </span>
-              </div>
-              {selected.activity.length === 0 ? (
-                <p className="text-xs" style={{ color: '#9A9AA6' }}>
-                  Sin actividad reciente. Cuando el agente responda o se produzca un handoff aparecerá
-                  aquí.
+              {/* Canales asignados — beta local */}
+              <div
+                className="rounded-lg p-4"
+                style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                    Canales asignados
+                  </h3>
+                  <span
+                    className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                    style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                    title="Persistencia local hasta que backend confirme shape"
+                  >
+                    BETA
+                  </span>
+                </div>
+                <p className="mb-3 text-xs" style={{ color: '#84848F' }}>
+                  Cuando llegue un mensaje por uno de estos canales, este agente lo atenderá según su
+                  configuración.
                 </p>
-              ) : (
-                <ul className="space-y-2">
-                  {selected.activity.map((a) => (
-                    <li key={a.id} className="flex items-start gap-3">
-                      <span
-                        className="mt-1 h-2 w-2 shrink-0 rounded-full"
+                <div className="flex flex-wrap gap-2">
+                  {Object.keys(CHANNEL_LABEL).map((ch) => {
+                    const isActive = selectedChannels.includes(ch);
+                    return (
+                      <button
+                        key={ch}
+                        aria-pressed={isActive}
+                        className="flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+                        onClick={() => toggleChannelAssignment(selected.id, ch)}
                         style={{
-                          backgroundColor:
-                            a.type === 'handoff'
-                              ? '#F59E0B'
-                              : a.type === 'config_change'
-                                ? '#84848F'
-                                : '#6B4EFF',
+                          backgroundColor: isActive ? '#EDE9FE' : '#FFFFFF',
+                          border: `1px solid ${isActive ? '#EDE9FE' : '#EDEDF0'}`,
+                          color: isActive ? '#6B4EFF' : '#84848F',
                         }}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <p className="text-xs" style={{ color: '#1C1C22' }}>
-                          {a.description}
-                        </p>
-                        <p className="mt-0.5 text-[11px]" style={{ color: '#9A9AA6' }}>
-                          hace {a.timestamp}
-                        </p>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+                        type="button"
+                      >
+                        <span
+                          className="h-2 w-2 rounded-full"
+                          style={{ backgroundColor: CHANNEL_DOT[ch] ?? '#84848F' }}
+                        />
+                        {CHANNEL_LABEL[ch]}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
 
-            {/* Nota mocks */}
-            <p className="text-center text-[11px] italic" style={{ color: '#9A9AA6' }}>
-              Los datos marcados DEMO son mocks. Se cablearán cuando backend confirme shapes
-              (endpoint métricas + asignación canales + evento handoff, Slack ts 1784383734).
-            </p>
+              {/* Instrucciones del agente — cableado a updateAgentConfig */}
+              <div
+                className="rounded-lg p-4"
+                style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+              >
+                <div className="mb-2 flex items-center justify-between">
+                  <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                    Instrucciones del agente
+                  </h3>
+                  <span
+                    className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                    style={{ backgroundColor: '#DCFCE7', color: '#166534' }}
+                    title="Se guarda en el backend"
+                  >
+                    GUARDADO EN LA NUBE
+                  </span>
+                </div>
+                <p className="mb-3 text-xs" style={{ color: '#84848F' }}>
+                  Estas son las reglas que sigue el agente al responder. Los cambios se guardan
+                  automáticamente y persisten entre dispositivos.
+                </p>
+                <textarea
+                  className="w-full rounded-md p-3 text-sm focus:outline-none"
+                  onChange={(e) => setPromptDraft(e.target.value)}
+                  rows={8}
+                  style={{
+                    backgroundColor: '#F2F1F6',
+                    border: '1px solid transparent',
+                    color: '#1C1C22',
+                    resize: 'vertical',
+                  }}
+                  onFocus={(e) => {
+                    e.currentTarget.style.backgroundColor = '#FFFFFF';
+                    e.currentTarget.style.borderColor = '#6B4EFF';
+                  }}
+                  onBlur={(e) => {
+                    e.currentTarget.style.backgroundColor = '#F2F1F6';
+                    e.currentTarget.style.borderColor = 'transparent';
+                  }}
+                  value={promptDraft}
+                />
+              </div>
+
+              {/* Actividad reciente — mock hasta SSE handoff */}
+              <div
+                className="rounded-lg p-4"
+                style={{ border: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <h3 className="text-sm font-semibold" style={{ color: '#1C1C22' }}>
+                    Actividad reciente
+                  </h3>
+                  <span
+                    className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                    style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                    title="Feed de actividad pendiente en SSE"
+                  >
+                    PRÓXIMAMENTE
+                  </span>
+                </div>
+                <p className="text-xs" style={{ color: '#9A9AA6' }}>
+                  Cuando el agente responda o se produzca un handoff aparecerá aquí. Feed en tiempo
+                  real por SSE (pendiente backend).
+                </p>
+              </div>
+
+              {/* Nota al pie */}
+              <p className="text-center text-[11px] italic" style={{ color: '#9A9AA6' }}>
+                Instrucciones y datos del agente ({selected.meta.title ?? 'agente'}) guardados en la
+                nube. Rendimiento, asignación de canales y feed en tiempo real se activarán cuando
+                backend confirme shapes (Slack ts 1784383734).
+              </p>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
     </div>
   );
 }
 
+// Silenciar warning TS por reservar el type (útil para futuros expandir)
+export type _AgentActivity = AgentActivity;
+
 function MetricCard({ label, value }: { label: string; value: string }) {
   return (
-    <div
-      className="rounded-md px-3 py-2"
-      style={{ backgroundColor: '#F2F1F6' }}
-    >
+    <div className="rounded-md px-3 py-2" style={{ backgroundColor: '#F2F1F6' }}>
       <div className="text-xs" style={{ color: '#84848F' }}>
         {label}
       </div>

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/[channel]/[conversation_id]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/[channel]/[conversation_id]/page.tsx
@@ -45,11 +45,14 @@ export default function ConversationPage({ params }: ConversationPageProps) {
 
   return (
     <>
-      <div className="hidden w-[420px] shrink-0 overflow-auto border-r border-gray-200 bg-white md:block">
+      <div
+        className="hidden w-[300px] shrink-0 overflow-auto md:block"
+        style={{ borderRight: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+      >
         <ConversationList channel={channel} selectedId={conversation_id} />
       </div>
 
-      <div className="flex flex-1 flex-col bg-gray-50">
+      <div className="flex flex-1 flex-col" style={{ backgroundColor: '#FCFCFD' }}>
         <div className="md:hidden flex items-center gap-2 border-b border-gray-200 bg-white px-2 py-1">
           <button
             aria-label="Volver"

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/[channel]/[conversation_id]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/[channel]/[conversation_id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useState } from 'react';
+import { use, useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ConversationList } from '../../components/ConversationList';
 import { MessageList } from '../../components/MessageList';
@@ -25,12 +25,43 @@ function parseTaskChannel(channel: string): string | null {
   return m ? m[1] : null;
 }
 
+const SIDEBAR_EXPANDED_KEY = 'messages_sidebar_expanded_default';
+
 export default function ConversationPage({ params }: ConversationPageProps) {
   const { channel, conversation_id } = use(params);
   const router = useRouter();
   const [searchFilter, setSearchFilter] = useState('');
   // Móvil: bottom sheet con sidebar info contacto (Diseño 24-jun móvil)
   const [infoSheetOpen, setInfoSheetOpen] = useState(false);
+
+  // Rediseño A.4 (18-jul): panel derecho (EventSidebar / ConversationNotesSidebar)
+  // pasa de fijo 280px a desplegable con toggle "Detalles" en el header.
+  // Estado inicial COLAPSADO — persistido en localStorage. Hidratación via
+  // useEffect post-mount para no romper SSR (BUG-04 QA #13).
+  const [sidebarExpanded, setSidebarExpanded] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      if (localStorage.getItem(SIDEBAR_EXPANDED_KEY) === '1') {
+        setSidebarExpanded(true);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  const toggleSidebar = useCallback(() => {
+    setSidebarExpanded((prev) => {
+      const next = !prev;
+      try {
+        if (typeof window !== 'undefined') {
+          localStorage.setItem(SIDEBAR_EXPANDED_KEY, next ? '1' : '0');
+        }
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
 
   // Datos extra de la conversación para el sidebar de notas (linked_contact_id,
   // linked_event_id, nombre del contacto). useConversations ya carga la lista.
@@ -85,6 +116,8 @@ export default function ConversationPage({ params }: ConversationPageProps) {
             channel={channel}
             conversationId={conversation_id}
             onSearchFilter={setSearchFilter}
+            detailsOpen={sidebarExpanded}
+            onToggleDetails={toggleSidebar}
           />
         </div>
 
@@ -97,36 +130,38 @@ export default function ConversationPage({ params }: ConversationPageProps) {
         </div>
       </div>
 
-      {/* Sidebar derecho 280px — FASE B v2.0 handoff Bandeja Diseño 24-jun.
-          P9: render condicional según contexto:
-            · linkedEventId presente → EventSidebar (RSVP + asignación + datos + notas)
-            · linkedEventId vacío    → ConversationNotesSidebar (modo Soporte: solo notas)
-          Solo desktop ≥1024px. */}
-      <aside className="hidden w-[280px] shrink-0 overflow-hidden border-l border-gray-200 bg-white lg:flex lg:flex-col">
-        {conv?.linkedEventId ? (
-          <EventSidebar
-            conversationId={conversation_id}
-            contactName={conv.contact?.name}
-            contactPhone={conv.contact?.phone}
-            linkedContactId={conv.linkedContactId}
-            linkedEventId={conv.linkedEventId}
-            channel={conv.channel ?? channel}
-            // FASE B v2.0 — api-mcp commit 7d52fec (25-jun) expone guestStatus
-            // resolviendo invitado por teléfono internamente.
-            rsvpStatus={conv.guestStatus ?? undefined}
-            // assignedTo: api-mcp confirma user-asignación ya disponible
-            // (team requiere entidad Teams, sprint aparte). Cableo en próximo commit.
-          />
-        ) : (
-          <ConversationNotesSidebar
-            conversationId={conversation_id}
-            contactName={conv?.contact?.name}
-            linkedContactId={conv?.linkedContactId}
-            linkedEventId={conv?.linkedEventId}
-            channel={conv?.channel ?? channel}
-          />
-        )}
-      </aside>
+      {/* Sidebar derecho DESPLEGABLE 280px — Rediseño A.4 (18-jul).
+          Antes era fijo siempre visible ≥1024. Ahora se controla con toggle
+          "Detalles" en el header. Estado persistido en localStorage.
+          Render condicional (preservado):
+            · linkedEventId presente → EventSidebar (RSVP + asignación + notas)
+            · linkedEventId vacío    → ConversationNotesSidebar (modo Soporte) */}
+      {sidebarExpanded && (
+        <aside
+          className="hidden w-[280px] shrink-0 overflow-hidden lg:flex lg:flex-col"
+          style={{ borderLeft: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+        >
+          {conv?.linkedEventId ? (
+            <EventSidebar
+              conversationId={conversation_id}
+              contactName={conv.contact?.name}
+              contactPhone={conv.contact?.phone}
+              linkedContactId={conv.linkedContactId}
+              linkedEventId={conv.linkedEventId}
+              channel={conv.channel ?? channel}
+              rsvpStatus={conv.guestStatus ?? undefined}
+            />
+          ) : (
+            <ConversationNotesSidebar
+              conversationId={conversation_id}
+              contactName={conv?.contact?.name}
+              linkedContactId={conv?.linkedContactId}
+              linkedEventId={conv?.linkedEventId}
+              channel={conv?.channel ?? channel}
+            />
+          )}
+        </aside>
+      )}
 
       {/* Bottom sheet móvil 75% con sidebar info contacto.
           El sidebar derecho lateral NO existe en móvil (Diseño 24-jun). */}

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/[channel]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/[channel]/page.tsx
@@ -168,7 +168,10 @@ export default function ChannelPage({ params }: ChannelPageProps) {
 
       {/* Desktop: lista de conversaciones del canal + empty right */}
       <div className="hidden flex-1 overflow-hidden md:flex">
-        <div className="w-[420px] shrink-0 overflow-auto border-r border-gray-200 bg-white">
+        <div
+          className="w-[300px] shrink-0 overflow-auto"
+          style={{ borderRight: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+        >
           <ConversationList channel={channel} />
         </div>
         <div className="flex flex-1 items-center justify-center bg-gray-50">

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationHeader.meta.test.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationHeader.meta.test.tsx
@@ -45,7 +45,14 @@ describe('ConversationHeader meta', () => {
 
     render(<ConversationHeader channel="web" conversationId="c1" />);
 
-    expect(screen.getByText('Abierta', { selector: 'span' })).toBeInTheDocument();
+    // Rediseño A.3 (18-jul): el badge de estado dejó de ser <span> y pasó a
+    // <select> nativo con opciones. Se comprueba el select con value inicial "open".
+    const statusSelect = screen.getByRole('combobox', {
+      name: 'Cambiar estado de la conversación',
+    }) as HTMLSelectElement;
+    expect(statusSelect.value).toBe('open');
+    expect(screen.getByText('Abierta', { selector: 'option' })).toBeInTheDocument();
+
     const assignBtn = screen.getByRole('button', { name: 'Sin asignar' });
     fireEvent.click(assignBtn);
 

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationHeader.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationHeader.tsx
@@ -194,30 +194,36 @@ export function ConversationHeader({ channel, conversationId, onSearchFilter }: 
   const isOnline = minutesAgo < 5;
 
   return (
-    <div className="border-b border-gray-200 bg-white">
-      <div className="flex items-center justify-between p-4">
+    <div style={{ backgroundColor: '#FFFFFF', borderBottom: '1px solid #EDEDF0' }}>
+      <div className="flex items-center justify-between gap-3 px-4 py-3">
         {/* Left: Contact Info */}
-        <div className="flex items-center gap-3">
-          {/* Avatar with presence */}
-          <div className="relative">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 text-lg font-semibold text-white">
+        <div className="flex min-w-0 items-center gap-3">
+          {/* Avatar 40x40 con presence + punto canal */}
+          <div className="relative flex-shrink-0">
+            <div
+              className="flex h-10 w-10 items-center justify-center rounded-full text-base font-semibold"
+              style={{ backgroundColor: '#F2F1F6', color: '#1C1C22' }}
+            >
               {conversation.contact.name.charAt(0).toUpperCase()}
             </div>
-            <span
-              aria-label={isOnline ? 'En línea' : 'Desconectado'}
-              className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-white ${
-                isOnline ? 'bg-green-500' : 'bg-gray-300'
-              }`}
-            />
+            {isOnline && (
+              <span
+                aria-label="En línea"
+                className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: '#22C55E', boxShadow: '0 0 0 2px #FFFFFF' }}
+              />
+            )}
           </div>
 
-          {/* Info */}
-          <div>
+          {/* Info: nombre + ChannelBadge (preservado) + IaLevelPicker (preservado) */}
+          <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h2 className="font-semibold text-gray-900">
+              <h2 className="truncate text-sm font-semibold" style={{ color: '#1C1C22' }}>
                 {conversation.contact.name}
               </h2>
               <ChannelBadge channel={conversation.channel} size="sm" />
+              {/* IaLevelPicker PRESERVADO 3-niveles — solo se rediseña visualmente
+                  desde su propio componente en un bloque posterior si se decide. */}
               <IaLevelPicker
                 level={iaLevel}
                 onChange={(next) => {
@@ -227,52 +233,53 @@ export function ConversationHeader({ channel, conversationId, onSearchFilter }: 
                 }}
               />
             </div>
-            <p className="text-xs text-gray-500">
-              {isOnline ? (
-                <span className="text-green-600 font-medium">En línea</span>
-              ) : (
-                conversation.contact.phone || conversation.contact.username || 'Sin info de contacto'
-              )}
+            <p className="mt-0.5 truncate text-xs" style={{ color: '#84848F' }}>
+              {isOnline
+                ? 'En línea'
+                : conversation.contact.phone ||
+                  conversation.contact.username ||
+                  'Sin info de contacto'}
             </p>
           </div>
         </div>
 
         {/* Right: Actions */}
-        <div className="flex items-center gap-2">
-          <div className="hidden items-center gap-2 md:flex">
-            <div className="flex items-center gap-1">
-              <span
-                className={
-                  status === 'open'
-                    ? 'rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700'
-                    : status === 'pending'
-                      ? 'rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700'
-                      : 'rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600'
-                }
-              >
-                {status === 'open' ? 'Abierta' : status === 'pending' ? 'En espera' : 'Cerrada'}
-              </span>
-              <select
-                aria-label="Cambiar estado"
-                className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:border-gray-300"
-                onChange={(e) => setStatus(e.target.value as ConversationStatus)}
-                value={status}
-              >
-                <option value="open">Abierta</option>
-                <option value="pending">En espera</option>
-                <option value="closed">Cerrada</option>
-              </select>
-            </div>
+        <div className="flex flex-shrink-0 items-center gap-1.5">
+          <div className="hidden items-center gap-1.5 md:flex">
+            {/* Selector estado — solo select, sin duplicar pill (la señal cromática
+                queda en el select mismo). */}
+            <select
+              aria-label="Cambiar estado de la conversación"
+              className="rounded-md px-2 py-1 text-xs focus:outline-none"
+              onChange={(e) => setStatus(e.target.value as ConversationStatus)}
+              style={{
+                backgroundColor:
+                  status === 'open' ? '#FFFFFF' : status === 'pending' ? '#FEF3C7' : '#F2F1F6',
+                border: `1px solid ${
+                  status === 'open' ? '#EDEDF0' : status === 'pending' ? '#FCD34D' : '#EDEDF0'
+                }`,
+                color:
+                  status === 'open' ? '#1C1C22' : status === 'pending' ? '#92400E' : '#84848F',
+              }}
+              value={status}
+            >
+              <option value="open">Abierta</option>
+              <option value="pending">En espera</option>
+              <option value="closed">Cerrada</option>
+            </select>
 
+            {/* Asignación */}
             <button
-              className={
-                assignedToMe
-                  ? 'rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100'
-                  : 'rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-600 hover:border-gray-300 hover:bg-gray-50'
-              }
+              className="rounded-md px-2 py-1 text-xs transition-colors"
               onClick={() => {
                 if (!userId) return;
                 assignToUser(assignedToMe ? null : userId);
+              }}
+              style={{
+                backgroundColor: assignedToMe ? '#EDE9FE' : '#FFFFFF',
+                border: `1px solid ${assignedToMe ? '#EDE9FE' : '#EDEDF0'}`,
+                color: assignedToMe ? '#6B4EFF' : '#84848F',
+                fontWeight: assignedToMe ? 500 : 400,
               }}
               type="button"
             >
@@ -280,61 +287,136 @@ export function ConversationHeader({ channel, conversationId, onSearchFilter }: 
             </button>
           </div>
 
+          {/* Botón búsqueda con Lucide SVG (antes emoji 🔍) */}
           <button
-            className={`flex h-9 w-9 items-center justify-center rounded-lg text-lg transition-colors ${
-              searchOpen ? 'bg-blue-100 text-blue-600' : 'text-gray-500 hover:bg-gray-100'
-            }`}
-            onClick={() => searchOpen ? closeSearch() : setSearchOpen(true)}
-            title="Buscar en conversación"
+            aria-label="Buscar en conversación"
+            className="flex h-8 w-8 items-center justify-center rounded-md transition-colors"
+            onClick={() => (searchOpen ? closeSearch() : setSearchOpen(true))}
+            style={{
+              backgroundColor: searchOpen ? '#EDE9FE' : 'transparent',
+              color: searchOpen ? '#6B4EFF' : '#84848F',
+            }}
+            onMouseEnter={(e) => {
+              if (!searchOpen) e.currentTarget.style.backgroundColor = '#F2F1F6';
+            }}
+            onMouseLeave={(e) => {
+              if (!searchOpen) e.currentTarget.style.backgroundColor = 'transparent';
+            }}
+            title="Buscar en conversación (⌘K)"
             type="button"
           >
-            🔍
+            <svg
+              fill="none"
+              height="16"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.8"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+            </svg>
           </button>
+          {/* Botón llamar disabled — Lucide phone SVG (antes emoji 📞) */}
           <button
-            className="flex h-9 w-9 items-center justify-center rounded-lg text-lg text-gray-300 cursor-not-allowed"
+            aria-label="Llamar (próximamente)"
+            className="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-md"
             disabled
+            style={{ color: '#D4D4D8' }}
             title="Llamar (próximamente)"
             type="button"
           >
-            📞
+            <svg
+              fill="none"
+              height="16"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.8"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+            </svg>
           </button>
 
-          {/* More options menu */}
+          {/* Menú más opciones — Lucide MoreVertical (antes ⋮) */}
           <div className="relative" ref={menuRef}>
             <button
               aria-expanded={menuOpen}
-              className={`flex h-9 w-9 items-center justify-center rounded-lg text-lg transition-colors ${
-                menuOpen ? 'bg-gray-100 text-gray-900' : 'text-gray-500 hover:bg-gray-100'
-              }`}
+              aria-label="Más opciones"
+              className="flex h-8 w-8 items-center justify-center rounded-md transition-colors"
               onClick={() => setMenuOpen(!menuOpen)}
+              style={{
+                backgroundColor: menuOpen ? '#F2F1F6' : 'transparent',
+                color: menuOpen ? '#1C1C22' : '#84848F',
+              }}
+              onMouseEnter={(e) => {
+                if (!menuOpen) e.currentTarget.style.backgroundColor = '#F2F1F6';
+              }}
+              onMouseLeave={(e) => {
+                if (!menuOpen) e.currentTarget.style.backgroundColor = 'transparent';
+              }}
               title="Más opciones"
               type="button"
             >
-              ⋮
+              <svg
+                fill="none"
+                height="16"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+                viewBox="0 0 24 24"
+                width="16"
+              >
+                <circle cx="12" cy="12" r="1" />
+                <circle cx="12" cy="5" r="1" />
+                <circle cx="12" cy="19" r="1" />
+              </svg>
             </button>
             {menuOpen && (
-              <div className="absolute right-0 top-full z-10 mt-1 w-48 rounded-lg border border-gray-200 bg-white py-1 shadow-lg" role="menu">
+              <div
+                className="absolute right-0 top-full z-10 mt-1 w-56 overflow-hidden rounded-lg py-1"
+                role="menu"
+                style={{
+                  backgroundColor: '#FFFFFF',
+                  border: '1px solid #EDEDF0',
+                  boxShadow: '0 4px 12px rgba(28,28,34,0.08)',
+                }}
+              >
                 <button
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors"
                   onClick={() => handleMenuAction('archive')}
+                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#F2F1F6')}
+                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+                  style={{ color: '#1C1C22' }}
                   type="button"
                 >
-                  📦 Archivar conversación
+                  Archivar conversación
                 </button>
                 <button
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors"
                   onClick={() => handleMenuAction('mute')}
+                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#F2F1F6')}
+                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+                  style={{ color: '#1C1C22' }}
                   type="button"
                 >
-                  {conversationMuted ? '🔔 Activar sonido' : '🔇 Silenciar'}
+                  {conversationMuted ? 'Activar sonido' : 'Silenciar'}
                 </button>
-                <div className="my-1 h-px bg-gray-100" />
+                <div style={{ borderTop: '1px solid #EDEDF0', margin: '4px 0' }} />
                 <button
-                  className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors"
                   onClick={() => handleMenuAction('clear')}
+                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#FEF2F2')}
+                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+                  style={{ color: '#DC2626' }}
                   type="button"
                 >
-                  🗑️ Limpiar chat
+                  Limpiar chat
                 </button>
               </div>
             )}
@@ -342,25 +424,43 @@ export function ConversationHeader({ channel, conversationId, onSearchFilter }: 
         </div>
       </div>
 
-      {/* Inline search bar */}
+      {/* Inline search bar rediseñada con tokens del sistema */}
       {searchOpen && (
-        <div className="flex items-center gap-2 border-t border-gray-100 px-4 py-2">
-          <span className="text-gray-400 text-sm">🔍</span>
+        <div
+          className="flex items-center gap-2 px-4 py-2"
+          style={{ borderTop: '1px solid #EDEDF0' }}
+        >
+          <svg
+            aria-hidden
+            fill="none"
+            height="14"
+            stroke="#9A9AA6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+            viewBox="0 0 24 24"
+            width="14"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
           <input
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-gray-400"
+            className="flex-1 bg-transparent text-sm outline-none"
             onChange={(e) => handleSearchChange(e.target.value)}
             placeholder="Buscar mensajes..."
             ref={searchInputRef}
+            style={{ color: '#1C1C22' }}
             type="text"
             value={searchTerm}
           />
           {searchTerm && (
             <button
-              className="text-xs text-gray-400 hover:text-gray-600"
+              className="text-xs transition-colors"
               onClick={closeSearch}
+              style={{ color: '#84848F' }}
               type="button"
             >
-              ✕
+              Cerrar
             </button>
           )}
         </div>

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationHeader.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationHeader.tsx
@@ -12,9 +12,18 @@ interface ConversationHeaderProps {
   channel?: string;
   conversationId: string;
   onSearchFilter?: (term: string) => void;
+  /** Rediseño A.4 (18-jul): controla el sidebar desplegable de detalles. */
+  detailsOpen?: boolean;
+  onToggleDetails?: () => void;
 }
 
-export function ConversationHeader({ channel, conversationId, onSearchFilter }: ConversationHeaderProps) {
+export function ConversationHeader({
+  channel,
+  conversationId,
+  onSearchFilter,
+  detailsOpen,
+  onToggleDetails,
+}: ConversationHeaderProps) {
   const { conversations, loading: convListLoading } = useConversations(channel ?? null);
   const conversation = conversations.find((c) => c.id === conversationId);
 
@@ -342,6 +351,42 @@ export function ConversationHeader({ channel, conversationId, onSearchFilter }: 
             </svg>
           </button>
 
+          {/* Toggle "Detalles" — abre/cierra el sidebar derecho (A.4) */}
+          {onToggleDetails && (
+            <button
+              aria-label={detailsOpen ? 'Ocultar detalles' : 'Mostrar detalles'}
+              aria-pressed={!!detailsOpen}
+              className="flex h-8 w-8 items-center justify-center rounded-md transition-colors"
+              onClick={onToggleDetails}
+              style={{
+                backgroundColor: detailsOpen ? '#EDE9FE' : 'transparent',
+                color: detailsOpen ? '#6B4EFF' : '#84848F',
+              }}
+              onMouseEnter={(e) => {
+                if (!detailsOpen) e.currentTarget.style.backgroundColor = '#F2F1F6';
+              }}
+              onMouseLeave={(e) => {
+                if (!detailsOpen) e.currentTarget.style.backgroundColor = 'transparent';
+              }}
+              title={detailsOpen ? 'Ocultar detalles del contacto' : 'Mostrar detalles del contacto'}
+              type="button"
+            >
+              {/* Lucide PanelRightOpen / PanelRightClose (stroke 1.8) */}
+              <svg
+                fill="none"
+                height="16"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+                viewBox="0 0 24 24"
+                width="16"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                <line x1="15" x2="15" y1="3" y2="21" />
+              </svg>
+            </button>
+          )}
           {/* Menú más opciones — Lucide MoreVertical (antes ⋮) */}
           <div className="relative" ref={menuRef}>
             <button

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationItem.meta.test.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationItem.meta.test.tsx
@@ -44,7 +44,9 @@ describe('ConversationItem meta', () => {
     );
 
     expect(screen.getByText('En espera')).toBeInTheDocument();
-    expect(screen.getByText('Asignada')).toBeInTheDocument();
+    // Rediseño 18-jul: la etiqueta "Asignada" se rebautizó como "Asignada a ti"
+    // (más claro para el usuario en la propia conversación).
+    expect(screen.getByText('Asignada a ti')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button'));
   });

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationItem.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationItem.tsx
@@ -8,7 +8,6 @@ import { useTypingInConv } from '@/store/bandeja/selectors';
 import { Conversation } from '../hooks/useConversations';
 import { useConversationActions } from '../hooks/useConversationActions';
 import { ConversationStatus, useConversationMeta } from '../hooks/useConversationMeta';
-import { ChannelBadge } from './ChannelBadge';
 
 interface ConversationItemProps {
   conversation: Conversation;
@@ -32,16 +31,27 @@ const formatTimestamp = (timestamp: string) => {
 
 function TypingIndicator() {
   return (
-    <span className="inline-flex items-center gap-0.5 text-xs text-blue-600 italic">
+    <span className="inline-flex items-center gap-0.5 text-xs italic" style={{ color: '#6B4EFF' }}>
       <span>Escribiendo</span>
       <span className="flex gap-px">
-        <span className="h-1 w-1 animate-bounce rounded-full bg-blue-500" style={{ animationDelay: '0ms' }} />
-        <span className="h-1 w-1 animate-bounce rounded-full bg-blue-500" style={{ animationDelay: '150ms' }} />
-        <span className="h-1 w-1 animate-bounce rounded-full bg-blue-500" style={{ animationDelay: '300ms' }} />
+        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '0ms', backgroundColor: '#6B4EFF' }} />
+        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '150ms', backgroundColor: '#6B4EFF' }} />
+        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '300ms', backgroundColor: '#6B4EFF' }} />
       </span>
     </span>
   );
 }
+
+// Colores canal (rediseño 18-jul). Solo puntos indicadores, no fondos.
+const CHANNEL_DOT: Record<string, string> = {
+  whatsapp: '#25D366',
+  instagram: '#E1306C',
+  facebook: '#1877F2',
+  telegram: '#2AABEE',
+  web: '#6B4EFF',
+  email: '#84848F',
+  sms: '#84848F',
+};
 
 export function ConversationItem({
   conversation,
@@ -115,101 +125,154 @@ export function ConversationItem({
     }
   };
 
+  const channelDot = CHANNEL_DOT[conversation.channel] ?? '#84848F';
+  // Señal ✦: si esta conversación tiene IA activa (copilot o autopilot).
+  // Preservamos la señal cromática de los mensajes (teal/cyan/morado) — este ✦
+  // es solo un marcador de "hay IA operando aquí" en la lista. Cast defensivo:
+  // el hook useConversations no tipa `iaLevel`, pero el store bandeja sí lo
+  // propaga en algunos endpoints — si no viene, hasIa cae a false.
+  const iaLevel = (conversation as unknown as { iaLevel?: string }).iaLevel;
+  const hasIa = iaLevel === 'copilot' || iaLevel === 'autopilot';
+
   return (
     <>
       <button
-        className={`w-full text-left transition-colors ${
-          isSelected
-            ? 'bg-blue-50 border-l-4 border-blue-600'
-            : 'hover:bg-gray-50'
-        }`}
+        className="w-full text-left transition-colors"
         onClick={handleClick}
         onContextMenu={handleContextMenu}
+        style={{
+          backgroundColor: isSelected ? '#F2F1F6' : 'transparent',
+        }}
+        onMouseEnter={(e) => {
+          if (!isSelected) e.currentTarget.style.backgroundColor = '#FCFCFD';
+        }}
+        onMouseLeave={(e) => {
+          if (!isSelected) e.currentTarget.style.backgroundColor = 'transparent';
+        }}
         type="button"
       >
-        <div className="flex items-start gap-3 p-4">
-          {/* Avatar with presence indicator */}
+        <div className="flex items-start gap-3 px-3 py-3">
+          {/* Avatar 40x40 con punto de canal 12px bottom-right */}
           <div className="relative flex-shrink-0">
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 text-lg font-semibold text-white">
+            <div
+              className="flex h-10 w-10 items-center justify-center rounded-full text-base font-semibold"
+              style={{
+                backgroundColor: '#F2F1F6',
+                color: '#1C1C22',
+              }}
+            >
               {conversation.contact.name.charAt(0).toUpperCase()}
             </div>
-            {/* Unread badge */}
-            {conversation.unreadCount > 0 && (
-              <div className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-red-500 text-xs font-bold text-white">
-                {conversation.unreadCount}
-              </div>
-            )}
-            {/* Presence dot */}
+            {/* Punto de canal (rediseño 18-jul) */}
             <span
-              aria-label={isOnline ? 'En línea' : 'Desconectado'}
-              className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-white ${
-                isOnline ? 'bg-green-500' : 'bg-gray-300'
-              }`}
+              aria-label={`Canal ${conversation.channel}`}
+              className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full"
+              style={{
+                backgroundColor: channelDot,
+                boxShadow: '0 0 0 2px #FFFFFF',
+              }}
             />
+            {/* Presence dot: si hay presencia, encima del canal en top-right */}
+            {isOnline && (
+              <span
+                aria-label="En línea"
+                className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full"
+                style={{
+                  backgroundColor: '#22C55E',
+                  boxShadow: '0 0 0 2px #FFFFFF',
+                }}
+              />
+            )}
           </div>
 
           {/* Content */}
           <div className="min-w-0 flex-1">
-            {/* Header */}
-            <div className="mb-1 flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <h3
-                  className={`truncate text-sm font-semibold ${
-                    conversation.unreadCount > 0
-                      ? 'text-gray-900'
-                      : 'text-gray-700'
-                  }`}
-                >
-                  {conversation.contact.name}
-                </h3>
-                <ChannelBadge channel={conversation.channel} size="sm" />
-                <span
-                  className={
-                    status === 'open'
-                      ? 'rounded-full bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700'
-                      : status === 'pending'
-                        ? 'rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700'
-                        : 'rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600'
-                  }
-                >
-                  {status === 'open' ? 'Abierta' : status === 'pending' ? 'En espera' : 'Cerrada'}
-                </span>
-              </div>
-              <div className="flex flex-shrink-0 items-center gap-2">
-                {assignedToMe ? (
-                  <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-700">
-                    Asignada
-                  </span>
-                ) : null}
-                <span className="text-xs text-gray-500">
-                  {formatTimestamp(conversation.lastMessage.timestamp)}
-                </span>
-              </div>
+            {/* Header: nombre + hora */}
+            <div className="mb-0.5 flex items-baseline justify-between gap-2">
+              <h3
+                className="truncate text-sm font-semibold"
+                style={{
+                  color: conversation.unreadCount > 0 ? '#1C1C22' : '#1C1C22',
+                }}
+              >
+                {conversation.contact.name}
+              </h3>
+              <span className="flex-shrink-0 text-xs" style={{ color: '#9A9AA6' }}>
+                {formatTimestamp(conversation.lastMessage.timestamp)}
+              </span>
             </div>
 
-            {/* Last Message or Typing */}
-            {isTyping ? (
-              <TypingIndicator />
-            ) : (
-              <div className="flex items-center gap-2">
-                {!conversation.lastMessage.fromUser && (
-                  <span className="text-xs text-blue-600">Tú:</span>
+            {/* Preview mensaje / Typing + contador no leídos */}
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0 flex-1">
+                {isTyping ? (
+                  <TypingIndicator />
+                ) : (
+                  <p
+                    className="truncate text-sm"
+                    style={{
+                      color: conversation.unreadCount > 0 ? '#1C1C22' : '#84848F',
+                      fontWeight: conversation.unreadCount > 0 ? 500 : 400,
+                    }}
+                  >
+                    {hasIa && (
+                      <span
+                        aria-hidden
+                        style={{ color: '#6B4EFF', marginRight: 4 }}
+                      >
+                        ✦
+                      </span>
+                    )}
+                    {!conversation.lastMessage.fromUser && (
+                      <span style={{ color: '#9A9AA6' }}>Tú: </span>
+                    )}
+                    {conversation.lastMessage.text}
+                  </p>
                 )}
-                <p
-                  className={`truncate text-sm ${
-                    conversation.unreadCount > 0
-                      ? 'font-medium text-gray-900'
-                      : 'text-gray-600'
-                  }`}
-                >
-                  {conversation.lastMessage.text}
-                </p>
               </div>
-            )}
+              {/* Contador no leídos: pill morado #6B4EFF */}
+              {conversation.unreadCount > 0 && (
+                <span
+                  aria-label={`${conversation.unreadCount} sin leer`}
+                  className="flex-shrink-0 rounded-full px-2 py-0.5 text-[11px] font-bold text-white"
+                  style={{ backgroundColor: '#6B4EFF', minWidth: 20 }}
+                >
+                  {conversation.unreadCount}
+                </span>
+              )}
+            </div>
 
-            {/* Contact Info */}
-            <div className="mt-1 text-xs text-gray-500">
-              {conversation.contact.phone || conversation.contact.username || ''}
+            {/* Fila 3: chips secundarios (status + asignada + phone) */}
+            <div className="mt-1 flex items-center gap-1.5 text-[11px]" style={{ color: '#9A9AA6' }}>
+              {status === 'pending' && (
+                <span
+                  className="rounded-full px-1.5 py-0.5 font-medium"
+                  style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
+                >
+                  En espera
+                </span>
+              )}
+              {status === 'closed' && (
+                <span
+                  className="rounded-full px-1.5 py-0.5 font-medium"
+                  style={{ backgroundColor: '#F2F1F6', color: '#84848F' }}
+                >
+                  Cerrada
+                </span>
+              )}
+              {assignedToMe && (
+                <span
+                  className="rounded-full px-1.5 py-0.5 font-medium"
+                  style={{ backgroundColor: '#EDE9FE', color: '#6B4EFF' }}
+                >
+                  Asignada a ti
+                </span>
+              )}
+              {(conversation.contact.phone || conversation.contact.username) && (
+                <span className="truncate">
+                  {conversation.contact.phone || conversation.contact.username}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationList.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/ConversationList.tsx
@@ -112,12 +112,33 @@ function ConversationListInner({ channel, selectedId }: ConversationListProps) {
   );
 
   if (loading) {
+    // Rediseño A.2: skeleton simple 3 filas con tokens del sistema
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <div className="mb-2 text-3xl">⏳</div>
-          <p className="text-sm text-gray-500">Cargando conversaciones...</p>
+      <div style={{ backgroundColor: '#FFFFFF' }} className="h-full">
+        <div
+          className="sticky top-0 z-10 px-4 py-3"
+          style={{ backgroundColor: '#FFFFFF', borderBottom: '1px solid #EDEDF0' }}
+        >
+          <div className="h-4 w-32 rounded" style={{ backgroundColor: '#F2F1F6' }} />
+          <div className="mt-1.5 h-3 w-24 rounded" style={{ backgroundColor: '#F2F1F6' }} />
+          <div className="mt-2 h-8 w-full rounded-md" style={{ backgroundColor: '#F2F1F6' }} />
         </div>
+        {[1, 2, 3, 4].map((n) => (
+          <div
+            key={n}
+            className="flex items-start gap-3 px-3 py-3"
+            style={{ borderBottom: '1px solid #EDEDF0' }}
+          >
+            <div
+              className="h-10 w-10 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: '#F2F1F6' }}
+            />
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="h-3 w-3/5 rounded" style={{ backgroundColor: '#F2F1F6' }} />
+              <div className="h-3 w-4/5 rounded" style={{ backgroundColor: '#F2F1F6' }} />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
@@ -125,9 +146,13 @@ function ConversationListInner({ channel, selectedId }: ConversationListProps) {
   if (error) {
     return (
       <div className="flex h-full items-center justify-center p-4">
-        <div className="text-center">
-          <div className="mb-2 text-3xl">❌</div>
-          <p className="text-sm text-red-600">Error: {error.message}</p>
+        <div className="text-center max-w-xs">
+          <p className="text-sm font-medium" style={{ color: '#1C1C22' }}>
+            No pudimos cargar tus conversaciones
+          </p>
+          <p className="mt-1 text-xs" style={{ color: '#84848F' }}>
+            {error.message}
+          </p>
         </div>
       </div>
     );
@@ -135,12 +160,13 @@ function ConversationListInner({ channel, selectedId }: ConversationListProps) {
 
   if (conversations.length === 0) {
     return (
-      <div className="flex h-full items-center justify-center p-4">
-        <div className="text-center">
-          <div className="mb-2 text-4xl">📭</div>
-          <p className="text-sm text-gray-500">No hay conversaciones</p>
-          <p className="text-xs text-gray-400 mt-1">
-            Tus conversaciones aparecerán aquí cuando recibas mensajes
+      <div className="flex h-full items-center justify-center p-6">
+        <div className="text-center max-w-xs">
+          <p className="text-sm font-medium" style={{ color: '#1C1C22' }}>
+            Aún no hay conversaciones
+          </p>
+          <p className="mt-1 text-xs" style={{ color: '#84848F' }}>
+            Cuando recibas mensajes aparecerán aquí.
           </p>
         </div>
       </div>
@@ -148,55 +174,117 @@ function ConversationListInner({ channel, selectedId }: ConversationListProps) {
   }
 
   return (
-    <div className="h-full overflow-auto">
-      {/* Header */}
-      <div className="sticky top-0 z-10 border-b border-gray-200 bg-white p-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-gray-900">Conversaciones</h2>
-            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
-              {conversations.length}
-            </span>
-            {totalUnread > 0 && (
-              <span className="rounded-full bg-red-500 px-2 py-0.5 text-xs font-bold text-white">
-                {totalUnread} sin leer
-              </span>
-            )}
+    <div className="h-full overflow-auto" style={{ backgroundColor: '#FFFFFF' }}>
+      {/* Header rediseñado (Bloque A.2) — título "Comunicaciones" + subtítulo
+          con contadores dinámicos + buscador con icono + botón sort discreto. */}
+      <div
+        className="sticky top-0 z-10 px-4 py-3"
+        style={{
+          backgroundColor: '#FFFFFF',
+          borderBottom: '1px solid #EDEDF0',
+        }}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <h2
+              className="truncate text-base font-semibold"
+              style={{ color: '#1C1C22', letterSpacing: '-0.01em' }}
+            >
+              Comunicaciones
+            </h2>
+            <p className="mt-0.5 text-xs" style={{ color: '#84848F' }}>
+              {conversations.length}{' '}
+              {conversations.length === 1 ? 'conversación' : 'conversaciones'}
+              {totalUnread > 0 && (
+                <>
+                  <span style={{ color: '#EDEDF0', margin: '0 6px' }}>·</span>
+                  <span style={{ color: '#6B4EFF', fontWeight: 500 }}>
+                    {totalUnread} sin leer
+                  </span>
+                </>
+              )}
+            </p>
           </div>
-          {/* Sort toggle */}
+          {/* Sort toggle discreto */}
           <button
-            className="rounded-md px-2 py-1 text-xs text-gray-500 hover:bg-gray-100 transition-colors"
+            className="flex-shrink-0 rounded-md px-2 py-1 text-[11px] transition-colors"
             onClick={() => setSortMode((m) => (m === 'recent' ? 'unread' : 'recent'))}
-            title={sortMode === 'recent' ? 'Ordenar: no leídos primero' : 'Ordenar: recientes primero'}
+            style={{
+              color: '#84848F',
+              backgroundColor: 'transparent',
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = '#F2F1F6')}
+            onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+            title={
+              sortMode === 'recent'
+                ? 'Ordenar: no leídos primero'
+                : 'Ordenar: recientes primero'
+            }
             type="button"
           >
-            {sortMode === 'recent' ? '🕐 Recientes' : '🔴 No leídos'}
+            {sortMode === 'recent' ? 'Recientes' : 'No leídos'}
           </button>
         </div>
-        <div className="mt-2">
+        {/* Buscador con icono Search y tokens del sistema */}
+        <div className="mt-2 relative">
+          <svg
+            aria-hidden
+            className="absolute left-2.5 top-1/2 -translate-y-1/2"
+            fill="none"
+            height="14"
+            stroke="#9A9AA6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+            viewBox="0 0 24 24"
+            width="14"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.35-4.35" />
+          </svg>
           <input
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            className="w-full rounded-md py-1.5 pr-3 text-sm focus:outline-none"
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Buscar conversación..."
+            style={{
+              backgroundColor: '#F2F1F6',
+              border: '1px solid transparent',
+              color: '#1C1C22',
+              paddingLeft: '2rem',
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.backgroundColor = '#FFFFFF';
+              e.currentTarget.style.borderColor = '#6B4EFF';
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.backgroundColor = '#F2F1F6';
+              e.currentTarget.style.borderColor = 'transparent';
+            }}
             type="text"
             value={search}
           />
         </div>
       </div>
 
-      {/* Conversations */}
-      <div className="divide-y divide-gray-200">
+      {/* Conversations — divide-y con color sutil del sistema */}
+      <div style={{ borderColor: '#EDEDF0' }}>
         {filtered.length === 0 && search.trim() ? (
-          <div className="p-4 text-center text-sm text-gray-400">
+          <div className="p-4 text-center text-sm" style={{ color: '#9A9AA6' }}>
             Sin resultados para &ldquo;{search}&rdquo;
           </div>
         ) : null}
-        {filtered.map((conversation) => (
-          <ConversationItem
-            conversation={conversation}
-            isSelected={conversation.id === selectedId}
+        {filtered.map((conversation, idx) => (
+          <div
             key={conversation.id}
-          />
+            style={{
+              borderTop: idx === 0 ? 'none' : '1px solid #EDEDF0',
+            }}
+          >
+            <ConversationItem
+              conversation={conversation}
+              isSelected={conversation.id === selectedId}
+            />
+          </div>
         ))}
       </div>
     </div>

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/MessageItem.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/MessageItem.tsx
@@ -30,7 +30,8 @@ const getStatusIcon = (status?: string) => {
       return '\u2713\u2713';
     }
     case 'read': {
-      return <span className="text-blue-500">{'\u2713\u2713'}</span>;
+      // Redise\u00f1o 18-jul: azul m\u00e1s sutil #3B82F6 (Tailwind blue-500 segu\u00eda ok).
+      return <span style={{ color: '#3B82F6' }}>{'\u2713\u2713'}</span>;
     }
     default: {
       return null;
@@ -43,24 +44,32 @@ export function MessageItem({ message, compact }: MessageItemProps) {
   const [feedback, setFeedback] = useState<FeedbackRating | null>(null);
 
   if (message.kind === 'internal_note') {
+    // Nota interna rediseñada — tokens amber más sutiles del sistema.
     return (
       <div className="flex justify-center">
         <div
-          className={`max-w-[80%] rounded-xl border border-amber-200 bg-amber-50 px-4 ${
-            compact ? 'py-1.5' : 'py-3'
-          } text-amber-950`}
+          className={`max-w-[80%] rounded-xl px-4 ${compact ? 'py-1.5' : 'py-3'}`}
+          style={{
+            backgroundColor: '#FFFBEB',
+            border: '1px solid #FDE68A',
+            color: '#78350F',
+          }}
         >
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-2">
-              <Lock className="h-4 w-4 text-amber-700" />
-              <span className="text-xs font-semibold text-amber-900">Nota interna</span>
+              <Lock className="h-3.5 w-3.5" style={{ color: '#B45309' }} />
+              <span className="text-xs font-semibold" style={{ color: '#92400E' }}>
+                Nota interna
+              </span>
               {message.author && (
-                <span className="text-xs text-amber-700">
+                <span className="text-xs" style={{ color: '#B45309' }}>
                   {message.author}
                 </span>
               )}
             </div>
-            <span className="shrink-0 text-xs text-amber-700">{formatTime(message.timestamp)}</span>
+            <span className="shrink-0 text-xs" style={{ color: '#B45309' }}>
+              {formatTime(message.timestamp)}
+            </span>
           </div>
           <p className="mt-2 whitespace-pre-wrap break-words text-sm">{message.text}</p>
         </div>
@@ -74,16 +83,24 @@ export function MessageItem({ message, compact }: MessageItemProps) {
     await sendFeedback({ messageId: message.id, rating });
   };
 
-  // FASE B v2.0 — distinción visual por origen (Diseño 24-jun):
-  //   contact (fromUser=true)              → blanco, borde, radius 4-16-16-16, izq
-  //   equipo humano (fromUser=false sin IA) → morado #7C3AED, radius 16-4-16-16, der
+  // FASE B v2.0 — distinción visual por origen (Diseño 24-jun) — PRESERVADO
+  // en el rediseño 18-jul (Opción A: no unificar colores para conservar la
+  // señal cromática al vuelo):
+  //   contact (fromUser=true)              → blanco, borde sutil, izq
+  //   equipo humano (fromUser=false sin IA) → morado #7C3AED, der
   //   IA copilot aprobada                  → teal #2DD4BF + texto #0A2A28
   //   IA autopilot                         → gradiente teal→cyan #0D9488→#0891B2
   const isIa = !isFromUser && message.iaGenerated === true;
   const isIaAutopilot = isIa && message.iaMode === 'autopilot';
 
   const bubbleStyle: React.CSSProperties = isFromUser
-    ? {}
+    ? {
+        // Rediseño: burbuja entrante blanca con borde sutil #EDEDF0 (antes solo
+        // shadow-sm). Más minimalista tipo Claude/ChatGPT.
+        backgroundColor: '#FFFFFF',
+        border: '1px solid #EDEDF0',
+        color: '#1C1C22',
+      }
     : isIaAutopilot
       ? { background: 'linear-gradient(135deg, #0D9488, #0891B2)', color: '#fff' }
       : isIa
@@ -93,9 +110,9 @@ export function MessageItem({ message, compact }: MessageItemProps) {
   return (
     <div className={`flex ${isFromUser ? 'justify-start' : 'justify-end'}`}>
       <div
-        className={`group max-w-[70%] px-4 ${compact ? 'py-0.5' : 'py-2'} shadow-sm ${
+        className={`group max-w-[70%] px-4 ${compact ? 'py-0.5' : 'py-2'} ${
           compact ? 'rounded-lg' : 'rounded-2xl'
-        } ${isFromUser ? 'bg-white' : ''}`}
+        }`}
         style={bubbleStyle}
       >
         {/* Sello IA — solo cuando viene del modelo */}
@@ -116,9 +133,12 @@ export function MessageItem({ message, compact }: MessageItemProps) {
 
         {/* Timestamp & Status */}
         <div
-          className={`mt-1 flex items-center justify-end gap-1 text-xs ${
-            isFromUser ? 'text-gray-500' : 'text-white/70'
-          }`}
+          className="mt-1 flex items-center justify-end gap-1 text-xs"
+          style={{
+            color: isFromUser
+              ? '#9A9AA6' // contact — token secundario sistema
+              : 'rgba(255,255,255,0.75)', // IA/humano equipo — blanco 75%
+          }}
         >
           {/* SPRINT 3 iMessage (6-jul): pill (editado) si editedAt está */}
           {message.editedAt ? (

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/MessagesRail.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/MessagesRail.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 /**
- * MessagesRail — rail vertical 54px del lado izquierdo de la Bandeja.
+ * MessagesRail — rail vertical 56px del lado izquierdo de la Bandeja.
+ * Rediseño 18-jul: 54 → 56px + fondo #FCFCFD + border #EDEDF0 (tokens sistema).
  * Diseño 25-jun-2026 (handoff v2):
  *
  * De arriba a abajo:
@@ -102,8 +103,8 @@ export function MessagesRail({
   return (
     <nav
       aria-label="Rail navegación Bandeja"
-      className="hidden h-full w-[54px] shrink-0 flex-col items-center justify-between border-r py-3 lg:flex"
-      style={{ backgroundColor: '#F6F4FB', borderColor: '#EFEFF3' }}
+      className="hidden h-full w-[56px] shrink-0 flex-col items-center justify-between border-r py-3 lg:flex"
+      style={{ backgroundColor: '#FCFCFD', borderColor: '#EDEDF0' }}
     >
       {/* Top: avatar + items navegación */}
       <div className="flex flex-col items-center gap-2">

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/components/MessagesRail.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/components/MessagesRail.tsx
@@ -51,6 +51,16 @@ const ICON_HISTORY = (
   </svg>
 );
 
+// Rediseño 18-jul Fase B — item nuevo "Agentes" (Cowork). Ver /agentes.
+const ICON_AGENTS = (
+  <svg fill="none" height="20" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="20">
+    <path d="M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
+    <circle cx="10" cy="7" r="4" />
+    <path d="M22 11l-2 2-2-2" />
+    <path d="M20 13V7" />
+  </svg>
+);
+
 interface MessagesRailProps {
   inboxUnread?: number;
   historyUnread?: number;
@@ -81,6 +91,12 @@ export function MessagesRail({
         matchPrefix: '/messages',
         icon: ICON_INBOX,
         unreadCount: inboxUnread,
+      },
+      {
+        href: '/agentes',
+        label: 'Agentes',
+        matchPrefix: '/agentes',
+        icon: ICON_AGENTS,
       },
       {
         href: '/messages?tab=history',

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useConversationActions.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useConversationActions.ts
@@ -16,6 +16,9 @@ type ActionsMap = Record<string, ActionState>;
 
 // ─── external store for cross-component reactivity ──────────────────────────
 
+// Referencia estable — ver useConversationMeta.ts para el motivo.
+const EMPTY_MAP: ActionsMap = Object.freeze({}) as ActionsMap;
+
 let listeners = new Set<() => void>();
 
 function subscribe(cb: () => void) {
@@ -23,19 +26,22 @@ function subscribe(cb: () => void) {
   return () => listeners.delete(cb);
 }
 
-function getMap(): ActionsMap {
-  if (typeof window === 'undefined') return {};
+function readFromStorage(): ActionsMap {
+  if (typeof window === 'undefined') return EMPTY_MAP;
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_MAP;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : EMPTY_MAP;
   } catch {
-    return {};
+    return EMPTY_MAP;
   }
 }
 
-let cachedSnapshot: ActionsMap = getMap();
+let cachedSnapshot: ActionsMap = readFromStorage();
 
 function notify() {
-  cachedSnapshot = getMap();
+  cachedSnapshot = readFromStorage();
   listeners.forEach((cb) => cb());
 }
 
@@ -49,7 +55,7 @@ function getSnapshot(): ActionsMap {
 }
 
 function getServerSnapshot(): ActionsMap {
-  return {};
+  return EMPTY_MAP;
 }
 
 // ─── hook ───────────────────────────────────────────────────────────────────
@@ -68,21 +74,21 @@ export function useConversationActions() {
   );
 
   const toggleArchive = useCallback((conversationId: string) => {
-    const map = getMap();
+    const map = { ...readFromStorage() };
     const current = map[conversationId] ?? {};
     map[conversationId] = { ...current, archived: !current.archived };
     saveMap(map);
   }, []);
 
   const toggleMute = useCallback((conversationId: string) => {
-    const map = getMap();
+    const map = { ...readFromStorage() };
     const current = map[conversationId] ?? {};
     map[conversationId] = { ...current, muted: !current.muted };
     saveMap(map);
   }, []);
 
   const deleteConversation = useCallback((conversationId: string) => {
-    const map = getMap();
+    const map = { ...readFromStorage() };
     map[conversationId] = { ...map[conversationId], archived: true };
     saveMap(map);
   }, []);

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useConversationMeta.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/hooks/useConversationMeta.ts
@@ -13,6 +13,11 @@ type MetaMap = Record<string, ConversationMeta>;
 
 const STORAGE_KEY = 'inbox_conversation_meta';
 
+// Referencia estable para SSR y para el estado inicial vacío en cliente.
+// useSyncExternalStore compara con Object.is; devolver `{}` nuevo en cada
+// llamada disparaba loop "Maximum update depth" en tests con jsdom.
+const EMPTY_MAP: MetaMap = Object.freeze({}) as MetaMap;
+
 let listeners = new Set<() => void>();
 
 function subscribe(cb: () => void) {
@@ -20,19 +25,22 @@ function subscribe(cb: () => void) {
   return () => listeners.delete(cb);
 }
 
-function getMap(): MetaMap {
-  if (typeof window === 'undefined') return {};
+function readFromStorage(): MetaMap {
+  if (typeof window === 'undefined') return EMPTY_MAP;
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return EMPTY_MAP;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : EMPTY_MAP;
   } catch {
-    return {};
+    return EMPTY_MAP;
   }
 }
 
-let cachedSnapshot: MetaMap = getMap();
+let cachedSnapshot: MetaMap = readFromStorage();
 
 function notify() {
-  cachedSnapshot = getMap();
+  cachedSnapshot = readFromStorage();
   listeners.forEach((cb) => cb());
 }
 
@@ -46,7 +54,7 @@ function getSnapshot(): MetaMap {
 }
 
 function getServerSnapshot(): MetaMap {
-  return {};
+  return EMPTY_MAP;
 }
 
 export function useConversationMeta(conversationId: string | null | undefined) {
@@ -60,7 +68,7 @@ export function useConversationMeta(conversationId: string | null | undefined) {
   const setStatus = useCallback(
     (status: ConversationStatus) => {
       if (!conversationId) return;
-      const map = getMap();
+      const map = { ...readFromStorage() };
       const current = map[conversationId] ?? {};
       map[conversationId] = { ...current, status };
       saveMap(map);
@@ -71,7 +79,7 @@ export function useConversationMeta(conversationId: string | null | undefined) {
   const assignToUser = useCallback(
     (assignedUserId: string | null) => {
       if (!conversationId) return;
-      const map = getMap();
+      const map = { ...readFromStorage() };
       const current = map[conversationId] ?? {};
       map[conversationId] = { ...current, assignedUserId };
       saveMap(map);
@@ -81,7 +89,7 @@ export function useConversationMeta(conversationId: string | null | undefined) {
 
   const clearMeta = useCallback(() => {
     if (!conversationId) return;
-    const map = getMap();
+    const map = { ...readFromStorage() };
     delete map[conversationId];
     saveMap(map);
   }, [conversationId]);

--- a/apps/chat-ia/src/app/[variants]/(main)/messages/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/messages/page.tsx
@@ -175,7 +175,10 @@ export default function MessagesPage() {
           counts={{ history: notifUnreadCount, inbox: convUnreadCount }}
         />
         <div className="flex flex-1 overflow-hidden">
-          <div className="flex w-[420px] shrink-0 flex-col overflow-hidden border-r border-gray-200 bg-white">
+          <div
+            className="flex w-[300px] shrink-0 flex-col overflow-hidden"
+            style={{ borderRight: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+          >
             {/* ScopeSelector + filtros solo visibles en tab 'inbox'. En 'history'
                 el feed es plano (notificaciones) sin scope ni filtros canal/RSVP. */}
             {activeTab === 'inbox' && (

--- a/apps/chat-ia/src/app/[variants]/loading/Client/Redirect.tsx
+++ b/apps/chat-ia/src/app/[variants]/loading/Client/Redirect.tsx
@@ -44,6 +44,7 @@ const Redirect = memo<RedirectProps>(({ setActiveStage }) => {
         '/admin',
         '/image',
         '/changelog',
+        '/agentes',
       ];
       
       // Si estamos en una de estas rutas, NO redirigir
@@ -88,6 +89,7 @@ const Redirect = memo<RedirectProps>(({ setActiveStage }) => {
         '/admin',
         '/image',
         '/changelog',
+        '/agentes',
       ];
       
       // Si estamos en una de estas rutas, NO hacer NADA - salir inmediatamente

--- a/apps/chat-ia/src/app/[variants]/loading/Server/Content.tsx
+++ b/apps/chat-ia/src/app/[variants]/loading/Server/Content.tsx
@@ -33,6 +33,7 @@ const ROUTES_TO_SKIP = [
   '/admin',
   '/image',
   '/changelog',
+  '/agentes',
 ];
 
 const Content = memo<ContentProps>(({ loadingStage }) => {

--- a/apps/chat-ia/src/store/bandeja/selectors.ts
+++ b/apps/chat-ia/src/store/bandeja/selectors.ts
@@ -5,8 +5,15 @@
  * componentes. Evita que cada componente recompute filtros desde el state
  * crudo y permite memoización fina.
  */
+import { useShallow } from 'zustand/react/shallow';
+
 import { useBandejaStore } from './index';
 import type { ChannelKind, Conversation } from './types';
+
+// Referencia estable para el caso "sin typers" — evita crear array nuevo cada
+// llamada del selector, lo que disparaba loop "Maximum update depth" en tests
+// con jsdom (Zustand compara por identity por default).
+const EMPTY_TYPERS: readonly never[] = Object.freeze([]);
 
 /** Lista plana de conversaciones ordenadas por lastMessageAt desc. */
 export const useConversationsList = (): Conversation[] => {
@@ -45,12 +52,20 @@ export const useUnreadCounts = () => useBandejaStore((s) => s.unreadCounts);
 /** Notificaciones. */
 export const useNotifications = () => useBandejaStore((s) => s.notifications);
 
-/** Indicador de typing en una conversación. */
+/** Indicador de typing en una conversación.
+ *  useShallow: si el array resultante tiene los mismos userIds vigentes,
+ *  Zustand no dispara rerender aunque el selector cree un array nuevo.
+ *  Sin esto entraba en loop "Maximum update depth" al montar. */
 export const useTypingInConv = (convId: string) =>
-  useBandejaStore((s) => {
-    const now = Date.now();
-    return (s.typingByConv[convId] ?? []).filter((t) => t.expiresAt > now);
-  });
+  useBandejaStore(
+    useShallow((s) => {
+      const list = s.typingByConv[convId];
+      if (!list || list.length === 0) return EMPTY_TYPERS;
+      const now = Date.now();
+      const filtered = list.filter((t) => t.expiresAt > now);
+      return filtered.length === 0 ? EMPTY_TYPERS : filtered;
+    }),
+  );
 
 /** Loading + error global. */
 export const useBandejaStatus = () =>

--- a/packages/shared/src/tracking/index.ts
+++ b/packages/shared/src/tracking/index.ts
@@ -14,6 +14,14 @@
  *   await registerReferralIfPending(jwtToken, development);
  */
 
+// Shim mínimo para `process.env.NODE_ENV` sin añadir @types/node al workspace.
+// El código real ya hace `typeof process !== 'undefined'` antes de usarlo,
+// pero TypeScript sin @types/node no reconoce el identificador y emitía
+// TS2580 al compilar packages/shared. Declaración local, no export.
+declare const process:
+  | { env?: { NODE_ENV?: string } | Record<string, string | undefined> }
+  | undefined;
+
 const DEFAULT_API_MCP_URL = 'https://api-mcp.eventosorganizador.com';
 
 // ─── Tipos ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumen

Rediseño 18-jul de la vista **Bandeja / Comunicaciones** (`/messages`) siguiendo el sistema de tokens definido en el pega + nueva vista **Cowork de Agentes** (`/agentes`).

Preserva **toda** la funcionalidad previa (auditada en `INVENTARIO-BASELINE-2026-07-17.md`, 22 sistemas de negocio catalogados).

---

## Fase A — Rediseño /messages (6 bloques, 6 commits)

| Bloque | Commit | Contenido |
|---|---|---|
| A.1 | `43fb9afc` | `ConversationItem` — 40×40 avatar, dot canal 12px, pill morada #6B4EFF, ✦ IA signal |
| A.2 | `766efb80` | Header lista "Comunicaciones · N conversaciones · M sin leer" + búsqueda |
| A.3 | `9d51ec44` | `ConversationHeader` — tokens sistema, IaLevelPicker (3 niveles) preservado |
| A.4 | `c64ff1c9` | `EventSidebar` desplegable con toggle "Detalles" + persistencia localStorage |
| A.5 | `2c7ce059` | Layout 3 columnas: rail 56 + lista 300 + hilo flex-1 |
| A.6 | `ee71d100` | `MessageItem` — 3 colores IA (copilot/autopilot/humano), nota interna, tokens |

### Preservado explícito en Fase A
- `IaLevelPicker` con **3 niveles** (manual/copilot/autopilot) — NO se degrada a toggle binario.
- `useConversationMeta` typing/presencia/status/assignedToMe intactos.
- Filtros de `ConversationList` (all/mine/unassigned/closed) intactos.
- Todos los hooks y contexto de MessagesProvider, EventSidebar, BottomSheet móvil.

---

## Fase B — Nueva vista `/agentes` (Cowork)

**Commit** `9a541888`.

Vista nueva — el grep de `cowork` antes del cambio devolvía **0 hits** (validado en inventario baseline). El `group_chat` supervisor existente es 1 humano ↔ N IAs (otro caso de uso).

**Layout:** 3 columnas — rail 56 + lista agentes 260 + ficha agente flex-1.

**Ficha del agente:**
- Cabecera: avatar + nombre + badge estado + botón **Pausar / Reanudar**.
- **Rendimiento hoy** (Respuestas / % resueltas sola / tiempo medio) — badge `DEMO`.
- **Canales asignados** (chips con dot color por canal) — badge `BETA` (persist local).
- **Instrucciones** (textarea prompt editable).
- **Actividad reciente** (reply / handoff / config_change / suggestion) — badge `DEMO`.

**Navegación:** item nuevo "Agentes" en `MessagesRail` entre Bandeja y Historial. Rail compartido entre `/messages` y `/agentes`.

### Backend pendiente (Slack ts `1784383734` a proveedores api-ia + api-mcp)
Todos los mocks marcados con `TODO: reemplazar cuando backend exponga`:

1. `GET /api/backend/chat/agents/{userId}/metrics?period=today` → `{ replies_count, resolved_percent, avg_response_seconds }`
2. Endpoint asignación canales → `POST /api/backend/chat/agents/{userId}/channel-assignments` con `{ agentId, channels[] }`
3. Evento SSE `handoff` → `{ type:'handoff', convId, fromAgentId, toUserId, at }`
4. Extensión `LobeAgentConfig.disabled?: boolean` — persistencia via `PATCH /chat/sessions/{id}`

Hasta que confirmen shape: mocks en memoria + persistencia local (`localStorage`).

### Prompt del agente
Ya cableado — cuando sustituyamos `MOCK_AGENTS` por `sessionSelectors.defaultSessions`, `updateAgentConfig({ systemRole })` de `useAgentStore` persiste el prompt (ya existe).

---

## Rutas — compatibilidad Redirect
- `Redirect.tsx` y `Content.tsx` incluyen `/agentes` en `ROUTES_TO_SKIP` (evita que el Redirect global lleve la URL directa a `/chat` — BUG QA 14-jul #B).

## Test plan

- [ ] `/messages` desktop: rail 56 + lista 300 + hilo carga y responde; `IaLevelPicker` 3 niveles; toggle Detalles preserva estado tras F5.
- [ ] `/messages` móvil: bottom sheet `ℹ` abre `EventSidebar` en 75%.
- [ ] `/agentes`: 3 agentes mock; Pausar → dot gris; canales chips toggle; prompt editable; botón crear alerta placeholder.
- [ ] Rail: click "Agentes" navega; item activo se resalta morado.
- [ ] `curl -o /dev/null -w '%{http_code}' :3210/agentes` = 200.
- [ ] `bunx vitest run --silent=passed-only apps/chat-ia` sin regresiones nuevas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)