### PR TITLE
🐛 fix(chat-ia): QA bugs 2/8/11 — invitado 'sesión expirada' + 'Analizando' pegado + bandeja ancho

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/layout.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/layout.tsx
@@ -136,8 +136,11 @@ export default function MessagesLayout({ children }: MessagesLayoutProps) {
     );
   }
 
+  // BUG-11 QA (23-jul): w-full + flex-1 para que la bandeja OCUPE todo el ancho del
+  // contenedor (antes se quedaba en ~910px dejando franja vacía a la derecha en
+  // desktop ancho, porque la raíz no forzaba el ancho del padre).
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-white">
+    <div className="flex h-full w-full flex-1 flex-col overflow-hidden bg-white">
       <div className="flex flex-1 overflow-hidden">
         {/* Rail 54px FASE B v2.0 Diseño 25-jun — solo desktop ≥1024px.
             Iconos avatar + Conversaciones + Bandeja + Historial + badge plan. */}

--- a/apps/chat-ia/src/services/_auth.ts
+++ b/apps/chat-ia/src/services/_auth.ts
@@ -7,9 +7,8 @@ import {
   ComfyUIKeyVault,
   OpenAICompatibleKeyVault,
   VertexAIKeyVault,
-} from '@lobechat/types';
+ ModelProvider } from '@lobechat/types';
 import { clientApiKeyManager } from '@lobechat/utils/client';
-import { ModelProvider } from '@lobechat/types';
 
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useUserStore } from '@/store/user';
@@ -217,13 +216,27 @@ export const createHeaderWithAuth = async (params?: AuthParams): Promise<Headers
       return new Date(expiresAt) <= new Date();
     };
 
-    if (isJwtExpired()) {
-      // Sesión expirada: no incluir JWT para evitar que api-ia devuelva datos privados
-      // con un token caducado que el servidor aún no ha invalidado.
+    // BUG-2 QA (23-jul): un expires_at VIEJO en localStorage hacía que un INVITADO
+    // (que nunca tuvo sesión) se tratara como "sesión expirada" → route.ts bloqueaba
+    // su mensaje con 401 y el asistente respondía "tu sesión ha expirado" (y su burbuja
+    // no se pintaba). Solo es "expirada" para un usuario REAL (no visitor_/guest).
+    const currentUid = String(userProfileSelectors.userId(useUserStore.getState()) || '');
+    const isRealUser =
+      !!currentUid &&
+      currentUid !== 'guest' &&
+      currentUid !== 'anonymous' &&
+      !currentUid.startsWith('visitor_');
+
+    if (isJwtExpired() && isRealUser) {
+      // Sesión expirada de un usuario real: no incluir JWT para evitar que api-ia
+      // devuelva datos privados con un token caducado que el servidor aún no ha invalidado.
       console.warn('⚠️ [createHeaderWithAuth] JWT expirado — Authorization header OMITIDO. Disparando evento session-expired.');
       window.dispatchEvent(new CustomEvent('mcp:token-expired'));
       // Añadir header para que route.ts lo detecte y bloquee antes de llegar a api-ia
       (headers as Record<string, string>)['X-Session-Expired'] = '1';
+    } else if (isJwtExpired() && !isRealUser) {
+      // Invitado con expires_at obsoleto: NO es una sesión expirada. Continúa como
+      // visitante (sin JWT, sujeto a los límites de visitante) — no se bloquea el mensaje.
     } else {
       const jwtToken =
         localStorage.getItem('jwt_token') ||

--- a/apps/chat-ia/src/store/chat/slices/aiChat/actions/generateAIChat.ts
+++ b/apps/chat-ia/src/store/chat/slices/aiChat/actions/generateAIChat.ts
@@ -786,6 +786,19 @@ export const generateAIChat: StateCreator<
           imageList: finalImages.length > 0 ? finalImages : undefined,
           metadata: speed ? { ...usage, ...speed } : usage,
         });
+
+        // BUG-8 QA (23-jul): red de seguridad. El toggle-off de reasoning solo salta
+        // en onMessageHandle al transicionar de "thinking" a contenido; si el stream
+        // termina sin esa transición, el id se queda en reasoningLoadingIds y el header
+        // "Analizando tu solicitud…" queda pegado tras completar la respuesta. Al
+        // finalizar el stream lo limpiamos siempre (idempotente si ya estaba off).
+        if (chatSelectors.isMessageInChatReasoning(messageId)(get())) {
+          internal_toggleChatReasoning(
+            false,
+            messageId,
+            n('toggleChatReasoning/finish-cleanup') as string,
+          );
+        }
       },
       onMessageHandle: async (chunk) => {
         switch (chunk.type) {


### PR DESCRIPTION
Segunda tanda de fixes front del informe QA chat-dev (23-jul). Solo chat-ia.

## Bug 2 (alta) — invitado tratado como 'sesión expirada', mensaje bloqueado
Un `expires_at` viejo en localStorage marcaba `X-Session-Expired=1` para un invitado que nunca tuvo sesión → route.ts bloqueaba su mensaje (401) y el asistente respondía 'tu sesión ha expirado'. Ahora solo aplica a usuarios reales (no visitor_/guest). Misma raíz que bug 1.

## Bug 8 (baja-media) — header 'Analizando tu solicitud…' pegado tras responder
El toggle-off de reasoning solo saltaba al transicionar thinking→contenido; si el stream acababa sin esa transición, el id se quedaba en `reasoningLoadingIds`. Red de seguridad en `onFinish` (idempotente).

## Bug 11 (media) — bandeja no ocupaba el ancho (franja vacía a la derecha)
Raíz del layout de bandeja ahora `w-full flex-1` para ocupar todo el contenedor en desktop ancho.

0 errores eslint. Pendiente: Bug 12 (desync lista, coordinar con backend), 5+6 (persistencia, api-ia), 7+13 (datos api-mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)