### PR TITLE
✨ feat(chat-ia/bandeja): HD-01 — modo del composer por canal (status/broadcast = solo nota)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/[conversation_id]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/[conversation_id]/page.tsx
@@ -127,7 +127,7 @@ export default function ConversationPage({ params }: ConversationPageProps) {
         </div>
 
         <div className="border-t border-gray-200 bg-white p-4">
-          <MessageInput channel={channel} conversationId={conversation_id} />
+          <MessageInput channel={channel} conversationId={conversation_id} jidType={conv?.jidType} />
         </div>
       </div>
 

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
@@ -59,6 +59,11 @@ function extractHsmParamsFromFilledBody(filled: string, tpl: WhatsAppTemplate): 
 interface MessageInputProps {
   channel: string;
   conversationId: string;
+  /** api-mcp jidType: user|group|newsletter|broadcast|... — HD-01: newsletter/broadcast
+   *  son canales de UNA VÍA (status): no admiten respuesta externa, solo nota interna.
+   *  (Mientras el backend no exponga el contrato de capacidades por conversación, el
+   *  front lo deriva de aquí; ver Slack contrato 24-jul.) */
+  jidType?: string | null;
 }
 
 type ComposerMode = 'reply' | 'internal';
@@ -165,9 +170,15 @@ function appendInternalNote(conversationId: string, note: { author: string; id: 
 
 const SMS_MAX_CHARS = 160;
 
-export function MessageInput({ channel, conversationId }: MessageInputProps) {
-  const [mode, setMode] = useState<ComposerMode>('reply');
+export function MessageInput({ channel, conversationId, jidType }: MessageInputProps) {
+  // HD-01: canal de UNA VÍA (status/newsletter/broadcast) → sin respuesta externa.
+  const isOneWayChannel = jidType === 'newsletter' || jidType === 'broadcast';
+  const [mode, setMode] = useState<ComposerMode>(isOneWayChannel ? 'internal' : 'reply');
   const [text, setText] = useState(() => loadDraft(conversationId, 'reply'));
+  // HD-01: si el canal es de una vía, forzar modo nota interna (no hay respuesta externa).
+  useEffect(() => {
+    if (isOneWayChannel && mode === 'reply') setMode('internal');
+  }, [isOneWayChannel, mode]);
   const [emojiOpen, setEmojiOpen] = useState(false);
   const [emojiCategory, setEmojiCategory] = useState('Caras');
   const [emojiSearch, setEmojiSearch] = useState('');
@@ -426,15 +437,30 @@ export function MessageInput({ channel, conversationId }: MessageInputProps) {
           </div>
         </div>
       )}
+      {/* HD-01: banda de MODO del composer. Canal de una vía (status/newsletter/
+          broadcast) → no admite respuesta externa; solo nota interna. */}
+      {isOneWayChannel && (
+        <div
+          className="mb-1 flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-medium"
+          style={{ backgroundColor: '#F6F4FB', borderColor: '#E6E5EC', color: '#6B6678' }}
+        >
+          <span aria-hidden>📢</span>
+          <span>Canal informativo (status/newsletter): no admite respuesta externa. Solo nota interna.</span>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1 rounded-lg bg-gray-50 p-1">
           <button
             className={`rounded-md px-2.5 py-1 text-xs font-semibold transition-colors ${
-              mode === 'reply'
-                ? 'bg-white text-gray-900 shadow-sm'
-                : 'text-gray-500 hover:bg-white/60 hover:text-gray-800'
+              isOneWayChannel
+                ? 'cursor-not-allowed text-gray-300'
+                : mode === 'reply'
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-500 hover:bg-white/60 hover:text-gray-800'
             }`}
+            disabled={isOneWayChannel}
             onClick={() => setMode('reply')}
+            title={isOneWayChannel ? 'Este canal no admite respuesta externa' : 'Responder'}
             type="button"
           >
             Responder


### PR DESCRIPTION
QA 24-jul HD-01: el composer se veía idéntico en Web/WhatsApp/Status sin señalar el modo real del canal.

## Fix front (mientras llega el contrato de capacidades del backend — pedido por Slack)
- `jidType` newsletter/broadcast = canal de **una vía** → fuerza modo 'nota interna', deshabilita 'Responder', y muestra banda **'📢 Canal informativo: no admite respuesta externa. Solo nota interna.'**
- Web/WhatsApp intactos (libre + plantillas HSM 24h ya existentes).
- MessageInput recibe `jidType` desde la conversación.

## Contexto del informe
HD-02 (/pendientes rebota), HD-03 (/files → visitante), HD-04 (UI mixta) son **síntomas de HD-05** (Firebase securetoken bloqueado en la API key — config Google Cloud) → coordinado a infra/api-ia con el error exacto. Y pedido el contrato de capacidades por conversación para HD-01 completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)