### PR TITLE
🐛 fix(chat-ia): QA bug 6 (front) — quitar 'Sincronizado' optimista del mensaje

### DIFF
--- a/apps/chat-ia/src/features/Conversation/Messages/User/BelowMessage.tsx
+++ b/apps/chat-ia/src/features/Conversation/Messages/User/BelowMessage.tsx
@@ -66,7 +66,12 @@ export const UserBelowMessage = memo<UserBelowMessageProps>(
       s.rewriteQuery,
     ]);
 
-    const status: DeliveryStatus = deliveryStatus ?? 'synced';
+    // BUG-6 QA (23-jul): antes el default era 'synced' ("Sincronizado", doble check)
+    // → afirmaba PERSISTENCIA de forma OPTIMISTA aunque el guardado fallara (500),
+    // contradiciendo el banner de error. Default honesto = 'sent' ("Enviado"): el
+    // mensaje se envió, sin afirmar que se guardó. 'synced' solo con confirmación real
+    // (que el backend de persistencia debe proveer). El caller pasa 'error' si falló.
+    const status: DeliveryStatus = deliveryStatus ?? 'sent';
     const StatusIcon = STATUS_ICON[status] ?? Check;
     const statusColorMap: Record<DeliveryStatus, string> = {
       error: theme.colorError,

--- a/apps/chat-ia/src/features/Conversation/Messages/User/index.tsx
+++ b/apps/chat-ia/src/features/Conversation/Messages/User/index.tsx
@@ -178,7 +178,14 @@ const UserMessage = memo<UserMessageProps>((props) => {
             </Flexbox>
           )}
         </Flexbox>
-        <UserBelowMessage content={content} id={id} ragQuery={ragQuery} />
+        {/* BUG-6 QA: si el mensaje falló (p. ej. 500 al guardar), mostrar 'error' en
+            vez del optimista 'synced'. Sin error → default honesto 'sent' (ver BelowMessage). */}
+        <UserBelowMessage
+          content={content}
+          deliveryStatus={error ? 'error' : undefined}
+          id={id}
+          ragQuery={ragQuery}
+        />
       </Flexbox>
       {mobile && variant === 'bubble' && <BorderSpacing borderSpacing={32} />}
     </Flexbox>


### PR DESCRIPTION
Parte FRONT del bug 6 (crítico). Independiente de la decisión de persistencia (a/b, coordinada con api-ia con pruebas).

El mensaje de usuario mostraba 'Sincronizado' (doble check, = persistido) por defecto, aunque el guardado fallara (500) → contradicción con el banner de error. Ahora:
- default honesto **'sent'** ('Enviado'): afirma envío, no persistencia.
- si el mensaje tiene error → **'error'**.
- 'synced' se reserva para cuando el backend confirme guardado.

No arregla el 500 en sí (eso es la decisión a/b de api-ia/infra), pero elimina el mensaje contradictorio. 0 errores eslint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)