### PR TITLE
✨ feat(chat-ia/bandeja): multi-marca Fase 1 — tokenizar color de marca al whitelabel

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/BottomNavBar.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/BottomNavBar.tsx
@@ -14,6 +14,8 @@
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 
+import { useBandejaBrand } from '../utils/brand';
+
 interface BottomNavBarProps {
   activeTab: 'conv' | 'inbox' | 'history';
   inboxUnread?: number;
@@ -36,6 +38,7 @@ export function BottomNavBar({
   inboxUnread = 0,
   historyUnread = 0,
 }: BottomNavBarProps) {
+  const brand = useBandejaBrand();
   const router = useRouter();
 
   const handleClick = useCallback(
@@ -61,7 +64,7 @@ export function BottomNavBar({
             className="flex flex-1 flex-col items-center gap-0.5 py-2 transition-colors"
             key={item.id}
             onClick={() => handleClick(item.href)}
-            style={{ color: isActive ? '#7C3AED' : '#6B6678' }}
+            style={{ color: isActive ? brand.brand : '#6B6678' }}
             type="button"
           >
             <span aria-hidden className="relative text-xl">

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationHeader.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationHeader.tsx
@@ -6,6 +6,7 @@ import { useConversations } from '../hooks/useConversations';
 import { useConversationActions } from '../hooks/useConversationActions';
 import { ConversationStatus, useConversationMeta } from '../hooks/useConversationMeta';
 import { ChannelBadge } from './ChannelBadge';
+import { useBandejaBrand } from '../utils/brand';
 import { IaLevelPicker, type IaLevel } from './IaLevelPicker';
 
 interface ConversationHeaderProps {
@@ -24,6 +25,7 @@ export function ConversationHeader({
   detailsOpen,
   onToggleDetails,
 }: ConversationHeaderProps) {
+  const brand = useBandejaBrand();
   const { conversations, loading: convListLoading } = useConversations(channel ?? null);
   const conversation = conversations.find((c) => c.id === conversationId);
 
@@ -285,9 +287,9 @@ export function ConversationHeader({
                 assignToUser(assignedToMe ? null : userId);
               }}
               style={{
-                backgroundColor: assignedToMe ? '#EDE9FE' : '#FFFFFF',
-                border: `1px solid ${assignedToMe ? '#EDE9FE' : '#EDEDF0'}`,
-                color: assignedToMe ? '#6B4EFF' : '#84848F',
+                backgroundColor: assignedToMe ? brand.brandBg : '#FFFFFF',
+                border: `1px solid ${assignedToMe ? brand.brandBg : '#EDEDF0'}`,
+                color: assignedToMe ? brand.brand : '#84848F',
                 fontWeight: assignedToMe ? 500 : 400,
               }}
               type="button"
@@ -302,8 +304,8 @@ export function ConversationHeader({
             className="flex h-8 w-8 items-center justify-center rounded-md transition-colors"
             onClick={() => (searchOpen ? closeSearch() : setSearchOpen(true))}
             style={{
-              backgroundColor: searchOpen ? '#EDE9FE' : 'transparent',
-              color: searchOpen ? '#6B4EFF' : '#84848F',
+              backgroundColor: searchOpen ? brand.brandBg : 'transparent',
+              color: searchOpen ? brand.brand : '#84848F',
             }}
             onMouseEnter={(e) => {
               if (!searchOpen) e.currentTarget.style.backgroundColor = '#F2F1F6';
@@ -359,8 +361,8 @@ export function ConversationHeader({
               className="flex h-8 w-8 items-center justify-center rounded-md transition-colors"
               onClick={onToggleDetails}
               style={{
-                backgroundColor: detailsOpen ? '#EDE9FE' : 'transparent',
-                color: detailsOpen ? '#6B4EFF' : '#84848F',
+                backgroundColor: detailsOpen ? brand.brandBg : 'transparent',
+                color: detailsOpen ? brand.brand : '#84848F',
               }}
               onMouseEnter={(e) => {
                 if (!detailsOpen) e.currentTarget.style.backgroundColor = '#F2F1F6';

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationItem.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationItem.tsx
@@ -6,6 +6,7 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 import { useTypingInConv } from '@/store/bandeja/selectors';
 import { Conversation } from '../hooks/useConversations';
+import { useBandejaBrand } from '../utils/brand';
 import { useConversationActions } from '../hooks/useConversationActions';
 import { ConversationStatus, useConversationMeta } from '../hooks/useConversationMeta';
 
@@ -30,13 +31,14 @@ const formatTimestamp = (timestamp: string) => {
 };
 
 function TypingIndicator() {
+  const brand = useBandejaBrand();
   return (
-    <span className="inline-flex items-center gap-0.5 text-xs italic" style={{ color: '#6B4EFF' }}>
+    <span className="inline-flex items-center gap-0.5 text-xs italic" style={{ color: brand.brand }}>
       <span>Escribiendo</span>
       <span className="flex gap-px">
-        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '0ms', backgroundColor: '#6B4EFF' }} />
-        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '150ms', backgroundColor: '#6B4EFF' }} />
-        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '300ms', backgroundColor: '#6B4EFF' }} />
+        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '0ms', backgroundColor: brand.brand }} />
+        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '150ms', backgroundColor: brand.brand }} />
+        <span className="h-1 w-1 animate-bounce rounded-full" style={{ animationDelay: '300ms', backgroundColor: brand.brand }} />
       </span>
     </span>
   );
@@ -57,6 +59,7 @@ export function ConversationItem({
   conversation,
   isSelected,
 }: ConversationItemProps) {
+  const brand = useBandejaBrand();
   const router = useRouter();
   const { checkAuth } = useAuthCheck();
   const { userId } = checkAuth();
@@ -218,7 +221,7 @@ export function ConversationItem({
                     {hasIa && (
                       <span
                         aria-hidden
-                        style={{ color: '#6B4EFF', marginRight: 4 }}
+                        style={{ color: brand.brand, marginRight: 4 }}
                       >
                         ✦
                       </span>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationList.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationList.tsx
@@ -6,6 +6,8 @@ import { useMemo, useState } from 'react';
 
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 
+import { useBandejaBrand } from '../utils/brand';
+
 import { useConversationActions } from '../hooks/useConversationActions';
 import { ConversationStatus, useConversationMetaState } from '../hooks/useConversationMeta';
 import { useConversations } from '../hooks/useConversations';
@@ -198,7 +200,7 @@ function ConversationListInner({ channel, selectedId }: ConversationListProps) {
               {totalUnread > 0 && (
                 <>
                   <span style={{ color: '#EDEDF0', margin: '0 6px' }}>·</span>
-                  <span style={{ color: '#6B4EFF', fontWeight: 500 }}>
+                  <span style={{ color: brand.brand, fontWeight: 500 }}>
                     {totalUnread} sin leer
                   </span>
                 </>
@@ -254,7 +256,7 @@ function ConversationListInner({ channel, selectedId }: ConversationListProps) {
             }}
             onFocus={(e) => {
               e.currentTarget.style.backgroundColor = '#FFFFFF';
-              e.currentTarget.style.borderColor = '#6B4EFF';
+              e.currentTarget.style.borderColor = brand.brand;
             }}
             onBlur={(e) => {
               e.currentTarget.style.backgroundColor = '#F2F1F6';
@@ -371,6 +373,7 @@ function EmptyStateWithChannels(_props: { onSelectChannel: (ch: string) => void 
 }
 
 export function ConversationList({ channel, selectedId }: ConversationListProps) {
+  const brand = useBandejaBrand();
   const { checkAuth } = useAuthCheck();
   const { development } = checkAuth();
   const dev = development || 'bodasdehoy';

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/InboxFilters.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/InboxFilters.tsx
@@ -12,6 +12,8 @@
  */
 import { useMemo } from 'react';
 
+import { useBandejaBrand } from '../utils/brand';
+
 export type RsvpFilter = 'all' | 'pending' | 'confirmed' | 'declined';
 export type ChannelFilter = 'all' | 'wa' | 'sms' | 'ig' | 'web' | 'tg' | 'fb';
 
@@ -81,6 +83,14 @@ export function InboxFilters({
   pendingIaActive = false,
   onPendingIaToggle,
 }: InboxFiltersProps) {
+  const brand = useBandejaBrand();
+  // Los filtros de MARCA del config estático (#EDE9FE/#5B21B6, ej. "Todos"/"Todo"/"Web")
+  // se resuelven a la paleta del whitelabel. Los SEMÁNTICOS (RSVP ámbar/verde/rojo,
+  // canal WA/IG/TG) conservan su color fijo.
+  const activeStyle = (opt: { activeBg: string; activeColor: string }) =>
+    opt.activeBg === '#EDE9FE'
+      ? { backgroundColor: brand.brandBg, color: brand.brandText }
+      : { backgroundColor: opt.activeBg, color: opt.activeColor };
   const rsvpRow = useMemo(
     () =>
       RSVP_OPTIONS.map((opt) => {
@@ -92,7 +102,7 @@ export function InboxFilters({
             className="inline-flex items-center gap-1 rounded-[9px] px-2 py-1 text-[11px] font-semibold transition-colors"
             key={opt.value}
             onClick={() => onRsvpChange(opt.value)}
-            style={isActive ? { backgroundColor: opt.activeBg, color: opt.activeColor } : INACTIVE_STYLE}
+            style={isActive ? activeStyle(opt) : INACTIVE_STYLE}
             type="button"
           >
             {opt.icon && <span aria-hidden>{opt.icon}</span>}
@@ -119,7 +129,7 @@ export function InboxFilters({
             className="inline-flex items-center gap-1 rounded-[9px] px-2 py-1 text-[11px] font-semibold transition-colors"
             key={opt.value}
             onClick={() => onChannelChange(opt.value)}
-            style={isActive ? { backgroundColor: opt.activeBg, color: opt.activeColor } : INACTIVE_STYLE}
+            style={isActive ? activeStyle(opt) : INACTIVE_STYLE}
             type="button"
           >
             <span>{opt.label}</span>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageItem.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageItem.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { Lock } from 'lucide-react';
 
+import { useBandejaBrand } from '../utils/brand';
+
 import { sendFeedback, type FeedbackRating } from '@/services/feedback';
 
 import { Message } from '../hooks/useMessages';
@@ -40,6 +42,7 @@ const getStatusIcon = (status?: string) => {
 };
 
 export function MessageItem({ message, compact }: MessageItemProps) {
+  const brand = useBandejaBrand();
   const isFromUser = message.fromUser;
   const [feedback, setFeedback] = useState<FeedbackRating | null>(null);
 
@@ -105,7 +108,7 @@ export function MessageItem({ message, compact }: MessageItemProps) {
       ? { background: 'linear-gradient(135deg, #0D9488, #0891B2)', color: '#fff' }
       : isIa
         ? { backgroundColor: '#2DD4BF', color: '#0A2A28' }
-        : { backgroundColor: '#7C3AED', color: '#fff' };
+        : { backgroundColor: brand.brand, color: brand.onBrand };
 
   return (
     <div className={`flex ${isFromUser ? 'justify-start' : 'justify-end'}`}>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessagesRail.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessagesRail.tsx
@@ -23,11 +23,13 @@ import { type ReactNode, useMemo } from 'react';
 
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 
+import { useBandejaBrand } from '../utils/brand';
+
 interface RailItem {
   href: string;
+  icon: ReactNode;
   label: string;
   matchPrefix: string;
-  icon: ReactNode;
   unreadCount?: number;
 }
 
@@ -62,8 +64,8 @@ const ICON_AGENTS = (
 );
 
 interface MessagesRailProps {
-  inboxUnread?: number;
   historyUnread?: number;
+  inboxUnread?: number;
   planLabel?: string;
 }
 
@@ -73,6 +75,7 @@ export function MessagesRail({
   planLabel,
 }: MessagesRailProps) {
   const pathname = usePathname();
+  const brand = useBandejaBrand();
   const { checkAuth } = useAuthCheck();
   const auth = checkAuth();
   const userInitial = (auth.userId || '?').charAt(0).toUpperCase();
@@ -81,28 +84,28 @@ export function MessagesRail({
     () => [
       {
         href: '/asistente',
+        icon: ICON_CONVERSATIONS,
         label: 'Conversaciones',
         matchPrefix: '/asistente',
-        icon: ICON_CONVERSATIONS,
       },
       {
         href: '/bandeja',
+        icon: ICON_INBOX,
         label: 'Bandeja',
         matchPrefix: '/bandeja',
-        icon: ICON_INBOX,
         unreadCount: inboxUnread,
       },
       {
         href: '/agentes',
+        icon: ICON_AGENTS,
         label: 'Agentes',
         matchPrefix: '/agentes',
-        icon: ICON_AGENTS,
       },
       {
         href: '/bandeja?tab=history',
+        icon: ICON_HISTORY,
         label: 'Historial',
         matchPrefix: '/bandeja?tab=history',
-        icon: ICON_HISTORY,
         unreadCount: historyUnread,
       },
     ],
@@ -148,7 +151,7 @@ export function MessagesRail({
               key={item.href}
               style={
                 active
-                  ? { backgroundColor: '#7C3AED', color: '#fff' }
+                  ? { backgroundColor: brand.brand, color: brand.onBrand }
                   : { backgroundColor: 'transparent', color: '#A39DB5' }
               }
               title={item.label}
@@ -175,7 +178,7 @@ export function MessagesRail({
       {planLabel && (
         <div
           className="rounded-md px-1.5 py-0.5 text-[9px] font-bold"
-          style={{ backgroundColor: '#EFE9FB', color: '#7C3AED' }}
+          style={{ backgroundColor: brand.brandBg, color: brand.brand }}
           title={`Plan ${planLabel}`}
         >
           {planLabel}

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ScopeSelector.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ScopeSelector.tsx
@@ -20,6 +20,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useAuthCheck } from '@/hooks/useAuthCheck';
+
+import { useBandejaBrand } from '../utils/brand';
 import { getEventosByUsuario, type Evento } from '@/services/mcpApi/eventos';
 
 export type ScopeId = 'support' | string; // 'support' o un eventId
@@ -44,6 +46,7 @@ function isEventScope(kind: 'support' | 'event'): boolean {
 }
 
 export function ScopeSelector({ activeScope, onChange, events }: ScopeSelectorProps) {
+  const brand = useBandejaBrand();
   const [open, setOpen] = useState(false);
   const [internalEvents, setInternalEvents] = useState<Evento[]>([]);
   const [loadingEvents, setLoadingEvents] = useState(false);
@@ -100,7 +103,7 @@ export function ScopeSelector({ activeScope, onChange, events }: ScopeSelectorPr
   const isEvent = isEventScope(active.kind);
   const pillStyle = isEvent
     ? { borderColor: '#FBD0D7', backgroundColor: '#FFF6F7', color: '#9F1239' }
-    : { borderColor: '#C4B5FD', backgroundColor: '#F4F1FE', color: '#5B21B6' };
+    : { borderColor: brand.brandBorder, backgroundColor: brand.brandBg, color: brand.brandText };
 
   return (
     <div className="relative" ref={ref}>
@@ -116,7 +119,7 @@ export function ScopeSelector({ activeScope, onChange, events }: ScopeSelectorPr
           <span
             aria-hidden
             className="inline-block h-1.5 w-1.5 rounded-full"
-            style={{ backgroundColor: isEvent ? '#E11D48' : '#7C3AED' }}
+            style={{ backgroundColor: isEvent ? '#E11D48' : brand.brand }}
           />
           <span className="truncate">{active.label}</span>
         </span>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/utils/brand.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/utils/brand.ts
@@ -1,0 +1,42 @@
+import { useTheme } from 'antd-style';
+
+/**
+ * Paleta de MARCA de la Bandeja, derivada del whitelabel activo.
+ *
+ * MULTI-MARCA (regla del proyecto): cada whitelabel elige su `primaryColor`
+ * (bodasdehoy = #ec4899 rosa · otros = #6771ae, #6096B9, #ecb290…). El tema
+ * (antd-style, `cssVar:true`, `AppTheme.tsx`) lo expone en `theme.colorPrimary`
+ * y sus derivados. El prototipo "Bandeja - Prototipo.dc.html" usa #7C3AED como
+ * color de marca de DEMOSTRACIÓN; aquí ese morado = el primario del whitelabel,
+ * así cada marca se pinta en SU paleta.
+ *
+ * Lo que NO va aquí (colores SEMÁNTICOS, iguales entre marcas):
+ *   RSVP (verde/ámbar/rojo), canales (WA verde, IG rosa, SMS gris…), IA teal/cyan.
+ * Esos siguen fijos porque su significado no cambia por marca.
+ */
+export interface BandejaBrand {
+  /** Color de marca (demo #7C3AED / #6B4EFF). */
+  brand: string;
+  /** Fondo claro de marca para estados activos (demo #EDE9FE / #F4F1FE / #EFE9FB). */
+  brandBg: string;
+  /** Fondo claro de marca al hover. */
+  brandBgHover: string;
+  /** Borde de marca suave (demo #C4B5FD). */
+  brandBorder: string;
+  /** Texto de marca sobre fondo claro (demo #5B21B6). */
+  brandText: string;
+  /** Texto sobre el color de marca sólido (blanco). */
+  onBrand: string;
+}
+
+export function useBandejaBrand(): BandejaBrand {
+  const theme = useTheme();
+  return {
+    brand: theme.colorPrimary,
+    brandBg: theme.colorPrimaryBg,
+    brandBgHover: theme.colorPrimaryBgHover,
+    brandBorder: theme.colorPrimaryBorder,
+    brandText: theme.colorPrimaryTextActive || theme.colorPrimaryText,
+    onBrand: theme.colorTextLightSolid || '#fff',
+  };
+}


### PR DESCRIPTION
## Contexto
Handoff de diseño "Bandeja - Prototipo.dc.html" (Bodas de Hoy). El proto usa `#7C3AED` (morado) como color de marca de DEMO, pero **somos multi-marca**: cada whitelabel elige su `primaryColor` (bodasdehoy #ec4899 rosa · otros #6771ae, #6096B9…).

Implementar el proto literal pintaría todo morado en todas las marcas. Esta Fase 1 lo hace **correcto por marca**.

## Qué hace
- Nuevo hook `useBandejaBrand()`: deriva la paleta de marca de `theme.colorPrimary` (antd-style `cssVar:true`, ya alimentado por el whitelabel en AppTheme).
- 8 componentes tokenizados (rail, MessageItem, ScopeSelector, BottomNavBar, ConversationHeader, ConversationList, ConversationItem, InboxFilters): los 24 hardcodes de marca (#7C3AED/#6B4EFF + tints) → `brand.*`.
- **Semánticos intactos** (iguales entre marcas): RSVP verde/ámbar/rojo, canales WA/IG/TG, IA teal.

## Resultado
Cada whitelabel ve su Bandeja en SU paleta. Base para Fase 2 (afinar spacing/tipografía al hifi) y Fase 3 (piezas del spec que falten).

Sin errores de sintaxis; los lint de sort-keys son pre-existentes en esos ficheros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)