### PR TITLE
💄 feat(appEventos/mesas): sidebar fiel al proto — tabs solo-texto · Planos+Añadir plano · Mobiliario · Mesas→lista

### DIFF
--- a/apps/appEventos/components/Mesas/BlockPanelElements.tsx
+++ b/apps/appEventos/components/Mesas/BlockPanelElements.tsx
@@ -1,4 +1,3 @@
-import { Group83, PlusIcon, } from "../icons";
 import { FC, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import BlockDefault from "./BlockDefault";
@@ -159,52 +158,59 @@ const BlockPanelElements: FC<propsBlockPanelElements> = ({ listElements, setList
     return { isValid: true };
   };
 
+  // Modal "Añadir SVG" — rediseñado a la paleta rosa del prototipo (antes azul/gris genérico).
+  // Lógica intacta: handleFileUpload / handleUrlSubmit / createGalerySvgs.
   const Modal = () => (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 text-gray-700">
-      <div className="bg-white p-6 rounded-lg max-w-md w-full mx-4">
-        <h3 className="text-lg font-semibold mb-4">Agregar SVG</h3>
-        {/* Información sobre límites de tamaño */}
-        <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded">
-          <p className="text-sm text-blue-800">
-            <strong>Límites de tamaño:</strong><br />
-            • Máximo: {SVG_SIZE_LIMITS.MAX_FILE_SIZE / 1024}KB<br />
-            • Recomendado: {SVG_SIZE_LIMITS.RECOMMENDED_SIZE / 1024}KB o menos
-          </p>
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-[rgba(43,43,48,.38)] px-4"
+      onClick={() => { if (!isLoading) setShowModal(false) }}
+    >
+      <div onClick={(e) => e.stopPropagation()} className="w-[400px] max-w-full bg-white rounded-[18px] shadow-[0_24px_60px_rgba(0,0,0,.28)] p-6 text-[#3A3A42]">
+        <div className="flex items-center gap-[11px] mb-[18px]">
+          <div className="w-10 h-10 rounded-[11px] flex-none bg-[#FCE7F0] text-[#EF5B94] flex items-center justify-center text-[20px] leading-none">＋</div>
+          <div>
+            <div className="text-[16px] font-bold text-[#3A3A42]">Añadir SVG</div>
+            <div className="text-[11.5px] font-medium text-[#a0a0a8]">Un elemento decorativo para tu plano</div>
+          </div>
+        </div>
+        {/* Límites de tamaño en pastilla rosa (regla proyecto: avisos en pastilla) */}
+        <div className="bg-[#FCF2F6] border border-[#f7c2da] rounded-[12px] px-4 py-3 mb-4 text-[11px] font-medium text-[#c14a78] leading-relaxed">
+          Máximo {SVG_SIZE_LIMITS.MAX_FILE_SIZE / 1024}KB · Recomendado {SVG_SIZE_LIMITS.RECOMMENDED_SIZE / 1024}KB o menos.
         </div>
         {/* Opción 1: Cargar desde archivo */}
         <div className="mb-4">
-          <label className="block text-sm font-medium mb-2">Cargar desde archivo:</label>
+          <div className="text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba] mb-2">Cargar desde archivo</div>
           <input
             type="file"
             accept=".svg"
             onChange={handleFileUpload}
-            className="w-full p-2 border border-gray-300 rounded"
             disabled={isLoading}
+            className="w-full p-3 rounded-[11px] border-[1.5px] border-[#E7E7EA] text-[12.5px] file:mr-3 file:py-1.5 file:px-3 file:rounded-[8px] file:border-0 file:bg-[#FCE7F0] file:text-[#EF5B94] file:font-semibold file:cursor-pointer disabled:opacity-60"
           />
         </div>
         {/* Opción 2: Cargar desde URL */}
         <div className="mb-4">
-          <label className="block text-sm font-medium mb-2">Cargar desde URL:</label>
+          <div className="text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba] mb-2">Cargar desde URL</div>
           <input
             type="text"
-            placeholder="URL del SVG (ej: https://ejemplo.com/icono.svg)"
+            placeholder="https://ejemplo.com/icono.svg"
             value={svgUrl}
             onChange={(e) => setSvgUrl(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded mb-2"
             disabled={isLoading}
+            className="w-full p-3 rounded-[11px] border-[1.5px] border-[#E7E7EA] focus:border-[#EF5B94] outline-none text-[12.5px] mb-2 disabled:opacity-60"
           />
           <button
             onClick={handleUrlSubmit}
             disabled={isLoading}
-            className="w-full mt-2 bg-primary text-white p-2 rounded-full disabled:bg-gray-400 disabled:cursor-not-allowed"
+            className="w-full py-[11px] rounded-[11px] bg-[#EF5B94] text-white text-[12.5px] font-semibold disabled:bg-[#f0aecb] disabled:cursor-not-allowed"
           >
-            {isLoading ? 'Cargando...' : 'Agregar desde URL'}
+            {isLoading ? 'Cargando…' : 'Agregar desde URL'}
           </button>
         </div>
         <button
           onClick={() => setShowModal(false)}
           disabled={isLoading}
-          className="w-full bg-gray-400 text-white p-2 rounded-full disabled:bg-gray-400 disabled:cursor-not-allowed"
+          className="w-full py-[11px] rounded-[11px] bg-[#f7f7f9] text-[#6b6b72] text-[12.5px] font-semibold disabled:cursor-not-allowed"
         >
           Cancelar
         </button>
@@ -219,36 +225,42 @@ const BlockPanelElements: FC<propsBlockPanelElements> = ({ listElements, setList
         <Modal />,
         document.getElementById('rootElementMain') || document.body
       )}
-      <div id="listTables" className="w-full h-full">
-        <BlockDefault listaLength={listElements.length}>
-          <DragTable item={{
-            size: { width: 60, height: 120 },
-            tipo: "text",
-            title: "",
-            icon: <CiText className="w-8 h-8 text-gray-400" />
-          }} />
-          {listElements.map((item, idx) => (
-            <DragTable key={idx} item={item} />
-          ))}
-          <div id="added-svg" onClick={() => { setShowModal(true) }} className="w-20 h-16 static">
-            <span className="w-full h-full flex items-center ">
-              <div className="w-full h-full p-2 flex-col justify-center items-center cursor-pointer relative">
-                <div className="w-full h-full flex transform hover:scale-105 transition justify-center items-center relative">
-                  <div className="js-dragDefault w-full h-10 flex justify-center items-center">
-                    <Group83 className="relative w-max" />
-                    <PlusIcon className={`absolute inset-0 m-auto text-primary w-3 h-3 `} />
-                  </div>
-                </div>
-              </div>
-            </span>
-          </div>
-          <style>{`
-            .listTables {
-              touch - action: none;
-              user-select: none;
-            }
-          `}</style>
-        </BlockDefault>
+      <div id="listTables" className="w-full h-full flex flex-col">
+        {/* Aviso en pastilla ovalada rosa (proto Mobiliario) */}
+        <div className="flex-none bg-[#FCF2F6] border border-[#f7c2da] rounded-[999px] px-4 py-[9px] mb-[11px]">
+          <div className="text-[10px] font-medium text-[#c14a78] whitespace-nowrap">Arrastra un elemento al plano para añadirlo.</div>
+        </div>
+        {/* Cabecera de sección */}
+        <div className="flex-none text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba] mb-[10px]">Elementos decorativos</div>
+        {/* Grid — BlockDefault + DragTable preservan el motor de arrastre (NO tocar IDs/js-dragDefault) */}
+        <div className="flex-1 min-h-0">
+          <BlockDefault listaLength={listElements.length}>
+            <DragTable item={{
+              size: { width: 60, height: 120 },
+              tipo: "text",
+              title: "",
+              icon: <CiText className="w-8 h-8 text-gray-400" />
+            }} />
+            {listElements.map((item, idx) => (
+              <DragTable key={idx} item={item} />
+            ))}
+            {/* Añadir SVG — tile punteado rosa; abre el modal real (createGalerySvgs). Es un botón, no un draggable. */}
+            <div
+              id="added-svg"
+              onClick={() => { setShowModal(true) }}
+              className="w-14 h-14 flex flex-col items-center justify-center gap-1 rounded-[12px] bg-white border-[1.5px] border-dashed border-[#f0aecb] cursor-pointer hover:bg-[#FCF2F6] transition-colors"
+            >
+              <span className="text-[#EF5B94] text-[18px] leading-none">＋</span>
+              <span className="text-[9px] font-semibold text-[#EF5B94] leading-none">SVG</span>
+            </div>
+            <style>{`
+              .listTables {
+                touch - action: none;
+                user-select: none;
+              }
+            `}</style>
+          </BlockDefault>
+        </div>
       </div>
     </>
   );

--- a/apps/appEventos/components/Mesas/BlockPanelMesas.tsx
+++ b/apps/appEventos/components/Mesas/BlockPanelMesas.tsx
@@ -1,14 +1,11 @@
-import { LineaBancos, MesaCuadrada, MesaImperial, MesaPodio, MesaRedonda, PlusIcon, Banco, MesaMilitar } from "../icons";
-import { Dispatch, FC, SetStateAction, useState } from "react";
-import BlockDefault from "./BlockDefault";
-import DragTable from "./DragTable"
+import { LineaBancos, MesaCuadrada, MesaImperial, MesaPodio, MesaRedonda, Banco, MesaMilitar } from "../icons";
+import { FC } from "react";
+import { EventContextProvider } from "../../context";
 import { useTranslation } from 'react-i18next';
 
-interface propsBlockPanelMesas {
-
-}
-
-
+// Catálogo de tipos de mesa. SIGUE en uso en pages/mesas.tsx:172 para construir
+// `defaultTablesDraggable` (accept del dropzone del canvas). NO borrar este export
+// aunque el grid arrastrable ya no se renderice aquí.
 export const ListTables = [
   { icon: <MesaCuadrada className="relative w-max" />, title: "cuadrada", tipo: "table" },
   { icon: <MesaPodio className="relative w-max" />, title: "podio", tipo: "table" },
@@ -17,22 +14,63 @@ export const ListTables = [
   { icon: <MesaMilitar className="relative w-max" />, title: "militar", tipo: "table" },
   { icon: <LineaBancos className="relative w-max" />, title: "bancos", tipo: "table" },
   { icon: <Banco className="relative w-max" />, title: "banco", tipo: "table" },
-
-
 ];
 
-const BlockPanelMesas: FC<propsBlockPanelMesas> = () => {
+interface propsBlockPanelMesas {
+  setShowFormEditar?: (v: { table: any; visible: boolean }) => void
+}
+
+// Rediseño fiel al prototipo (MESAS.dc.html, tab «Mesas»): LISTA de mesas creadas en el
+// plano activo (nº + nombre + "N personas" + chevron editar), en lugar del grid arrastrable
+// de tipos. La creación se unifica en el botón «＋ Añadir mesa» del canvas (TableConfigurator,
+// HANDOFF §0). Click en fila / chevron → abre el form de edición YA existente vía
+// setShowFormEditar (mismo shape que usa EditDefault). NO toca interact.js ni el estado de
+// selección del canvas.
+const BlockPanelMesas: FC<propsBlockPanelMesas> = ({ setShowFormEditar }) => {
+  const { t } = useTranslation();
+  const { planSpaceActive } = EventContextProvider()
+  const tables: any[] = planSpaceActive?.tables || []
+
+  const openEdit = (table: any) => {
+    if (setShowFormEditar) setShowFormEditar({ table, visible: true })
+  }
 
   return (
-    <>
-      <div id="listTables" className="js-dropTables bg-white w-full h-full">
-        <BlockDefault listaLength={ListTables.length}>
-          {ListTables.map((item, idx) => (
-            <DragTable key={idx} item={item} />
-          ))}
-        </BlockDefault>
+    <div id="listTables" className="w-full h-full overflow-auto flex flex-col gap-[11px] p-1">
+      <div className="flex-none text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba]">
+        {t('tablesin', 'Mesas en')} «{planSpaceActive?.title || '—'}» · <span className="text-[#EF5B94]">{tables.length}</span>
       </div>
-    </>
+
+      {tables.length === 0 &&
+        <div className="text-[11px] font-medium text-[#a0a0a8] leading-relaxed py-1">
+          {t('notablesyethint', 'Aún no hay mesas en este plano. Usa «＋ Añadir mesa» en el plano.')}
+        </div>
+      }
+
+      <div className="flex flex-col gap-[7px]">
+        {tables.map((table, idx) => {
+          const num = idx + 1
+          const name = table?.title || table?.nombre_mesa || `${t('table', 'Mesa')} ${num}`
+          const sillas = table?.numberChair ?? table?.cantidad_sillas ?? (table?.guests?.length || 0)
+          return (
+            <div
+              key={table?._id || idx}
+              onClick={() => openEdit(table)}
+              className="flex items-center gap-[11px] px-2.5 py-[9px] rounded-[11px] bg-white border border-[#f0f0f2] hover:border-[#e2e2e6] hover:bg-[#faf9fb] cursor-pointer transition-colors"
+            >
+              <div className="w-[30px] h-[30px] rounded-[9px] flex-none flex items-center justify-center bg-[#F0F0F2] border-[1.5px] border-[#E2E2E6] text-[12px] font-bold text-[#6b6b72]">{num}</div>
+              <div className="flex-1 min-w-0">
+                <div className="text-[12.5px] font-semibold text-[#3A3A42] truncate">{name}</div>
+                <div className="text-[10.5px] font-medium text-[#a0a0a8]">{sillas} {t('people', 'personas')}</div>
+              </div>
+              <div className="w-7 h-7 flex-none flex items-center justify-center text-[#c8c8ce] hover:text-[#6b6b72] transition-colors">
+                <svg className="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M9 18l6-6-6-6" /></svg>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
   );
 };
 

--- a/apps/appEventos/components/Mesas/BlockPlanos.tsx
+++ b/apps/appEventos/components/Mesas/BlockPlanos.tsx
@@ -1,17 +1,33 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { AuthContextProvider, EventContextProvider } from '../../context';
-import { HiTemplate } from 'react-icons/hi';
 import { planSpace } from '../../utils/Interfaces';
 import { fetchApiEventos, queries } from '../../utils/Fetching';
 import { useTranslation } from 'react-i18next';
 
 // Rediseño fiel al prototipo (MESAS.dc.html): lista vertical "Espacios del evento".
-// Fila = icono en cuadrado + nombre + nº de mesas + check del espacio activo.
+// Fila = icono de PLANO (SVG rect+divisiones) + nombre + "N mesas · M sentados" +
+// check rosa en el espacio activo. Colores exactos del proto (B.planos, líneas 720-727):
+//   activo → fila #FCE7F0/#f7c2da · icono #FCE7F0/#EF5B94 · check #EF5B94.
+//   inactivo → fila #fff/#f0f0f2 · icono #F0F0F2/#a0a0a8.
 // NO cambia la lógica de selección (setPlanSpaceSelect + fetchApiEventos).
+
+// Icono de plano del prototipo (no usar HiTemplate: el diseño pide este SVG concreto).
+const FloorPlanIcon: FC<{ className?: string }> = ({ className = '' }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="1.5" />
+    <path d="M3 13h5M12 13h9M15 3v4M15 11v10" />
+  </svg>
+)
+
 export const BlockPlanos: FC = () => {
   const { t } = useTranslation();
   const { event, planSpaceSelect, setPlanSpaceSelect } = EventContextProvider()
   const { user } = AuthContextProvider()
+  // Modal "Crear plano nuevo" (proto líneas 302-317). Local a este bloque.
+  const [newPlanoOpen, setNewPlanoOpen] = useState(false)
+  const [newPlanoName, setNewPlanoName] = useState('')
+  const [createNotice, setCreateNotice] = useState<string | null>(null)
+
   const handleClick = (item: planSpace) => {
     try {
       setPlanSpaceSelect(item?._id)
@@ -26,35 +42,117 @@ export const BlockPlanos: FC = () => {
     } catch {
     }
   }
+
+  // Sentados en un espacio = suma de invitados sentados en sus mesas (table.guests[]).
+  const seatedCount = (item: any): number =>
+    (item?.tables || []).reduce((n: number, tb: any) => n + (tb?.guests?.length || 0), 0)
+
+  const openNewPlano = () => {
+    setNewPlanoName('')
+    setCreateNotice(null)
+    setNewPlanoOpen(true)
+  }
+  const closeNewPlano = () => setNewPlanoOpen(false)
+  const handleCreatePlano = () => {
+    const name = newPlanoName.trim()
+    if (!name) return
+    // ⚠️ createPlanSpace NO existe en api-mcp (escalado 16-jul, sin respuesta).
+    // No se falsea el éxito (regla proyecto: no fallback / no parchear API desde front).
+    // Se informa que la creación está pendiente de backend.
+    setCreateNotice(t('createplanopending', 'La creación de espacios estará disponible en breve.'))
+  }
+
   return (
-    <div className="w-full h-full overflow-auto flex flex-col gap-2.5 p-1">
+    <div className="w-full h-full flex flex-col gap-2.5 p-1">
       <div className="flex items-center justify-between">
-        <span className="text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba]">{t("eventspaces") || "Espacios del evento"}</span>
-        <span className="text-[11px] font-semibold text-[#EF5B94]">{event?.planSpace?.length}</span>
+        <span className="text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba]">{t('eventspaces', 'Espacios del evento')}</span>
+        <span className="text-[11px] font-semibold text-[#EF5B94]">{event?.planSpace?.length || 0} {t('spaces', 'espacios')}</span>
       </div>
-      <div className="flex flex-col gap-[7px]">
+
+      <div className="flex flex-col gap-[7px] overflow-auto max-h-[340px]">
         {event?.planSpace?.map((item, idx) => {
           const active = planSpaceSelect === item?._id
+          const mesas = item?.tables?.length || 0
+          const sentados = seatedCount(item)
+          const mesasLabel = (mesas === 1 ? t('table', 'mesa') : t('tables', 'mesas')).toLowerCase()
+          const seatedLabel = t('seated', 'sentados').toLowerCase()
           return (
             <div
               key={idx}
               onClick={() => handleClick(item)}
-              className={`flex items-center gap-[11px] px-3 py-2.5 rounded-[11px] cursor-pointer border transition ${active ? "bg-[#FCF2F6] border-[#f7c2da]" : "bg-white border-[#f0f0f2] hover:border-[#e2e2e6]"}`}
+              className={`flex items-center gap-[11px] px-3 py-2.5 rounded-[11px] cursor-pointer border-[1.5px] transition ${active ? 'bg-[#FCE7F0] border-[#f7c2da]' : 'bg-white border-[#f0f0f2] hover:border-[#e2e2e6]'}`}
             >
-              <div className={`w-[30px] h-[30px] rounded-[9px] flex-none flex items-center justify-center ${active ? "bg-[#EF5B94] text-white" : "bg-[#f0f0f2] text-[#a0a0a8]"}`}>
-                <HiTemplate className="w-[17px] h-[17px]" />
+              <div className={`w-[30px] h-[30px] rounded-[9px] flex-none flex items-center justify-center ${active ? 'bg-[#FCE7F0] text-[#EF5B94]' : 'bg-[#F0F0F2] text-[#a0a0a8]'}`}>
+                <FloorPlanIcon className="w-[17px] h-[17px]" />
               </div>
               <div className="flex-1 min-w-0">
                 <div className="text-[12.5px] font-semibold text-[#3A3A42] truncate capitalize">{t(item?.title)}</div>
-                <div className="text-[10.5px] font-medium text-[#a0a0a8]">{item?.tables?.length || 0} {(t("table") || "mesas").toLowerCase()}</div>
+                <div className="text-[10.5px] font-medium text-[#a0a0a8]">{mesas} {mesasLabel} · {sentados} {seatedLabel}</div>
               </div>
               {active &&
-                <div className="w-[18px] h-[18px] rounded-full flex-none bg-[#EF5B94] text-white flex items-center justify-center text-[11px] font-bold">✓</div>
+                <div className="w-[18px] h-[18px] rounded-full flex-none bg-[#EF5B94] flex items-center justify-center">
+                  <svg className="w-[11px] h-[11px]" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
+                </div>
               }
             </div>
           )
         })}
       </div>
+
+      {/* ＋ Añadir plano — botón punteado rosa (proto línea 94) */}
+      <button
+        type="button"
+        onClick={openNewPlano}
+        className="flex-none flex items-center justify-center gap-[7px] p-[11px] rounded-[11px] bg-white border-[1.5px] border-dashed border-[#f0aecb] text-[#EF5B94] text-[12.5px] font-semibold cursor-pointer hover:bg-[#FCF2F6] transition-colors"
+      >
+        <span className="text-[15px] leading-none">＋</span>{t('addplano', 'Añadir plano')}
+      </button>
+
+      {/* MODAL CREAR PLANO (proto líneas 302-317) */}
+      {newPlanoOpen &&
+        <div
+          onClick={closeNewPlano}
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-[rgba(43,43,48,.38)] px-4"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="w-[380px] max-w-full bg-white rounded-[18px] shadow-[0_24px_60px_rgba(0,0,0,.28)] p-6"
+          >
+            <div className="flex items-center gap-[11px] mb-[18px]">
+              <div className="w-10 h-10 rounded-[11px] flex-none bg-[#FCE7F0] text-[#EF5B94] flex items-center justify-center">
+                <FloorPlanIcon className="w-5 h-5" />
+              </div>
+              <div>
+                <div className="text-[16px] font-bold text-[#3A3A42]">{t('newplanotitle', 'Crear plano nuevo')}</div>
+                <div className="text-[11.5px] font-medium text-[#a0a0a8]">{t('newplanosubtitle', 'Un espacio para tu evento')}</div>
+              </div>
+            </div>
+            <div className="text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba] mb-2">{t('planoname', 'Nombre del plano')}</div>
+            <input
+              type="text"
+              value={newPlanoName}
+              autoFocus
+              onChange={(e) => setNewPlanoName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleCreatePlano(); if (e.key === 'Escape') closeNewPlano() }}
+              placeholder={t('planonameplaceholder', 'Ej. Jardín, Cóctel, Terraza…')}
+              className="w-full p-3 rounded-[11px] border-[1.5px] border-[#E7E7EA] focus:border-[#EF5B94] outline-none bg-white text-[13px] font-medium text-[#3A3A42]"
+            />
+            {createNotice &&
+              <div className="mt-3 bg-[#FCF2F6] border border-[#f7c2da] rounded-[999px] px-4 py-2 text-[11px] font-medium text-[#c14a78]">{createNotice}</div>
+            }
+            <div className="flex gap-[11px] justify-end mt-[22px]">
+              <button type="button" onClick={closeNewPlano} className="px-5 py-[11px] rounded-[11px] bg-[#f7f7f9] text-[#6b6b72] text-[12.5px] font-semibold">{t('cancel', 'Cancelar')}</button>
+              <button
+                type="button"
+                onClick={handleCreatePlano}
+                className={`px-6 py-[11px] rounded-[11px] text-white text-[12.5px] font-semibold whitespace-nowrap shadow-[0_6px_16px_rgba(239,91,148,.28)] ${newPlanoName.trim() ? 'bg-[#EF5B94]' : 'bg-[#f0aecb]'}`}
+              >
+                {t('createplano', 'Crear plano')}
+              </button>
+            </div>
+          </div>
+        </div>
+      }
     </div>
   )
 }

--- a/apps/appEventos/components/Mesas/DragTable.tsx
+++ b/apps/appEventos/components/Mesas/DragTable.tsx
@@ -50,7 +50,7 @@ interface propsDragTable {
 const DragTable: FC<propsDragTable> = ({ item }) => {
 
   return (
-    <div className="w-14 h-14 static border-[1px] border-gray-300 hover:border-gray-400 rounded-lg">
+    <div className="w-14 h-14 static bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors">
       <div id={`icon${item.title}_${item.tipo}`} className="hidden">
         <div className="bg-gray-100 opacity-80 rounded-lg w-16 h-16 flex justify-center items-center">
           <SvgWrapper

--- a/apps/appEventos/components/Utils/SubMenu.tsx
+++ b/apps/appEventos/components/Utils/SubMenu.tsx
@@ -1,33 +1,19 @@
-import { InvitadosIcon, MesaIcon } from "../icons"
-import { GiGrandPiano } from 'react-icons/gi';
-import { HiDocumentReport, HiTemplate } from 'react-icons/hi';
 import { useTranslation } from "react-i18next";
 
 // Barra de pestañas del módulo Mesas. Rediseño fiel al prototipo (MESAS.dc.html):
-// tabs de icono + texto sobre fondo blanco, la activa con subrayado rosa marca.
+// tabs de SOLO texto (SIN iconos) sobre fondo blanco. La activa en rosa marca
+// (#EF5B94) con subrayado rosa 2.5px; las inactivas en gris #9a9aa2 sin subrayado.
+// Fuente 600 10.5px (spec exacto del proto, líneas 74-76 y B.tabs 712-716).
 // IMPORTANTE: NO cambiar los `title` (son los `itemSelect==` que enrutan el panel
 // en pages/mesas.tsx) ni la altura del contenedor (h-10 alimenta el calc del panel).
 const sutMenus = [
-  {
-    title: "invitados",
-    icon: <InvitadosIcon className="w-[18px] h-[18px]" />,
-  },
-  {
-    title: "planos",
-    icon: <HiTemplate className="w-[18px] h-[18px]" />,
-  },
-  {
-    title: "mesas",
-    icon: <MesaIcon className="w-[18px] h-[18px]" />,
-  },
-  {
-    title: "mobiliario",
-    icon: <GiGrandPiano className="w-[18px] h-[18px]" />,
-  },
-  {
-    title: "resumen",
-    icon: <HiDocumentReport className="w-[18px] h-[18px]" />,
-  },
+  // `invitados` solo se muestra en móvil (md:hidden); en desktop Invitados es el
+  // bloque colapsable inferior, por eso el proto solo tiene 4 tabs visibles.
+  { title: "invitados" },
+  { title: "planos" },
+  { title: "mesas" },
+  { title: "mobiliario" },
+  { title: "resumen" },
 ]
 
 
@@ -48,12 +34,11 @@ export const SubMenu = ({ itemSelect, setItemSelect }) => {
             type="button"
             onClick={() => handleClick(elem)}
             title={t(elem?.title)}
-            className={`flex-1 min-w-0 flex flex-col items-center justify-center gap-0.5 border-b-[2.5px] -mb-px transition-colors
+            className={`flex-1 min-w-0 flex items-center justify-center border-b-[2.5px] -mb-px transition-colors
               ${active ? "border-[#EF5B94]" : "border-transparent"}
               ${elem?.title === "invitados" ? "md:hidden" : ""}`}
           >
-            <span className={active ? "text-[#EF5B94]" : "text-[#a0a0a8]"}>{elem?.icon}</span>
-            <span className={`text-[10px] font-semibold capitalize leading-none truncate max-w-full ${active ? "text-[#EF5B94]" : "text-[#6b6b72]"}`}>{t(elem?.title)}</span>
+            <span className={`text-[10.5px] font-semibold capitalize leading-none truncate max-w-full ${active ? "text-[#EF5B94]" : "text-[#9a9aa2]"}`}>{t(elem?.title)}</span>
           </button>
         )
       })}

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -267,7 +267,7 @@ const Mesas: FC = () => {
                           <BlockInvitados set={setIsMounted} setEditInv={setEditInv} editInv={editInv} setSelected={setSelected} />
                         }
                         {itemSelect == "mesas" &&
-                          <BlockPanelMesas />
+                          <BlockPanelMesas setShowFormEditar={setShowFormEditar} />
                         }
                         {itemSelect == "mobiliario" &&
                           <BlockPanelElements listElements={listElements} setListElements={setListElements} />


### PR DESCRIPTION
## Rediseño sidebar Mesas fiel a MESAS.dc.html (6 archivos, +243/-110)

- **SubMenu**: tabs SOLO texto (sin iconos), activa rosa #EF5B94 + subrayado, inactivas #9a9aa2 (spec exacto proto)
- **BlockPlanos**: icono de plano (SVG del proto), colores fieles (#FCE7F0 activo), meta «N mesas · M sentados», contador «N espacios», botón «＋ Añadir plano» + modal «Crear plano nuevo» (la creación real muestra aviso honesto — pendiente `createPlanSpace` backend, re-escalado 4ª vez Slack ts 1784755511)
- **BlockPanelElements (Mobiliario)**: pastilla aviso rosa + header «Elementos decorativos» + modal «Añadir SVG» en paleta rosa (lógica createGalerySvgs intacta) + tile punteado
- **BlockPanelMesas (tab Mesas)**: grid arrastrable de tipos → LISTA de mesas creadas (nº+nombre+«N personas»+chevron); click → form edición existente vía setShowFormEditar. Creación unificada en botón «＋ Añadir mesa» del canvas (HANDOFF §0). `export ListTables` conservado (mesas.tsx:172)
- **DragTable**: tile tarjeta soft #faf9fb (solo CSS, motor de arrastre intacto)

### Verificado
- ESLint 0 en los 6 · build prod OK (BUILD_ID KuMm1TQHYoR7f2wsOfeBd) · desplegado y sirviendo en app-dev
- Motor interact.js NO tocado (IDs/clases/handlers intactos)

### QA manual pendiente
- Click fila lista Mesas abre editor y guarda
- Crear mesa por botón canvas OK · drag mesas/invitados sin regresión
- Nota: tipos exóticos (militar/bancos/banco) ya no se crean directo (mapeo formas del diseño aprobado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)