### PR TITLE
💄 feat(appEventos/mesas): rediseño canvas + Mobiliario fiel al HTML (beige · 6 cards+iconos · resize/borrar on-element · barra flotante · lock)

### DIFF
--- a/apps/appEventos/components/Mesas/BlockPanelElements.tsx
+++ b/apps/appEventos/components/Mesas/BlockPanelElements.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import BlockDefault from "./BlockDefault";
 import DragTable from "./DragTable"
 import SvgFromString from '../SvgFromString';
 import { getSvgOptimizationInfo, SVG_SIZE_LIMITS } from '../../utils/svgSizeUtils';
@@ -10,7 +9,7 @@ import { EventContextProvider } from "../../context";
 import { useToast } from "../../hooks/useToast";
 import { GalerySvg } from "../../utils/Interfaces";
 import { convertBackendSvgsToReact } from "../../pages/mesas";
-import { CiText } from "react-icons/ci";
+import { FURNITURE } from "./furnitureIcons";
 
 interface propsBlockPanelElements {
   listElements: GalerySvg[]
@@ -232,34 +231,35 @@ const BlockPanelElements: FC<propsBlockPanelElements> = ({ listElements, setList
         </div>
         {/* Cabecera de sección */}
         <div className="flex-none text-[11px] font-bold tracking-wider uppercase text-[#b3b3ba] mb-[10px]">Elementos decorativos</div>
-        {/* Grid — BlockDefault + DragTable preservan el motor de arrastre (NO tocar IDs/js-dragDefault) */}
-        <div className="flex-1 min-h-0">
-          <BlockDefault listaLength={listElements.length}>
-            <DragTable item={{
-              size: { width: 60, height: 120 },
-              tipo: "text",
-              title: "",
-              icon: <CiText className="w-8 h-8 text-gray-400" />
-            }} />
-            {listElements.map((item, idx) => (
-              <DragTable key={idx} item={item} />
+        {/* Grid 3-col de tarjetas fiel al HTML. DragTable conserva el motor de arrastre
+            (mismos IDs #dragN/#icon + js-dragDefault + handlers); `label` = modo tarjeta. */}
+        <div className="flex-1 min-h-0 overflow-auto">
+          <div className="grid grid-cols-3 gap-[9px] content-start">
+            {/* 6 elementos base del HTML: Texto · Árbol · Planta · Cabina DJ · Arco · Piano */}
+            {FURNITURE.map((f) => {
+              const isText = f.model === 'text'
+              const item = {
+                icon: <f.Icon />,
+                title: isText ? '' : f.model,
+                tipo: isText ? 'text' : 'element',
+                size: f.size,
+              } as GalerySvg
+              return <DragTable key={f.model} item={item} label={f.label} />
+            })}
+            {/* SVGs personalizados subidos por el usuario (galery, tienen _id) */}
+            {listElements.filter((el) => (el as any)?._id).map((item, idx) => (
+              <DragTable key={(item as any)._id || idx} item={item} label={item.title} />
             ))}
-            {/* Añadir SVG — tile punteado rosa; abre el modal real (createGalerySvgs). Es un botón, no un draggable. */}
+            {/* Añadir SVG — tarjeta punteada; abre el modal real (createGalerySvgs) */}
             <div
               id="added-svg"
               onClick={() => { setShowModal(true) }}
-              className="w-14 h-14 flex flex-col items-center justify-center gap-1 rounded-[12px] bg-white border-[1.5px] border-dashed border-[#f0aecb] cursor-pointer hover:bg-[#FCF2F6] transition-colors"
+              className="w-full flex flex-col items-center justify-center gap-1.5 py-3 px-1 rounded-[12px] bg-white border-[1.5px] border-dashed border-[#f0aecb] cursor-pointer hover:bg-[#FCF2F6] transition-colors"
             >
               <span className="text-[#EF5B94] text-[18px] leading-none">＋</span>
-              <span className="text-[9px] font-semibold text-[#EF5B94] leading-none">SVG</span>
+              <span className="text-[10px] font-semibold text-[#EF5B94] text-center leading-tight">Añadir SVG</span>
             </div>
-            <style>{`
-              .listTables {
-                touch - action: none;
-                user-select: none;
-              }
-            `}</style>
-          </BlockDefault>
+          </div>
         </div>
       </div>
     </>

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -107,21 +107,25 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
           </div>
         </div>
         <div className="flex text-red items-center pr-2 md:pr-3 gap-1 md:gap-2">
-          {/* Rediseño Fase D: exportar el plano a PDF (croquis + invitados por mesa). */}
-          <mdIcons.MdPictureAsPdf
-            title={t('exportpdf') || 'Exportar PDF'}
-            className="w-6 h-6 cursor-pointer text-primary"
-            onClick={() => {
-              const ok = exportPlanoPdf({ planSpaceActive, event, planoTitle: t(planSpaceActive?.title) })
-              if (!ok) toast('error', t('popupblocked') || 'Permite las ventanas emergentes para exportar el PDF')
-            }}
-          />
+          {/* PDF suelto eliminado para un plano más limpio: ahora "Exportar PDF" vive
+              DENTRO del menú del icono de descargas (abajo). */}
           <ClickAwayListener onClickAway={() => setShowMiniMenu(false)}>
             <div>
               <MdSaveAlt className="h-6 w-6 cursor-pointer text-primary" onClick={() => { !isAllowed() ? ht() : setShowMiniMenu(!showMiniMenu) }} />
               {showMiniMenu &&
                 <div className="bg-white flex flex-col absolute z-[50] top-8 right-18 rounded-b-md shadow-md items-center text-[9px] px-3 pt-1 pb-3 text-gray-800 gap-y-2">
                   <div className="bg-white flex flex-col absolute z-[10] top-[0px] right-0 rounded-b-md shadow-md min-w-[140px] md:min-w-[120px] items-center text-[10px] md:text-[12px] px-3 pt-1 pb-2 text-gray-800">
+                    {/* Exportar PDF — movido aquí desde el icono suelto (plano más limpio) */}
+                    <button
+                      onClick={() => {
+                        setShowMiniMenu(false)
+                        const ok = exportPlanoPdf({ planSpaceActive, event, planoTitle: t(planSpaceActive?.title) })
+                        if (!ok) toast('error', t('popupblocked') || 'Permite las ventanas emergentes para exportar el PDF')
+                      }}
+                      className="w-full flex items-center gap-2 text-left font-semibold py-1.5 mb-1 border-b border-gray-100 hover:text-primary"
+                    >
+                      <mdIcons.MdPictureAsPdf className="w-4 h-4 text-primary" />{t('exportpdf') || 'Exportar PDF'}
+                    </button>
                     <span className="w-full text-left font-bold transform -ml-2">{t("savetemplate")}</span>
                     <span className="flex flex-col text-[9px] md:text-[11px]">
                       <span className="capitalize">{t("names")}</span>
@@ -203,23 +207,27 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
       </div>
       {/* <Cuadricula className="w-100 h-100 text-black" /> */}
       <TransformComponent
-        wrapperStyle={{ width: "100%", height: "100%", background: "#F3F1EC" }}
+        wrapperStyle={{
+          width: "100%",
+          height: "100%",
+          // Fiel al prototipo MESAS.dc.html: la RETÍCULA es un fondo ESTÁTICO que llena TODO
+          // el viewport (no solo la caja del plano). Beige #F3F1EC + líneas #E4E1D8, 44px.
+          background: "#F3F1EC",
+          backgroundImage:
+            "linear-gradient(#E4E1D8 1px, transparent 1px), linear-gradient(90deg, #E4E1D8 1px, transparent 1px)",
+          backgroundSize: "44px 44px",
+        }}
         contentStyle={{
           width: `${lienzo?.width}px`,
           height: `${lienzo?.height}px`,
-          // Fiel al prototipo MESAS.dc.html: plano beige #F3F1EC + retícula #E4E1D8.
-          // (1 m = 100px, coherente con el tamaño del lienzo). Wrapper también beige para
-          // que se vea completo en pantalla (antes era "gray" → borde gris alrededor).
-          backgroundColor: "#F3F1EC",
-          backgroundImage:
-            "linear-gradient(#E4E1D8 1px, transparent 1px), linear-gradient(90deg, #E4E1D8 1px, transparent 1px)",
-          backgroundSize: "100px 100px",
+          // Transparente: deja ver la retícula estática del wrapper por todo el plano
+          // (antes tenía su propia retícula acotada a la caja + borde morado).
+          background: "transparent",
         }}
       >
         <div
           id={"lienzo-drop"}
           className="js-dropTables bg-transparent lienzo flex justify-center items-center">
-          <div className="lienzo border-4 border-indigo-600"></div>
           <LiezoDragable scale={state.scale} lienzo={lienzo} setDisableWrapper={setDisableWrapper} disableDrag={disableDrag} setShowFormEditar={setShowFormEditar} />
         </div>
       </TransformComponent>

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -77,8 +77,11 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
   !reset ? handleReset(centerView) : () => { }
   return (
     < >
-      <div className="bg-white flex w-full h-8 items-center justify-between absolute z-[20] transform translate-y-[-32px] shadow-sm border-b border-[#f0f0f2] pl-1 md:pl-2">
-        <div className="flex items-center gap-1.5">
+      {/* Controles FLOTANTES sobre el plano (fiel a MESAS.dc.html): sin franja/barra, cada
+          grupo es una pastilla que flota sobre el beige. pointer-events-none en el contenedor
+          + auto en los hijos → los huecos transparentes no bloquean el lienzo. */}
+      <div className="flex w-full items-center justify-between absolute z-[20] top-2 left-0 px-2 md:px-3 gap-2 pointer-events-none [&>*]:pointer-events-auto">
+        <div className="flex items-center gap-2">
           {/* Rediseño Fase C: zoom agrupado en pastilla blanca (fiel a MESAS.dc.html).
               Mismos handlers: zoomOut/centerView(reset a ajuste)/zoomIn. */}
           <div className="flex items-center bg-white rounded-lg border border-[#f0f0f2] shadow-sm overflow-hidden h-7">
@@ -95,6 +98,10 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
           <span className={`${disableDrag ? "block" : "hidden"}  `} onClick={() => { toast("error", t("unlocktables")) }}>
             <Lock className="text-primary md:block h-6 w-5" />
           </span>
+          {/* Plano actual — pastilla flotante rosa marca, integrada en el grupo izq (fiel al HTML) */}
+          <div className="hidden sm:block bg-white rounded-lg shadow-sm border border-[#f0f0f2] px-3 py-1.5 text-[10px] font-semibold text-[#EF5B94] truncate max-w-[220px]">
+            {`${t("plan")}: ${t(planSpaceActive?.title)} · ${lienzo?.width / 100}×${lienzo?.height / 100} m`}
+          </div>
         </div>
         <div className="flex text-red items-center pr-2 md:pr-3 gap-1 md:gap-2">
           {/* Rediseño Fase D: exportar el plano a PDF (croquis + invitados por mesa). */}
@@ -189,13 +196,6 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
             ? <mdIcons.MdFullscreen className="w-7 h-7 cursor-pointer text-primary" onClick={() => setFullScreen(!fullScreen)} />
             : <mdIcons.MdFullscreenExit className="w-7 h-7 cursor-pointer text-primary" onClick={() => setFullScreen(!fullScreen)} />
           }
-        </div>
-      </div>
-      {/* Rediseño Fase C: etiqueta del plano en pastilla blanca (rosa marca), fiel al
-          prototipo. El % de zoom ahora vive en la pastilla de zoom de arriba. */}
-      <div className="absolute z-[10] top-1 left-2 md:left-8">
-        <div className="bg-white rounded-lg shadow-sm border border-[#f0f0f2] px-3 py-1 text-[10px] font-semibold text-[#EF5B94] truncate max-w-[240px]">
-          {`${t("plan")}: ${t(planSpaceActive?.title)} · ${lienzo?.width / 100}×${lienzo?.height / 100} m`}
         </div>
       </div>
       {/* <Cuadricula className="w-100 h-100 text-black" /> */}

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -200,16 +200,16 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
       </div>
       {/* <Cuadricula className="w-100 h-100 text-black" /> */}
       <TransformComponent
-        wrapperStyle={{ width: "100%", height: "100%", background: "gray" }}
+        wrapperStyle={{ width: "100%", height: "100%", background: "#F3F1EC" }}
         contentStyle={{
           width: `${lienzo?.width}px`,
           height: `${lienzo?.height}px`,
-          // Antes: background:"blue" (debug residual). Plano = blanco + retícula gris clara
-          // (1 m = 100px, coherente con el tamaño del lienzo). No se toca el paper.svg
-          // compartido (verde) para no afectar otras vistas (home).
-          backgroundColor: "#ffffff",
+          // Fiel al prototipo MESAS.dc.html: plano beige #F3F1EC + retícula #E4E1D8.
+          // (1 m = 100px, coherente con el tamaño del lienzo). Wrapper también beige para
+          // que se vea completo en pantalla (antes era "gray" → borde gris alrededor).
+          backgroundColor: "#F3F1EC",
           backgroundImage:
-            "linear-gradient(#e5e7eb 1px, transparent 1px), linear-gradient(90deg, #e5e7eb 1px, transparent 1px)",
+            "linear-gradient(#E4E1D8 1px, transparent 1px), linear-gradient(90deg, #E4E1D8 1px, transparent 1px)",
           backgroundSize: "100px 100px",
         }}
       >

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -37,7 +37,7 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
   const [showSetup, setShowSetup] = useState(false)
   const [showMiniMenu, setShowMiniMenu] = useState(false)
   const { user } = AuthContextProvider()
-  const { event, planSpaceActive } = EventContextProvider()
+  const { event, planSpaceActive, setEditDefault } = EventContextProvider()
   const { psTemplates, setPsTemplates } = EventsGroupContextProvider()
   const [value, setValue] = useState("")
   const [valir, setValir] = useState(true)
@@ -227,6 +227,11 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
       >
         <div
           id={"lienzo-drop"}
+          onClick={(e) => {
+            // Click en el PLANO vacío (no sobre una mesa/elemento) → deseleccionar (fiel al HTML clearSel).
+            const el = e.target as HTMLElement
+            if (!el.closest('[id^="element_"]') && !el.closest('[id^="table_"]')) setEditDefault({})
+          }}
           className="js-dropTables bg-transparent lienzo flex justify-center items-center">
           <LiezoDragable scale={state.scale} lienzo={lienzo} setDisableWrapper={setDisableWrapper} disableDrag={disableDrag} setShowFormEditar={setShowFormEditar} />
         </div>

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from "react";
-import { ButtonConstrolsLienzo } from "./ControlsLienzo";
-import { Lock, WarningIcon } from "../icons";
+import { WarningIcon } from "../icons";
 import * as mdIcons from "react-icons/md";
 import { TransformComponent } from "react-zoom-pan-pinch";
 import { LiezoDragable } from "./LienzoDragable";
@@ -89,15 +88,19 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
             <button type="button" onClick={() => centerView(scaleIni)} title={t('adjust') || 'Ajustar'} className="px-2 h-7 min-w-[46px] text-[11px] font-bold text-[#3A3A42] md:hover:bg-[#FCF2F6] transition">{Math.round((state?.previousScale || 1) * 100)}%</button>
             <button type="button" onClick={() => zoomIn(0.1)} className="w-7 h-7 flex items-center justify-center text-[#EF5B94] text-base leading-none md:hover:bg-[#FCF2F6] transition">＋</button>
           </div>
-          <ButtonConstrolsLienzo onClick={() => {
-            window.getSelection()?.removeAllRanges()
-            !isAllowed() ? ht() : handleSetDisableDrag()
-          }} pulseButton={disableDrag}>
-            <span className="text-[10px] w-28 h-6 px-1 pt-[3px]">{disableDrag ? t('unlockfloorplan') : t('lockflat')}</span>
-          </ButtonConstrolsLienzo>
-          <span className={`${disableDrag ? "block" : "hidden"}  `} onClick={() => { toast("error", t("unlocktables")) }}>
-            <Lock className="text-primary md:block h-6 w-5" />
-          </span>
+          {/* Bloquear/Desbloquear plano — pastilla flotante fiel al HTML (🔒 + texto),
+              sustituye al ButtonConstrolsLienzo con pulso + al icono Lock separado. */}
+          <button
+            type="button"
+            onClick={() => {
+              window.getSelection()?.removeAllRanges()
+              !isAllowed() ? ht() : handleSetDisableDrag()
+            }}
+            className="flex items-center gap-1.5 bg-white rounded-lg shadow-sm border border-[#f0f0f2] px-3 py-1.5 text-[12px] font-semibold text-[#3A3A42] md:hover:bg-[#FCF2F6] transition whitespace-nowrap"
+          >
+            <span className="text-[13px] leading-none">🔒</span>
+            {disableDrag ? t('unlockfloorplan') : t('lockflat')}
+          </button>
           {/* Plano actual — pastilla flotante rosa marca, integrada en el grupo izq (fiel al HTML) */}
           <div className="hidden sm:block bg-white rounded-lg shadow-sm border border-[#f0f0f2] px-3 py-1.5 text-[10px] font-semibold text-[#EF5B94] truncate max-w-[220px]">
             {`${t("plan")}: ${t(planSpaceActive?.title)} · ${lienzo?.width / 100}×${lienzo?.height / 100} m`}

--- a/apps/appEventos/components/Mesas/DragTable.tsx
+++ b/apps/appEventos/components/Mesas/DragTable.tsx
@@ -46,11 +46,16 @@ const onUp = (item: GalerySvg) => {
 
 interface propsDragTable {
   item: GalerySvg
+  /** Si se pasa, se renderiza como TARJETA con icono + nombre debajo (menú Mobiliario fiel
+   * al HTML). Los hooks de drag (#dragN/#icon/js-dragDefault/handlers) NO cambian. */
+  label?: string
 }
-const DragTable: FC<propsDragTable> = ({ item }) => {
+const DragTable: FC<propsDragTable> = ({ item, label }) => {
 
   return (
-    <div className="w-14 h-14 static bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors">
+    <div className={label
+      ? "w-full flex flex-col items-center gap-1.5 py-3 px-1 bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors cursor-grab"
+      : "w-14 h-14 static bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors"}>
       <div id={`icon${item.title}_${item.tipo}`} className="hidden">
         <div className="bg-gray-100 opacity-80 rounded-lg w-16 h-16 flex justify-center items-center">
           <SvgWrapper
@@ -63,16 +68,16 @@ const DragTable: FC<propsDragTable> = ({ item }) => {
           <PlusIcon className={`absolute inset-0 m-auto text-primary w-3 h-3`} />
         </div>
       </div>
-      <div className="w-full h-full flex-col justify-center items-center cursor-pointer relative">
-        <div className="w-full h-full flex transform hover:scale-105 transition justify-center items-center relative">
-          <div id={`dragN${item.title}_${item.tipo}`} className="js-dragDefault w-full h-12 flex justify-center items-center"
+      <div className={label ? "flex justify-center items-center text-[#EF5B94]" : "w-full h-full flex-col justify-center items-center cursor-pointer relative"}>
+        <div className={label ? "flex justify-center items-center" : "w-full h-full flex transform hover:scale-105 transition justify-center items-center relative"}>
+          <div id={`dragN${item.title}_${item.tipo}`} className={label ? "js-dragDefault w-7 h-7 flex justify-center items-center" : "js-dragDefault w-full h-12 flex justify-center items-center"}
             onMouseDown={(e) => { onMouseDown(e, item) }}
             onMouseUp={() => { onUp(item) }}
             onTouchStart={(e) => { onTouchStart(e, item) }}
             onTouchEnd={() => { onUp(item) }} >
             <SvgWrapper
-              width={"85%"}
-              height={"85%"}
+              width={label ? "100%" : "85%"}
+              height={label ? "100%" : "85%"}
               autoScale={true}
             >
               {item.icon}
@@ -81,6 +86,7 @@ const DragTable: FC<propsDragTable> = ({ item }) => {
           </div>
         </div>
       </div>
+      {label && <span className="text-[10px] font-semibold text-[#3A3A42] text-center leading-tight">{label}</span>}
     </div>
   );
 };

--- a/apps/appEventos/components/Mesas/DragableDefault.tsx
+++ b/apps/appEventos/components/Mesas/DragableDefault.tsx
@@ -3,6 +3,7 @@ import { EventContextProvider } from "../../context";
 import { MesaContent } from "./MesaContent";
 import { ElementContent } from "./ElementContent";
 import { element, table } from "../../utils/Interfaces";
+import { fetchApiBodas, queries } from "../../utils/Fetching";
 
 interface propsTable extends Partial<HTMLDivElement> {
   ref: any
@@ -18,7 +19,37 @@ interface propsTable extends Partial<HTMLDivElement> {
 
 // eslint-disable-next-line react/display-name
 export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWrapper, disableDrag, prefijo, setShowFormEditar, DefinePosition, idx, scale }, ref: any) => {
-  const { editDefault, setEditDefault } = EventContextProvider()
+  const { editDefault, setEditDefault, planSpaceActive, setPlanSpaceActive, event, setEvent } = EventContextProvider()
+
+  // Mobiliario (no mesa, no texto): controles SOBRE el elemento fieles al HTML
+  // (papelera arriba-izq + pastilla −/＋ debajo). Misma lógica que EditDefault, persistida.
+  const isFurniture = prefijo !== "table" && item?.tipo !== "text"
+  const selected = editDefault?.clicked === item?._id
+
+  const handleDeleteEl = async () => {
+    setEditDefault({})
+    const nps = { ...planSpaceActive, elements: (planSpaceActive?.elements || []).filter((el: any) => el._id !== item._id) }
+    setPlanSpaceActive(nps)
+    setEvent((prev: any) => ({
+      ...prev,
+      galerySvgs: (prev?.galerySvgs ?? []).filter((el: any) => el._id !== item._id),
+      planSpace: prev.planSpace.map((ps: any) => ps._id !== planSpaceActive._id ? ps : nps),
+    }))
+    await fetchApiBodas({ query: queries.deleteElement, variables: { evento_id: event._id, element_id: item._id } })
+  }
+
+  const handleScaleEl = async (factor: number) => {
+    const cur = (item as any)?.size && typeof (item as any).size?.width === 'number' ? (item as any).size : { width: 80, height: 80 }
+    const clamp = (v: number) => Math.max(24, Math.min(600, Math.round(v)))
+    const newSize = { width: clamp(cur.width * factor), height: clamp(cur.height * factor) }
+    const nps = { ...planSpaceActive, elements: (planSpaceActive?.elements || []).map((el: any) => el._id !== item._id ? el : { ...el, size: newSize }) }
+    setPlanSpaceActive(nps)
+    setEvent((prev: any) => ({
+      ...prev,
+      planSpace: prev.planSpace.map((ps: any) => ps._id !== planSpaceActive._id ? ps : nps),
+    }))
+    await fetchApiBodas({ query: queries.editElement, variables: { evento_id: event._id, element_id: item._id, datos: { size: newSize } } })
+  }
 
   useEffect(() => {
     if (prefijo !== "table") {
@@ -92,6 +123,29 @@ export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWra
           : <ElementContent item={item} scale={scale} disableDrag={disableDrag} />
         }
       </div>
+      {/* Controles SOBRE el elemento (fiel al HTML): papelera arriba-izq + pastilla −/＋ debajo.
+          stopPropagation para no disparar la selección/arrastre del elemento. */}
+      {isFurniture && selected && (
+        <>
+          <button
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            onClick={(e) => { e.stopPropagation(); handleDeleteEl() }}
+            title="Borrar"
+            className="absolute -top-3 -left-3 w-[26px] h-[26px] rounded-full bg-white border border-[#f2c9d9] shadow-[0_3px_8px_rgba(0,0,0,.18)] flex items-center justify-center z-20"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
+          </button>
+          <div
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            className="absolute -bottom-4 left-1/2 -translate-x-1/2 flex gap-0.5 bg-white border border-[#eee] rounded-[10px] shadow-[0_3px_8px_rgba(0,0,0,.15)] p-0.5 z-20"
+          >
+            <button onClick={(e) => { e.stopPropagation(); handleScaleEl(1 / 1.2) }} title="Achicar" className="w-[22px] h-[22px] rounded-[7px] text-[#6b6b72] text-[15px] leading-none flex items-center justify-center">−</button>
+            <button onClick={(e) => { e.stopPropagation(); handleScaleEl(1.2) }} title="Agrandar" className="w-[22px] h-[22px] rounded-[7px] text-[#EF5B94] text-[15px] leading-none flex items-center justify-center">＋</button>
+          </div>
+        </>
+      )}
     </div>
   );
 })

--- a/apps/appEventos/components/Mesas/EditDefault.tsx
+++ b/apps/appEventos/components/Mesas/EditDefault.tsx
@@ -107,6 +107,31 @@ export const EditDefault: FC<EditDefaultState> = ({ item, setShowFormEditar, ite
     }
   }
 
+  // Agrandar/achicar el elemento (fiel al HTML: scaleFurn ±). Escala el size de forma
+  // inmutable y lo persiste con editElement (mismo patrón que la rotación). Solo elementos.
+  const handleScale = async (factor: number) => {
+    const current = item?.size && typeof item.size.width === 'number' ? item.size : { width: 80, height: 80 }
+    const clamp = (v: number) => Math.max(24, Math.min(600, Math.round(v)))
+    const newSize = { width: clamp(current.width * factor), height: clamp(current.height * factor) }
+    const newPlanSpaceActive = {
+      ...planSpaceActive,
+      elements: planSpaceActive.elements.map(elem =>
+        elem._id !== item._id ? elem : { ...elem, size: newSize }
+      ),
+    }
+    setPlanSpaceActive(newPlanSpaceActive)
+    setEvent((prev) => ({
+      ...prev,
+      planSpace: prev.planSpace.map(ps =>
+        ps._id !== planSpaceActive._id ? ps : newPlanSpaceActive
+      ),
+    }))
+    await fetchApiBodas({
+      query: queries.editElement,
+      variables: { evento_id: event._id, element_id: item._id, datos: { size: newSize } }
+    })
+  }
+
   return (
     <div className="bg-transparent absolute w-full h-full flex flex-col items-center justify-between py-3" >
       <button disabled={!isAllowed()} onClick={handleDeleteItem} className="bg-white border border-primary rounded-md w-7 h-7 flex items-center justify-center">
@@ -120,6 +145,12 @@ export const EditDefault: FC<EditDefaultState> = ({ item, setShowFormEditar, ite
         disabled={!isAllowed() || itemTipo === "element"}>
         <EditarIcon className={`${itemTipo === "table" ? "text-gray-600" : "text-gray-300"} w-5 h-5`} />
       </button>
+      {itemTipo === "element" &&
+        <>
+          <button disabled={!isAllowed()} onClick={() => handleScale(1.2)} title="Agrandar" className="bg-white border border-primary rounded-md w-7 h-7 flex items-center justify-center text-gray-600 text-lg leading-none">＋</button>
+          <button disabled={!isAllowed()} onClick={() => handleScale(1 / 1.2)} title="Achicar" className="bg-white border border-primary rounded-md w-7 h-7 flex items-center justify-center text-gray-600 text-lg leading-none">−</button>
+        </>
+      }
       <button disabled={!isAllowed()} onClick={() => { handleRotate("right") }} className="bg-white border border-primary rounded-md w-7 h-7 flex items-center justify-center">
         <MdRotateRight className="text-gray-600 w-5 h-5" />
       </button>

--- a/apps/appEventos/components/Mesas/furnitureIcons.tsx
+++ b/apps/appEventos/components/Mesas/furnitureIcons.tsx
@@ -1,0 +1,50 @@
+import { FC, SVGProps } from 'react';
+
+// Iconos de mobiliario EXACTOS del prototipo MESAS.dc.html (func furnIcon, líneas 395-401).
+// stroke=currentColor → el color lo pone el contenedor (rosa #EF5B94 en el menú, gris #6b6b72
+// en el plano). Aceptan props (className/style) para el cloneElement del canvas (ElementContent).
+const base: SVGProps<SVGSVGElement> = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.7,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+export const TextoIcon: FC<SVGProps<SVGSVGElement>> = (p) => (
+  <svg {...base} {...p}><path d="M5 6h14M12 6v13M9 19h6" /></svg>
+);
+export const ArbolIcon: FC<SVGProps<SVGSVGElement>> = (p) => (
+  <svg {...base} {...p}><path d="M12 3l5 7h-3l3 5H7l3-5H7z" /><path d="M12 15v6" /></svg>
+);
+export const PlantaIcon: FC<SVGProps<SVGSVGElement>> = (p) => (
+  <svg {...base} {...p}><path d="M12 21v-8" /><path d="M12 13c-4 0-6-2-6-6 4 0 6 2 6 6zM12 13c4 0 6-2 6-5-4 0-6 1-6 5z" /></svg>
+);
+export const CabinaDjIcon: FC<SVGProps<SVGSVGElement>> = (p) => (
+  <svg {...base} {...p}><rect x="3" y="6" width="18" height="12" rx="2" /><circle cx="8" cy="12" r="2.2" /><circle cx="16" cy="12" r="2.2" /></svg>
+);
+export const ArcoIcon: FC<SVGProps<SVGSVGElement>> = (p) => (
+  <svg {...base} {...p}><path d="M5 21V11a7 7 0 0 1 14 0v10" /></svg>
+);
+export const PianoIcon: FC<SVGProps<SVGSVGElement>> = (p) => (
+  <svg {...base} {...p}><rect x="3" y="5" width="18" height="6" rx="1" /><path d="M6 11v8M18 11v8M6 15h12" /></svg>
+);
+
+export interface FurnitureDef {
+  /** modelo/tipo que se guarda en el elemento (createElement tipo). 'text' es especial (Quill). */
+  model: string;
+  label: string;
+  Icon: FC<SVGProps<SVGSVGElement>>;
+  size: { width: number; height: number };
+}
+
+// Paleta del menú Mobiliario (6, fiel al HTML). El orden = el del prototipo.
+export const FURNITURE: FurnitureDef[] = [
+  { model: 'text', label: 'Texto', Icon: TextoIcon, size: { width: 60, height: 120 } },
+  { model: 'arbol', label: 'Árbol', Icon: ArbolIcon, size: { width: 60, height: 120 } },
+  { model: 'planta', label: 'Planta', Icon: PlantaIcon, size: { width: 70, height: 100 } },
+  { model: 'dj', label: 'Cabina DJ', Icon: CabinaDjIcon, size: { width: 140, height: 110 } },
+  { model: 'arco', label: 'Arco', Icon: ArcoIcon, size: { width: 120, height: 120 } },
+  { model: 'piano', label: 'Piano', Icon: PianoIcon, size: { width: 120, height: 120 } },
+];

--- a/apps/appEventos/components/Mesas/prueba.tsx
+++ b/apps/appEventos/components/Mesas/prueba.tsx
@@ -54,7 +54,9 @@ const Prueba: FC<propsPrueba> = ({ setShowFormEditar, fullScreen, setFullScreen 
         {/* BUG-6 (informe QA 21-jun): bg-blue-200 era debug hardcoded. Cambiamos a
             bg-base (token de tema) para que respete el diseño del whitelabel. */}
         <div id="rootElementTables" ref={refDiv} className="bg-base flex w-[100%] h-[calc(100%-32px)] relative">
-          {editDefault?.clicked &&
+          {/* Barra lateral izquierda: solo para mesas y texto. El mobiliario usa los
+              controles SOBRE el elemento (papelera + −/＋), fieles al HTML (DragableDefault). */}
+          {editDefault?.clicked && !(editDefault?.itemTipo === "element" && editDefault?.item?.tipo !== "text") &&
             <ClickAwayListener
               onClickAway={() => {
                 if (editDefault.activeButtons) {

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -156,7 +156,11 @@ const Mesas: FC = () => {
           // Update inmutable: añadir elemento al planSpaceActive.
           const newPlanSpaceActive = {
             ...planSpaceActive,
-            elements: [...(planSpaceActive.elements ?? []), { ...inputValues }],
+            // `_id` temporal para que el elemento recién soltado SEA arrastrable (interact usa
+            // el id del div `element_<_id>`). createElement no devuelve el _id del elemento
+            // (solo evento{_id}); al recargar llega el _id real del backend. Mismo patrón que
+            // TableConfigurator para las mesas.
+            elements: [...(planSpaceActive.elements ?? []), { ...inputValues, _id: `tmp_${Date.now()}_${Math.round(Math.random() * 100000)}` }],
           }
           setPlanSpaceActive(newPlanSpaceActive)
           // planSpaceSelect es ID (string) — match por _id, no por índice (mismo bug latente que FormCrearMesa).

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -36,18 +36,24 @@ import { useAllowed } from "../hooks/useAllowed";
 import { useTranslation } from 'react-i18next';
 import CopilotFilterBar from "../components/Utils/CopilotFilterBar";
 import { GalerySvg } from "../utils/Interfaces";
-import { Arbol, Arbol2, Dj, Layer2, Piano } from "../components/icons";
+import { Arbol2, Layer2 } from "../components/icons";
+import { ArbolIcon, PlantaIcon, CabinaDjIcon, ArcoIcon, PianoIcon } from "../components/Mesas/furnitureIcons";
 import SvgFromString from "../components/SvgFromString";
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 SwiperCore.use([Pagination]);
 
 export const ListElements: GalerySvg[] = [
-  { icon: <Arbol className="" />, title: "arbol", tipo: "element", size: { width: 60, height: 120 } },
+  // Mobiliario fiel al HTML (iconos de furnitureIcons). El MISMO icono se usa en el menú
+  // (BlockPanelElements) y en el plano (ElementContent), para que sean consistentes.
+  { icon: <ArbolIcon />, title: "arbol", tipo: "element", size: { width: 60, height: 120 } },
+  { icon: <PlantaIcon />, title: "planta", tipo: "element", size: { width: 70, height: 100 } },
+  { icon: <CabinaDjIcon />, title: "dj", tipo: "element", size: { width: 140, height: 110 } },
+  { icon: <ArcoIcon />, title: "arco", tipo: "element", size: { width: 120, height: 120 } },
+  { icon: <PianoIcon />, title: "piano", tipo: "element", size: { width: 120, height: 120 } },
+  // Legacy (fuera del menú): tipos antiguos que pudieran tener elementos ya colocados.
   { icon: <Arbol2 className="" />, title: "arbol2", tipo: "element", size: { width: 60, height: 120 } },
-  { icon: <Dj className="" />, title: "dj", tipo: "element", size: { width: 140, height: 110 } },
   { icon: <Layer2 className="" />, title: "layer2", tipo: "element", size: { width: 280, height: 250 } },
-  { icon: <Piano className="" />, title: "piano", tipo: "element", size: { width: 120, height: 120 } },
 ];
 
 // Función helper para convertir SVGs del backend en elementos React


### PR DESCRIPTION
Rediseño Mesas fiel a MESAS.dc.html (continúa #208). 8 archivos, 4 commits.

- **Canvas** beige #F3F1EC + retícula #E4E1D8 (era blanco/gris)
- **Mobiliario**: 6 tarjetas con nombre + iconos EXACTOS del proto (Texto/Árbol/Planta/Cabina DJ/Arco/Piano) en `furnitureIcons.tsx`; +Planta/Arco; arbol2/layer2 legacy fuera del menú
- **Controles del elemento SOBRE el elemento** (papelera arriba-izq + pastilla −/＋ debajo), barra lateral oculta para mobiliario
- **Barra superior flotante** (pastillas, sin franja) + "Plano" integrada
- **«Bloquear plano»** = pastilla 🔒+texto (quita pulso + icono Lock separado)

Motor interact.js NO tocado (IDs/clases/handlers intactos). ESLint 0. Build OK, desplegado y sirviendo en app-dev (BUILD 7bg_UmFacpzjJL3tHt0-q).

⚠️ QA manual: arrastrar mobiliario, resize/borrar on-element, drag mesas/invitados sin regresión.
NOTA coordinación: es LA fuente válida de Mesas/planos (hay otra rama local createPlanSpace que debe partir de ésta, no al revés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)