### PR TITLE
💄 feat(chat-ia/bandeja): Fase 2 hifi — ítem lista + burbujas al spec

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationItem.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationItem.tsx
@@ -154,7 +154,8 @@ export function ConversationItem({
         }}
         type="button"
       >
-        <div className="flex items-start gap-3 px-3 py-3">
+        {/* Fase 2 hifi: padding 10px 12px (spec Bandeja - Prototipo). */}
+        <div className="flex items-start gap-3 px-3 py-2.5">
           {/* Avatar 40x40 con punto de canal 12px bottom-right */}
           <div className="relative flex-shrink-0">
             <div
@@ -192,15 +193,11 @@ export function ConversationItem({
           <div className="min-w-0 flex-1">
             {/* Header: nombre + hora */}
             <div className="mb-0.5 flex items-baseline justify-between gap-2">
-              <h3
-                className="truncate text-sm font-semibold"
-                style={{
-                  color: conversation.unreadCount > 0 ? '#1C1C22' : '#1C1C22',
-                }}
-              >
+              {/* Fase 2 hifi: nombre 13px/700 #262131, timestamp 10px #A8A3B5 (spec). */}
+              <h3 className="truncate text-[13px] font-bold" style={{ color: '#262131' }}>
                 {conversation.contact.name}
               </h3>
-              <span className="flex-shrink-0 text-xs" style={{ color: '#9A9AA6' }}>
+              <span className="flex-shrink-0 text-[10px]" style={{ color: '#A8A3B5' }}>
                 {formatTimestamp(conversation.lastMessage.timestamp)}
               </span>
             </div>
@@ -212,9 +209,9 @@ export function ConversationItem({
                   <TypingIndicator />
                 ) : (
                   <p
-                    className="truncate text-sm"
+                    className="truncate text-[11.5px]"
                     style={{
-                      color: conversation.unreadCount > 0 ? '#1C1C22' : '#84848F',
+                      color: conversation.unreadCount > 0 ? '#1C1C22' : '#8B8698',
                       fontWeight: conversation.unreadCount > 0 ? 500 : 400,
                     }}
                   >

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageItem.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageItem.tsx
@@ -110,13 +110,22 @@ export function MessageItem({ message, compact }: MessageItemProps) {
         ? { backgroundColor: '#2DD4BF', color: '#0A2A28' }
         : { backgroundColor: brand.brand, color: brand.onBrand };
 
+  // Fase 2 hifi (spec Bandeja - Prototipo): radio asimétrico con "cola" (4px) en la
+  // esquina superior del lado del emisor. Contacto (izq): 4px 16px 16px 16px.
+  // Equipo/IA (der): 16px 4px 16px 16px.
+  const bubbleRadius = compact
+    ? undefined
+    : isFromUser
+      ? '4px 16px 16px 16px'
+      : '16px 4px 16px 16px';
+
   return (
     <div className={`flex ${isFromUser ? 'justify-start' : 'justify-end'}`}>
       <div
         className={`group max-w-[70%] px-4 ${compact ? 'py-0.5' : 'py-2'} ${
-          compact ? 'rounded-lg' : 'rounded-2xl'
+          compact ? 'rounded-lg' : ''
         }`}
-        style={bubbleStyle}
+        style={{ ...bubbleStyle, borderRadius: bubbleRadius }}
       >
         {/* Sello IA — solo cuando viene del modelo */}
         {isIa && (


### PR DESCRIPTION
Fase 2 (hifi) sobre la base multi-marca. Alinea valores EXACTOS del handoff en las 2 superficies más visibles:
- **ConversationItem**: nombre 13px/700 #262131, timestamp 10px #A8A3B5, preview 11.5px #8B8698, padding 10px vertical.
- **MessageItem**: burbujas con radio asimétrico (cola): contacto `4px 16px 16px 16px`, equipo/IA `16px 4px 16px 16px`.

Hanken Grotesk ya estaba. Continúa con scope selector/header/sidebar/composer — recomendable **validar en pantalla** antes de seguir (es polish visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)