### PR TITLE
🐛 fix(chat-ia): QA bugs 1/4/10 — banner 'caducado' falso + spinner mudo + leak repo interno

### DIFF
--- a/apps/chat-ia/package.json
+++ b/apps/chat-ia/package.json
@@ -14,7 +14,7 @@
     "tts",
     "stt"
   ],
-  "homepage": "https://github.com/marketingsoluciones/planner-ai",
+  "homepage": "https://bodasdehoy.com",
   "bugs": {
     "url": "https://github.com/marketingsoluciones/planner-ai/issues/new/choose"
   },

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/layout.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/layout.tsx
@@ -50,6 +50,12 @@ function hasLocalJwt(): boolean {
   return false;
 }
 
+/** Lee tab activa del URL y la pasa al BottomNavBar (móvil only). */
+function MobileBottomNav() {
+  const activeTab = useActiveBandejaTab();
+  return <BottomNavBar activeTab={activeTab} />;
+}
+
 export default function MessagesLayout({ children }: MessagesLayoutProps) {
   const router = useRouter();
   const isLoaded = useUserStore(authSelectors.isLoaded);
@@ -97,9 +103,16 @@ export default function MessagesLayout({ children }: MessagesLayoutProps) {
   // Mientras carga la auth O dentro de la ventana de gracia (aún puede resolverse a
   // usuario real), mostramos el spinner en vez de la pantalla "Acceso requerido".
   if (!localJwtPresent && (!isLoaded || (isGuest && !graceElapsed))) {
+    // BUG-4 QA (23-jul): antes era un spinner MUDO (pantalla en negro sin texto)
+    // durante 5s hasta redirigir a login → el usuario no sabía qué pasaba.
+    // Ahora se explica qué está ocurriendo mientras se comprueba la sesión.
     return (
-      <div className="flex h-full items-center justify-center">
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-purple-500" />
+        <div className="text-sm font-medium text-gray-600">Comprobando tu sesión…</div>
+        <div className="max-w-xs text-xs text-gray-400">
+          La bandeja necesita una sesión iniciada. Si no tienes cuenta, te llevaremos al login.
+        </div>
       </div>
     );
   }
@@ -142,10 +155,4 @@ export default function MessagesLayout({ children }: MessagesLayoutProps) {
       <MobileBottomNav />
     </div>
   );
-}
-
-/** Lee tab activa del URL y la pasa al BottomNavBar (móvil only). */
-function MobileBottomNav() {
-  const activeTab = useActiveBandejaTab();
-  return <BottomNavBar activeTab={activeTab} />;
 }

--- a/apps/chat-ia/src/hooks/useAuthCheck.ts
+++ b/apps/chat-ia/src/hooks/useAuthCheck.ts
@@ -155,8 +155,21 @@ export const useAuthCheck = () => {
 
     const hasValidJwt = checkJwtValidity();
 
-    // Usuario identificado pero sin JWT válido = necesita re-login
-    const needsRelogin = isAuthenticated && !hasValidJwt;
+    // BUG-1 QA (23-jul): el banner "Tu cuenta ha caducado" se mostraba a usuarios
+    // que NUNCA iniciaron sesión. "Caducado/expirado" solo es correcto si EXISTIÓ
+    // un token que ahora es inválido. Si no hay NINGÚN token (nunca hubo sesión de
+    // chat), no es un re-login: es un estado no-autenticado → no alarmar con "caducado".
+    const hasAnyToken =
+      typeof window !== 'undefined' &&
+      !!(
+        localStorage.getItem('jwt_token') ||
+        localStorage.getItem('mcp_jwt_token') ||
+        config?.token ||
+        localStorage.getItem('jwt_token_cache')
+      );
+
+    // Usuario identificado + TENÍA token (ahora inválido/expirado) = necesita re-login.
+    const needsRelogin = isAuthenticated && !hasValidJwt && hasAnyToken;
 
     if (needsRelogin) {
       warnOnce('needs-relogin', '⚠️ Usuario identificado pero sin JWT válido - necesita re-login');


### PR DESCRIPTION
Fixes de los 3 bugs front seguros del informe QA chat-dev (23-jul). Solo chat-ia.

## Bug 1 (media) — banner 'Tu cuenta ha caducado' a quien nunca inició sesión
`ReloginBanner` se disparaba con `needsRelogin = isAuthenticated && !hasValidJwt`.
Ahora exige que EXISTIERA un token (`hasAnyToken`): sin token = no-autenticado, no 'expirado'. useAuthCheck.ts.

## Bug 4 (media) — 'Ver bandeja completa' invitado: spinner mudo → redirect silencioso
bandeja/layout.tsx mostraba spinner sin texto 5s. Ahora: 'Comprobando tu sesión…' + qué pasará.

## Bug 10 (media) — leak de repo interno en share
El footer del share (pkg.homepage) exponía `github.com/marketingsoluciones/planner-ai`. → `https://bodasdehoy.com`.

Pendientes (otros PRs / coordinación): Bugs 5+6 (persistencia tRPC/DB — infra/api-ia), 7+13 (datos api-mcp), 2/8/11/12 (front, en cola).

🤖 Generated with [Claude Code](https://claude.com/claude-code)