### PR TITLE
✨ A4 cuentas vinculadas (Perfil) + R2 conversaciones cross-canal del contacto (Bandeja)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/[conversation_id]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/[conversation_id]/page.tsx
@@ -6,6 +6,7 @@ import { ConversationList } from '../../components/ConversationList';
 import { MessageList } from '../../components/MessageList';
 import { MessageInput } from '../../components/MessageInput';
 import { ConversationHeader } from '../../components/ConversationHeader';
+import { ContactConversationsPanel } from '../../components/ContactConversationsPanel';
 import { ConversationNotesSidebar } from '../../components/ConversationNotesSidebar';
 import { EventSidebar } from '../../components/EventSidebar';
 import { TaskDetailWorkspace } from '../../components/TaskDetailWorkspace';
@@ -78,7 +79,7 @@ export default function ConversationPage({ params }: ConversationPageProps) {
     <>
       <div
         className="hidden w-[300px] shrink-0 overflow-auto md:block"
-        style={{ borderRight: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+        style={{ backgroundColor: '#FFFFFF', borderRight: '1px solid #EDEDF0' }}
       >
         <ConversationList channel={channel} selectedId={conversation_id} />
       </div>
@@ -115,8 +116,8 @@ export default function ConversationPage({ params }: ConversationPageProps) {
           <ConversationHeader
             channel={channel}
             conversationId={conversation_id}
-            onSearchFilter={setSearchFilter}
             detailsOpen={sidebarExpanded}
+            onSearchFilter={setSearchFilter}
             onToggleDetails={toggleSidebar}
           />
         </div>
@@ -139,26 +140,38 @@ export default function ConversationPage({ params }: ConversationPageProps) {
       {sidebarExpanded && (
         <aside
           className="hidden w-[280px] shrink-0 overflow-hidden lg:flex lg:flex-col"
-          style={{ borderLeft: '1px solid #EDEDF0', backgroundColor: '#FFFFFF' }}
+          style={{ backgroundColor: '#FFFFFF', borderLeft: '1px solid #EDEDF0' }}
         >
-          {conv?.linkedEventId ? (
-            <EventSidebar
-              conversationId={conversation_id}
-              contactName={conv.contact?.name}
-              contactPhone={conv.contact?.phone}
-              linkedContactId={conv.linkedContactId}
-              linkedEventId={conv.linkedEventId}
-              channel={conv.channel ?? channel}
-              rsvpStatus={conv.guestStatus ?? undefined}
-            />
-          ) : (
-            <ConversationNotesSidebar
-              conversationId={conversation_id}
-              contactName={conv?.contact?.name}
-              linkedContactId={conv?.linkedContactId}
-              linkedEventId={conv?.linkedEventId}
-              channel={conv?.channel ?? channel}
-            />
+          <div className="min-h-0 flex-1 overflow-auto">
+            {conv?.linkedEventId ? (
+              <EventSidebar
+                channel={conv.channel ?? channel}
+                contactName={conv.contact?.name}
+                contactPhone={conv.contact?.phone}
+                conversationId={conversation_id}
+                linkedContactId={conv.linkedContactId}
+                linkedEventId={conv.linkedEventId}
+                rsvpStatus={conv.guestStatus ?? undefined}
+              />
+            ) : (
+              <ConversationNotesSidebar
+                channel={conv?.channel ?? channel}
+                contactName={conv?.contact?.name}
+                conversationId={conversation_id}
+                linkedContactId={conv?.linkedContactId}
+                linkedEventId={conv?.linkedEventId}
+              />
+            )}
+          </div>
+          {/* R2 (23-jul): conversaciones cross-canal/cross-evento del contacto. */}
+          {conv?.linkedContactId && (
+            <div className="max-h-[45%] flex-none overflow-auto">
+              <ContactConversationsPanel
+                contactId={conv.linkedContactId}
+                contactName={conv.contact?.name}
+                currentConversationId={conversation_id}
+              />
+            </div>
           )}
         </aside>
       )}
@@ -166,28 +179,36 @@ export default function ConversationPage({ params }: ConversationPageProps) {
       {/* Bottom sheet móvil 75% con sidebar info contacto.
           El sidebar derecho lateral NO existe en móvil (Diseño 24-jun). */}
       <BottomSheet
-        open={infoSheetOpen}
         onClose={() => setInfoSheetOpen(false)}
+        open={infoSheetOpen}
         title={conv?.contact?.name ?? 'Detalles de la conversación'}
       >
         {conv?.linkedEventId ? (
           <EventSidebar
-            conversationId={conversation_id}
+            channel={conv.channel ?? channel}
             contactName={conv.contact?.name}
             contactPhone={conv.contact?.phone}
+            conversationId={conversation_id}
             linkedContactId={conv.linkedContactId}
             linkedEventId={conv.linkedEventId}
-            channel={conv.channel ?? channel}
             rsvpStatus={conv.guestStatus ?? undefined}
           />
         ) : (
           <ConversationNotesSidebar
-            conversationId={conversation_id}
-            contactName={conv?.contact?.name}
-            linkedContactId={conv?.linkedContactId}
-            linkedEventId={conv?.linkedEventId}
             channel={conv?.channel ?? channel}
             compact
+            contactName={conv?.contact?.name}
+            conversationId={conversation_id}
+            linkedContactId={conv?.linkedContactId}
+            linkedEventId={conv?.linkedEventId}
+          />
+        )}
+        {/* R2 (23-jul): también en móvil, bajo las notas del sheet. */}
+        {conv?.linkedContactId && (
+          <ContactConversationsPanel
+            contactId={conv.linkedContactId}
+            contactName={conv.contact?.name}
+            currentConversationId={conversation_id}
           />
         )}
       </BottomSheet>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ContactConversationsPanel.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ContactConversationsPanel.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+/**
+ * ContactConversationsPanel — R2 (23-jul): conversaciones cross-canal y
+ * cross-evento del CONTACTO (diseño PLAN-CHAT-IA-REDISENO, caso "Carmen":
+ * un contacto único con N conversaciones agrupadas por scope Marca/Evento).
+ *
+ * Fuente: api-mcp `getContactConversations(contactId, developerId)` (pieza R2
+ * verificada implementada 23-jul). Se muestra bajo el sidebar derecho de la
+ * conversación cuando la conv tiene linkedContactId.
+ *
+ * Nota backend pendiente (reportado): el tipo GraphQL WhatsAppConversation NO
+ * expone `channel` → mientras tanto se navega con el canal por defecto
+ * 'whatsapp' (hoy todos los docs de esa colección lo son).
+ */
+import { gql } from '@apollo/client';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { getCurrentDevelopment } from '@/utils/developmentDetector';
+import { apolloClient } from '@/libs/graphql/client';
+
+import { ChannelBadge } from './ChannelBadge';
+
+const GET_CONTACT_CONVERSATIONS = gql`
+  query GetContactConversations($contactId: ID!, $developerId: String, $limit: Int) {
+    getContactConversations(contactId: $contactId, developerId: $developerId, limit: $limit) {
+      success
+      total
+      conversations {
+        id
+        phoneNumber
+        contactInfo {
+          name
+        }
+        status
+        lastMessageAt
+        messageCount
+        unread_count_for_agent
+        linked_event_id
+        guestStatus
+      }
+      errors {
+        message
+      }
+    }
+  }
+`;
+
+interface ContactConversation {
+  contactInfo?: { name?: string | null } | null;
+  guestStatus?: string | null;
+  id: string;
+  lastMessageAt?: string | null;
+  linked_event_id?: string | null;
+  messageCount?: number | null;
+  phoneNumber?: string | null;
+  status?: string | null;
+  unread_count_for_agent?: number | null;
+}
+
+interface ContactConversationsPanelProps {
+  contactId: string;
+  contactName?: string;
+  /** Conversación abierta ahora — se marca como "Actual" y no navega. */
+  currentConversationId: string;
+}
+
+function relativeTime(iso?: string | null): string {
+  if (!iso) return '';
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return '';
+  const mins = Math.floor((Date.now() - ts) / 60_000);
+  if (mins < 1) return 'ahora';
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+// Dot de RSVP (mismo código de color que ConversationItem / EventSidebar).
+const RSVP_DOT: Record<string, string> = {
+  confirmed: '#22C55E',
+  declined: '#EF4444',
+  pending: '#F59E0B',
+};
+
+export function ContactConversationsPanel({
+  contactId,
+  contactName,
+  currentConversationId,
+}: ContactConversationsPanelProps) {
+  const router = useRouter();
+  const [conversations, setConversations] = useState<ContactConversation[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data } = await apolloClient.query<{
+          getContactConversations: {
+            conversations: ContactConversation[];
+            errors?: { message: string }[] | null;
+            success: boolean;
+          };
+        }>({
+          fetchPolicy: 'network-only',
+          query: GET_CONTACT_CONVERSATIONS,
+          variables: {
+            contactId,
+            developerId: getCurrentDevelopment(),
+            limit: 20,
+          },
+        });
+        if (cancelled) return;
+        const res = data?.getContactConversations;
+        if (!res?.success) throw new Error(res?.errors?.[0]?.message || 'error');
+        setConversations(res.conversations ?? []);
+        setLoadError(null);
+      } catch (error: any) {
+        if (cancelled) return;
+        setConversations([]);
+        setLoadError(error?.message || 'error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [contactId]);
+
+  if (conversations === null) {
+    return (
+      <div className="px-4 py-3 text-xs text-gray-400">Cargando conversaciones del contacto…</div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="px-4 py-3 text-xs text-gray-400">
+        No se pudieron cargar las conversaciones del contacto.
+      </div>
+    );
+  }
+
+  // Agrupación por scope (diseño "Carmen"): Marca/Soporte (sin evento) vs Evento.
+  const marca = conversations.filter((c) => !c.linked_event_id);
+  const porEvento = new Map<string, ContactConversation[]>();
+  for (const c of conversations) {
+    if (!c.linked_event_id) continue;
+    const list = porEvento.get(c.linked_event_id) ?? [];
+    list.push(c);
+    porEvento.set(c.linked_event_id, list);
+  }
+
+  const renderRow = (c: ContactConversation) => {
+    const isCurrent = c.id === currentConversationId;
+    const name = c.contactInfo?.name || c.phoneNumber || c.id;
+    const unread = c.unread_count_for_agent ?? 0;
+    const rsvpColor = c.guestStatus ? RSVP_DOT[c.guestStatus] : undefined;
+    return (
+      <button
+        className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors ${
+          isCurrent ? 'cursor-default bg-gray-100' : 'hover:bg-gray-50'
+        }`}
+        disabled={isCurrent}
+        key={c.id}
+        onClick={() => {
+          // channel no expuesto aún por api-mcp (ver docstring) → whatsapp.
+          if (!isCurrent) router.push(`/bandeja/whatsapp/${c.id}`);
+        }}
+        type="button"
+      >
+        <ChannelBadge channel="whatsapp" size="sm" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-xs font-medium text-gray-700">
+            {name}
+            {isCurrent && <span className="ml-1 text-[10px] font-normal text-gray-400">· actual</span>}
+          </span>
+          <span className="block text-[10px] text-gray-400">
+            {c.messageCount ?? 0} msjs · {relativeTime(c.lastMessageAt)}
+          </span>
+        </span>
+        {rsvpColor && (
+          <span
+            className="h-2 w-2 flex-none rounded-full"
+            style={{ backgroundColor: rsvpColor }}
+            title={`RSVP: ${c.guestStatus}`}
+          />
+        )}
+        {unread > 0 && (
+          <span className="flex-none rounded-full bg-rose-500 px-1.5 text-[10px] font-semibold leading-4 text-white">
+            {unread}
+          </span>
+        )}
+      </button>
+    );
+  };
+
+  return (
+    <div className="border-t border-gray-100 px-2 py-3">
+      <div className="mb-2 px-2 text-[11px] font-bold uppercase tracking-wider text-gray-400">
+        Conversaciones de {contactName || 'este contacto'} ({conversations.length})
+      </div>
+
+      {conversations.length === 0 && (
+        <div className="px-2 text-xs text-gray-400">Sin más conversaciones registradas.</div>
+      )}
+
+      {marca.length > 0 && (
+        <div className="mb-2">
+          <div className="px-2 text-[10px] font-semibold uppercase text-gray-300">
+            Marca / Soporte
+          </div>
+          {marca.map(renderRow)}
+        </div>
+      )}
+
+      {[...porEvento.entries()].map(([eventId, list]) => (
+        <div className="mb-2" key={eventId}>
+          <div className="px-2 text-[10px] font-semibold uppercase text-gray-300">
+            Evento ·{eventId.slice(-6)}
+          </div>
+          {list.map(renderRow)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/chat-ia/src/app/[variants]/(main)/profile/(home)/Client.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/profile/(home)/Client.tsx
@@ -12,9 +12,10 @@ import UserAvatar from '@/features/User/UserAvatar';
 import { useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
-// SPRINT-N 2026-05-19 — migración Clerk-out:
-// SSOProvidersList era una UI que mostraba providers NextAuth (Google, GitHub, etc).
-// bodasdehoy usa Firebase via api-ia → no se renderiza ningún provider list.
+// SPRINT-N 2026-05-19 — migración Clerk-out: la SSOProvidersList de NextAuth se borró.
+// A4 23-jul: recreada contra api-mcp (getUserSSOProviders/unlinkSSOProvider) — muestra
+// las cuentas Firebase vinculadas del usuario Bodas (Google, Facebook, password…).
+import SSOProvidersList from './features/SSOProvidersList';
 
 const Client = memo<{ mobile?: boolean }>(({ mobile }) => {
   const [isLoginWithNextAuth, isLogin] = useUserStore((s) => [
@@ -60,7 +61,12 @@ const Client = memo<{ mobile?: boolean }>(({ mobile }) => {
         label: t('profile.email'),
         name: 'email',
       },
-      // SPRINT-N 2026-05-19: SSOProvidersList eliminado (NextAuth fuera).
+      {
+        children: <SSOProvidersList />,
+        label: t('profile.sso.title', 'Cuentas vinculadas'),
+        layout: 'vertical',
+        minWidth: undefined,
+      },
     ],
     title: t('tab.profile'),
   };

--- a/apps/chat-ia/src/app/[variants]/(main)/profile/(home)/features/SSOProvidersList/index.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/profile/(home)/features/SSOProvidersList/index.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+/**
+ * A4 (23-jul) — Cuentas vinculadas del usuario Bodas (Firebase via api-mcp).
+ *
+ * Sustituye a la antigua SSOProvidersList de NextAuth (borrada en C8, commit
+ * 61b44df0): misma ubicación en Perfil, pero la fuente ahora es api-mcp GraphQL
+ * (getUserSSOProviders / unlinkSSOProvider), que lee los providerData del
+ * usuario Firebase del tenant. Identidad = JWT Bodas (Authorization del
+ * apolloClient → proxy /api/graphql → api-mcp context.user).
+ */
+import { gql } from '@apollo/client';
+import { ActionIcon, List } from '@lobehub/ui';
+import { Skeleton } from 'antd';
+import { Unlink } from 'lucide-react';
+import { memo, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Flexbox } from 'react-layout-kit';
+
+import { modal, notification } from '@/components/AntdStaticMethods';
+import AuthIcons from '@/components/NextAuth/AuthIcons';
+import { apolloClient } from '@/libs/graphql/client';
+
+const { Item } = List;
+
+interface SSOProvider {
+  displayName?: string | null;
+  email?: string | null;
+  phoneNumber?: string | null;
+  photoURL?: string | null;
+  providerId: string;
+  uid?: string | null;
+}
+
+const GET_USER_SSO_PROVIDERS = gql`
+  query GetUserSSOProviders {
+    getUserSSOProviders {
+      providerId
+      uid
+      email
+      displayName
+      photoURL
+      phoneNumber
+    }
+  }
+`;
+
+const UNLINK_SSO_PROVIDER = gql`
+  mutation UnlinkSSOProvider($providerId: String!) {
+    unlinkSSOProvider(providerId: $providerId) {
+      providerId
+      uid
+      email
+      displayName
+      photoURL
+      phoneNumber
+    }
+  }
+`;
+
+// providerId de Firebase → clave de icono de AuthIcons + etiqueta legible.
+const PROVIDER_META: Record<string, { icon: string; label: string }> = {
+  'facebook.com': { icon: 'default', label: 'Facebook' },
+  'google.com': { icon: 'google', label: 'Google' },
+  'password': { icon: 'default', label: 'Email y contraseña' },
+  'phone': { icon: 'default', label: 'Teléfono' },
+};
+
+const providerMeta = (providerId: string) =>
+  PROVIDER_META[providerId] ?? { icon: 'default', label: providerId };
+
+export const SSOProvidersList = memo(() => {
+  const { t } = useTranslation('auth');
+  const [providers, setProviders] = useState<SSOProvider[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const { data, errors } = await apolloClient.query<{ getUserSSOProviders: SSOProvider[] }>({
+        fetchPolicy: 'network-only',
+        query: GET_USER_SSO_PROVIDERS,
+      });
+      if (errors?.length) throw new Error(errors[0].message);
+      setProviders(data?.getUserSSOProviders ?? []);
+      setLoadError(null);
+    } catch (error: any) {
+      // Sin sesión Bodas (UNAUTHENTICATED) u otro fallo: no romper el Perfil.
+      setProviders([]);
+      setLoadError(error?.message || 'error');
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const allowUnlink = (providers?.length ?? 0) > 1;
+
+  const handleUnlink = useCallback(
+    (provider: SSOProvider) => {
+      const { label } = providerMeta(provider.providerId);
+      if (!allowUnlink) {
+        // Debe quedar al menos una forma de iniciar sesión.
+        notification.error({
+          message: t(
+            'profile.sso.unlink.forbidden',
+            'No puedes desvincular tu único método de acceso.',
+          ),
+        });
+        return;
+      }
+      modal.confirm({
+        content: t(
+          'profile.sso.unlink.description',
+          `Dejarás de poder iniciar sesión con ${label} (${provider.email || provider.phoneNumber || provider.uid || ''}). Podrás volver a vincularla iniciando sesión con ese método.`,
+        ),
+        okButtonProps: { danger: true },
+        onOk: async () => {
+          try {
+            const { data, errors } = await apolloClient.mutate<{
+              unlinkSSOProvider: SSOProvider[];
+            }>({
+              mutation: UNLINK_SSO_PROVIDER,
+              variables: { providerId: provider.providerId },
+            });
+            if (errors?.length) throw new Error(errors[0].message);
+            // La mutation devuelve la lista actualizada — fuente de verdad.
+            setProviders(data?.unlinkSSOProvider ?? []);
+            notification.success({
+              message: t('profile.sso.unlink.success', `${label} desvinculada.`),
+            });
+          } catch (error: any) {
+            notification.error({
+              message: t(
+                'profile.sso.unlink.error',
+                `No se pudo desvincular ${label}: ${error?.message || 'error desconocido'}`,
+              ),
+            });
+          }
+        },
+        title: t('profile.sso.unlink.title', `¿Desvincular ${label}?`),
+      });
+    },
+    [allowUnlink, t],
+  );
+
+  if (providers === null) return <Skeleton active paragraph={{ rows: 2 }} title={false} />;
+
+  if (providers.length === 0)
+    return (
+      <Flexbox style={{ color: '#84848F', fontSize: 12 }}>
+        {loadError
+          ? t('profile.sso.loadError', 'No se pudieron cargar tus cuentas vinculadas.')
+          : t('profile.sso.empty', 'Sin cuentas vinculadas.')}
+      </Flexbox>
+    );
+
+  return (
+    <Flexbox>
+      {providers.map((item) => {
+        const { icon, label } = providerMeta(item.providerId);
+        return (
+          <Item
+            actions={
+              <ActionIcon
+                disabled={!allowUnlink}
+                icon={Unlink}
+                onClick={() => handleUnlink(item)}
+                size={'small'}
+                title={
+                  allowUnlink
+                    ? t('profile.sso.unlink.action', 'Desvincular')
+                    : t(
+                        'profile.sso.unlink.forbidden',
+                        'No puedes desvincular tu único método de acceso.',
+                      )
+                }
+              />
+            }
+            avatar={
+              item.photoURL ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  alt={label}
+                  src={item.photoURL}
+                  style={{ borderRadius: '50%', height: 36, width: 36 }}
+                />
+              ) : (
+                AuthIcons(icon)
+              )
+            }
+            description={item.email || item.phoneNumber || item.uid || undefined}
+            key={item.providerId}
+            showAction
+            title={label}
+          />
+        );
+      })}
+    </Flexbox>
+  );
+});
+
+SSOProvidersList.displayName = 'SSOProvidersList';
+
+export default SSOProvidersList;


### PR DESCRIPTION
## A4 — Cuentas vinculadas (recreada tras C8)
- `SSOProvidersList` nueva contra api-mcp (`getUserSSOProviders`/`unlinkSSOProvider`, verificados en su schema por SSH)
- Lista providers Firebase con avatar/label, unlink con confirmación y guard (no desvincular el único método)
- Integrada en Perfil → grupo «Cuentas vinculadas»; degrada honesto sin sesión

## R2 — Contacto cross-canal (caso «Carmen» del diseño)
- `ContactConversationsPanel`: `getContactConversations(contactId)` → agrupadas por scope **Marca/Soporte** vs **Evento**, RSVP dot, unread, «actual», navegación al hacer clic
- Montado en sidebar derecho (desktop) y bottom sheet (móvil), solo si la conversación tiene `linkedContactId`

## Calidad
- eslint 0 errores (4 ficheros) · tests bandeja 8/8 ✅

⚠️ Gap backend reportable: `WhatsAppConversation` no expone `channel` en GraphQL → navegación asume whatsapp hasta que api-mcp lo añada (1 línea de schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)