### PR TITLE
✨ Bandeja multi-marca — CTA + drawer a marca

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConnectChannelDrawer.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConnectChannelDrawer.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useBandejaBrand } from '../utils/brand';
+
 interface ConnectChannelDrawerProps {
   onClose: () => void;
   open: boolean;
@@ -55,6 +57,7 @@ const CHANNELS = [
 ];
 
 export function ConnectChannelDrawer({ onClose, open }: ConnectChannelDrawerProps) {
+  const brand = useBandejaBrand();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -133,9 +136,10 @@ export function ConnectChannelDrawer({ onClose, open }: ConnectChannelDrawerProp
         {/* Footer */}
         <div className="shrink-0 border-t border-gray-100 px-4 py-3">
           <Link
-            className="block w-full rounded-lg bg-purple-600 py-2 text-center text-xs font-semibold text-white transition-colors hover:bg-purple-700"
+            className="block w-full rounded-lg py-2 text-center text-xs font-semibold text-white transition-colors"
             href="/settings/integrations"
             onClick={onClose}
+            style={{ backgroundColor: brand.brand }}
           >
             Gestión avanzada de canales →
           </Link>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationList.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationList.tsx
@@ -352,6 +352,7 @@ const SETUP_CHANNELS = new Set(['instagram', 'telegram', 'email', 'web', 'facebo
 
 /** Empty state sin duplicar la lista de canales: redirige a Integraciones */
 function EmptyStateWithChannels(_props: { onSelectChannel: (ch: string) => void }) {
+  const brand = useBandejaBrand();
   return (
     <div className="flex h-full flex-col items-center justify-center p-6">
       <div className="mb-3 text-5xl">💬</div>
@@ -360,8 +361,9 @@ function EmptyStateWithChannels(_props: { onSelectChannel: (ch: string) => void 
         Configura WhatsApp, Instagram, Email y otros canales en Integraciones para recibir mensajes
       </p>
       <Link
-        className="flex w-full max-w-xs items-center justify-center gap-2 rounded-lg border border-purple-200 bg-purple-50 px-4 py-3 text-sm font-medium text-purple-700 transition-colors hover:border-purple-300 hover:bg-purple-100"
+        className="flex w-full max-w-xs items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-colors"
         href="/settings/integrations"
+        style={{ backgroundColor: brand.brandBg, borderColor: brand.brandBorder, color: brand.brand }}
       >
         Ir a Integraciones →
       </Link>


### PR DESCRIPTION
Cierra brand-purple visibles restantes (empty-state CTA + botón drawer). 🤖 Generated with [Claude Code](https://claude.com/claude-code)