### PR TITLE
Sprint γ · X2(d) picker de evento MVP client-only

### DIFF
--- a/apps/appEventos/context/EventContext.tsx
+++ b/apps/appEventos/context/EventContext.tsx
@@ -137,6 +137,31 @@ const EventProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => { eventRef.current = event }, [event])
   useEffect(() => { eventsGroupRef.current = eventsGroup }, [eventsGroup])
 
+  // X2(d) · plan consolidado 2026-07-20 (sprint γ). Publica la lista compacta
+  // de eventos del usuario en cookie `bodas_available_events` con Domain=
+  // .bodasdehoy.com para que chat-ia pueda ofrecer un picker al usuario cuando
+  // la IA no puede resolver el evento (o cuando el usuario abre el chip del
+  // header). Formato compacto: [{i, n}] con nombre truncado a 40 chars y
+  // limitado a los 20 eventos más recientes para caber en el ~4KB de cookie.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const isProd = !!process.env.NEXT_PUBLIC_PRODUCTION
+      const domainAttr = isProd ? '; Domain=.bodasdehoy.com' : ''
+      if (!eventsGroup || eventsGroup.length === 0) {
+        document.cookie = `bodas_available_events=; Path=/; SameSite=Lax; Max-Age=0${domainAttr}`
+        return
+      }
+      const compact = eventsGroup
+        .slice(0, 20)
+        .map((e: any) => ({ i: e?._id, n: String(e?.nombre || '').slice(0, 40) }))
+        .filter((e: any) => e.i)
+      const payload = encodeURIComponent(JSON.stringify(compact))
+      const maxAge = 60 * 60 * 24 * 30 // 30 días
+      document.cookie = `bodas_available_events=${payload}; Path=/; SameSite=Lax; Max-Age=${maxAge}${domainAttr}`
+    } catch { /* nunca romper la UI por telemetría */ }
+  }, [eventsGroup])
+
   useEffect(() => {
     if (typeof window === 'undefined') return
     const sync = () => {

--- a/apps/chat-ia/src/app/[variants]/(main)/chat/(workspace)/_layout/Desktop/ChatHeader/ActiveEventChip.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/chat/(workspace)/_layout/Desktop/ChatHeader/ActiveEventChip.tsx
@@ -1,22 +1,27 @@
 'use client';
 
-import { Tag } from 'antd';
-import { CalendarDaysIcon } from 'lucide-react';
-import { memo, useEffect, useState } from 'react';
+import { Dropdown, Tag } from 'antd';
+import { CalendarDaysIcon, ChevronDownIcon } from 'lucide-react';
+import { memo, useEffect, useMemo, useState } from 'react';
+
+import { useAvailableEventsFromCookie } from '@/hooks/useAvailableEventsFromCookie';
 
 /**
- * X2(e) · plan consolidado 2026-07-20.
- * Chip visible en el header del chat que muestra el evento activo actual.
- * Lee `current_event_id` + `current_event_name` de localStorage y se
- * refresca al recibir el CustomEvent `chatia:activeEventChanged`
- * (emitido por `useCrossAppActiveEventSync` cuando la cookie cambia).
+ * X2(e) + X2(d) · plan consolidado 2026-07-20.
+ * Chip clickeable en el header del chat que muestra el evento activo y
+ * abre un dropdown con la lista de eventos disponibles (`availableEvents`
+ * publicada por appEventos en `bodas_available_events` cookie).
  *
- * El click abre appEventos en la vista de eventos (por ahora — futuro:
- * abrir picker inline; requiere X2(d)).
+ * Elegir un evento del dropdown escribe la cookie `bodas_active_event`
+ * (mismo formato que appEventos.EventContext.setEvent) + dispara el
+ * CustomEvent que actualiza chat-ia sin recargar.
+ * Los consumidores existentes (services/chat, tools, storage-r2) recogen
+ * el nuevo valor en la siguiente llamada.
  */
 const ActiveEventChip = memo(() => {
-  const [eventName, setEventName] = useState<string | null>(null);
   const [eventId, setEventId] = useState<string | null>(null);
+  const [eventName, setEventName] = useState<string | null>(null);
+  const available = useAvailableEventsFromCookie();
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -27,7 +32,6 @@ const ActiveEventChip = memo(() => {
     };
 
     refresh();
-
     const onChange = () => refresh();
     window.addEventListener('chatia:activeEventChanged', onChange);
     window.addEventListener('storage', onChange);
@@ -37,19 +41,72 @@ const ActiveEventChip = memo(() => {
     };
   }, []);
 
-  if (!eventId) return null;
+  const items = useMemo(
+    () =>
+      available.map((e) => ({
+        key: e.id,
+        label: e.name || `Evento ${e.id.slice(-6)}`,
+      })),
+    [available],
+  );
 
-  const label = eventName || `Evento ${eventId.slice(-6)}`;
+  const selectEvent = (id: string) => {
+    if (typeof window === 'undefined') return;
+    const isProd = !!process.env.NEXT_PUBLIC_PRODUCTION;
+    const domainAttr = isProd ? '; Domain=.bodasdehoy.com' : '';
+    const maxAge = 60 * 60 * 24 * 30;
+    document.cookie = `bodas_active_event=${encodeURIComponent(id)}; Path=/; SameSite=Lax; Max-Age=${maxAge}${domainAttr}`;
+    const prevId = localStorage.getItem('current_event_id');
+    const picked = available.find((e) => e.id === id);
+    localStorage.setItem('current_event_id', id);
+    if (picked?.name) localStorage.setItem('current_event_name', picked.name);
+    else localStorage.removeItem('current_event_name');
+    localStorage.removeItem('current_event_type');
+    window.dispatchEvent(
+      new CustomEvent('chatia:activeEventChanged', {
+        detail: { eventId: id, prevEventId: prevId, source: 'user-picker' },
+      }),
+    );
+  };
 
-  return (
+  if (!eventId && items.length === 0) return null;
+
+  const label = eventName || (eventId ? `Evento ${eventId.slice(-6)}` : 'Elegir evento');
+
+  const chip = (
     <Tag
-      color="blue"
+      color={eventId ? 'blue' : 'default'}
       icon={<CalendarDaysIcon size={12} style={{ verticalAlign: 'middle' }} />}
-      style={{ cursor: 'default', marginInlineStart: 8 }}
-      title={eventName ? `Evento activo: ${eventName}` : `Evento activo (id: ${eventId})`}
+      style={{
+        cursor: items.length > 1 ? 'pointer' : 'default',
+        marginInlineStart: 8,
+      }}
+      title={
+        eventId
+          ? eventName
+            ? `Evento activo: ${eventName}${items.length > 1 ? ' — click para cambiar' : ''}`
+            : `Evento activo (id: ${eventId})`
+          : 'Elegir evento'
+      }
     >
       {label}
+      {items.length > 1 && <ChevronDownIcon size={10} style={{ marginInlineStart: 4, verticalAlign: 'middle' }} />}
     </Tag>
+  );
+
+  if (items.length <= 1) return chip;
+
+  return (
+    <Dropdown
+      menu={{
+        items,
+        onClick: ({ key }) => selectEvent(key),
+        selectedKeys: eventId ? [eventId] : [],
+      }}
+      trigger={['click']}
+    >
+      {chip}
+    </Dropdown>
   );
 });
 

--- a/apps/chat-ia/src/hooks/useAvailableEventsFromCookie.ts
+++ b/apps/chat-ia/src/hooks/useAvailableEventsFromCookie.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const COOKIE_NAME = 'bodas_available_events';
+
+export interface AvailableEvent {
+  id: string;
+  name: string;
+}
+
+const readCookie = (name: string): string | null => {
+  if (typeof document === 'undefined') return null;
+  const escaped = name.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+  const match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
+const parse = (raw: string | null): AvailableEvent[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((e: unknown) => {
+        if (!e || typeof e !== 'object') return null;
+        const obj = e as Record<string, unknown>;
+        const id = typeof obj.i === 'string' ? obj.i : null;
+        const name = typeof obj.n === 'string' ? obj.n : '';
+        return id ? { id, name } : null;
+      })
+      .filter((x): x is AvailableEvent => x !== null);
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * X2(d) · plan consolidado 2026-07-20.
+ * Lee la lista compacta de eventos del usuario publicada por appEventos en la
+ * cookie `bodas_available_events` (Domain=.bodasdehoy.com). Reactiva al montar,
+ * en cada `visibilitychange`, y en el `storage` event.
+ * Ver `apps/appEventos/context/EventContext.tsx` para el escritor.
+ */
+export const useAvailableEventsFromCookie = (): AvailableEvent[] => {
+  const [events, setEvents] = useState<AvailableEvent[]>(() => parse(readCookie(COOKIE_NAME)));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const refresh = () => setEvents(parse(readCookie(COOKIE_NAME)));
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+
+    refresh();
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('storage', refresh);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
+
+  return events;
+};


### PR DESCRIPTION
> Continuación PR #204 (α) + #205 (β). Este PR cierra X2(d) del plan consolidado sin dependencia backend.

## Summary
- **appEventos EventContext** publica cookie `bodas_available_events` con Domain=`.bodasdehoy.com` cuando cambia `eventsGroup`. Formato compacto `[{i, n}]` (id + nombre truncado 40 chars) limitado a 20 eventos recientes (~2KB payload).
- **chat-ia hook `useAvailableEventsFromCookie`** lee la cookie al montar + `visibilitychange` + `storage`. Devuelve lista tipada `AvailableEvent[]`.
- **`ActiveEventChip`** (creado en sprint β) evoluciona a `Dropdown` clickeable cuando hay >1 evento. Elegir un evento del picker escribe cookie `bodas_active_event`, actualiza localStorage y emite `chatia:activeEventChanged { source: 'user-picker' }`. Los tools/services existentes recogen el nuevo evento en la siguiente call.

Sin dependencia backend. El flujo IA-guiado (SSE `ambiguous_event` cuando la IA no puede resolver) queda para sprint futuro con api-ia. Este MVP cubre el 80% del caso: el usuario ve el evento activo y lo cambia con un click.

## Verificaciones
- `bun run type-check` chat-ia → **exit 0**.
- Cookie limit ~4KB verificado con el cálculo `20 × 100 chars ≈ 2KB`.

## Test plan
- [ ] En appEventos con >1 evento en `eventsGroup`, verificar `document.cookie` contiene `bodas_available_events` con lista JSON compacta.
- [ ] Abrir chat-ia fullscreen: el chip azul del header muestra el evento activo con ícono `▾`. Click abre dropdown con los N eventos disponibles.
- [ ] Elegir otro evento del dropdown → chip actualiza label + los siguientes mensajes al Copilot usan el nuevo `current_event_id`.
- [ ] Con 1 solo evento en `eventsGroup`, chip NO muestra dropdown (solo Tag informativo).
- [ ] Modo iframe embed (Copilot en appEventos): sigue funcionando con EVENT_CONTEXT postMessage — cookie es no-op cuando coincide.

## Referencias
- `docs/PLAN-CONSOLIDADO-CHAT-IA-2026-07-20.md` §2.2 X2(d).
- PRs previos: #204 (sprint α), #205 (sprint β).

🤖 Generated with [Claude Code](https://claude.com/claude-code)