### PR TITLE
✨ P1 canal desvinculado — solo-lectura + sin leak id (front)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/[conversation_id]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/[conversation_id]/page.tsx
@@ -66,8 +66,12 @@ export default function ConversationPage({ params }: ConversationPageProps) {
 
   // Datos extra de la conversación para el sidebar de notas (linked_contact_id,
   // linked_event_id, nombre del contacto). useConversations ya carga la lista.
-  const { conversations } = useConversations(channel);
+  const { conversations, loading } = useConversations(channel);
   const conv = conversations.find((c) => c.id === conversation_id);
+  // TICKET P1: canal no activo — la conv cargó (historial accesible) pero NO está en la
+  // lista del canal activo (conexión WA anterior, channelId huérfano) → compositor
+  // solo-lectura. Raíz = backend canonicalizar el channelId (coordinado).
+  const isChannelInactive = !loading && !conv;
 
   const taskEventId = parseTaskChannel(channel);
 
@@ -122,12 +126,14 @@ export default function ConversationPage({ params }: ConversationPageProps) {
           />
         </div>
 
-        <div className="flex-1 overflow-auto">
+        {/* TICKET P1 robustez layout: min-h suelo para que header+lista+banner+compositor
+            no empujen el compositor fuera de pantalla (validar a 1024×540). */}
+        <div className="min-h-[140px] flex-1 overflow-auto">
           <MessageList channel={channel} conversationId={conversation_id} searchFilter={searchFilter} />
         </div>
 
         <div className="border-t border-gray-200 bg-white p-4">
-          <MessageInput channel={channel} conversationId={conversation_id} jidType={conv?.jidType} />
+          <MessageInput channel={channel} conversationId={conversation_id} jidType={conv?.jidType} readOnly={isChannelInactive} />
         </div>
       </div>
 

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationHeader.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationHeader.tsx
@@ -179,19 +179,19 @@ export function ConversationHeader({
     // Fallback tras gracia: render mínimo con el conversationId (no bloqueante).
     // Permite seguir interactuando (notas, mensajes) aunque la conv no esté
     // en la lista del canal pedido (puede venir de otro endpoint backend).
+    // TICKET P1 (24-jul): NUNCA exponer el id interno del canal/conversación al usuario.
+    // Antes se filtraba "No disponible en la lista de wa-69d8…". Copy neutral + amable.
+    // El estado solo-lectura (banner + compositor) lo pinta la página del hilo.
     return (
       <div className="flex items-center justify-between border-b border-gray-200 bg-white p-4">
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-rose-500 text-sm font-semibold text-white">
-            ?
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-gray-200 text-sm font-semibold text-gray-500">
+            ⚠
           </div>
-          <div>
-            <h2 className="font-semibold text-gray-700">
-              Conversación {conversationId.slice(0, 12)}…
-            </h2>
-            <p className="text-xs text-gray-500">
-              No disponible en la lista de {channel ?? 'este canal'} —
-              el contenido sigue accesible.
+          <div className="min-w-0">
+            <h2 className="truncate font-semibold text-gray-700">Conversación anterior</h2>
+            <p className="truncate text-xs text-gray-500">
+              El historial sigue disponible. Conexión no activa.
             </p>
           </div>
         </div>

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
@@ -13,6 +13,7 @@ import {
   type WhatsAppTemplate,
 } from '../hooks/useWhatsAppTemplates';
 import { WhatsAppTemplatePicker } from './WhatsAppTemplatePicker';
+import { useBandejaBrand } from '../utils/brand';
 
 /**
  * Compara body original de la template (con `{{1}}`, `{{2}}`) contra el body ya
@@ -64,6 +65,44 @@ interface MessageInputProps {
    *  (Mientras el backend no exponga el contrato de capacidades por conversación, el
    *  front lo deriva de aquí; ver Slack contrato 24-jul.) */
   jidType?: string | null;
+  /** TICKET P1: la conversación pertenece a un canal no activo (conexión WA anterior) →
+   *  banner + compositor solo-lectura. El backend debe canonicalizar el channelId (raíz). */
+  readOnly?: boolean;
+}
+
+/** Banner "canal desvinculado / solo lectura" (TICKET P1). Ámbar semántico fijo; el
+ *  botón primario [Reconectar] usa el color de MARCA del whitelabel (no #EF5B94 fijo). */
+function ChannelInactiveBanner({ brandColor }: { brandColor: string }) {
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        background: '#FBF0DA',
+        borderTop: '1px solid #EBD9A8',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 9,
+        padding: '9px 14px',
+      }}
+    >
+      <span aria-hidden style={{ color: '#B07E14', flexShrink: 0, fontSize: 16 }}>⚠</span>
+      <span style={{ color: '#7A5A0E', flex: '1 1 130px', fontSize: 11.5, fontWeight: 700, minWidth: 0 }}>
+        Conexión de WhatsApp anterior — solo lectura
+      </span>
+      <a
+        href="/settings/integrations"
+        style={{ backgroundColor: brandColor, borderRadius: 999, color: '#fff', flexShrink: 0, fontSize: 11, fontWeight: 800, padding: '5px 11px' }}
+      >
+        Reconectar
+      </a>
+      <a
+        href="/settings/integrations"
+        style={{ background: '#fff', border: '1px solid #EBD9A8', borderRadius: 999, color: '#7A5A0E', flexShrink: 0, fontSize: 11, fontWeight: 700, padding: '5px 11px' }}
+      >
+        Conexiones
+      </a>
+    </div>
+  );
 }
 
 type ComposerMode = 'reply' | 'internal';
@@ -170,9 +209,10 @@ function appendInternalNote(conversationId: string, note: { author: string; id: 
 
 const SMS_MAX_CHARS = 160;
 
-export function MessageInput({ channel, conversationId, jidType }: MessageInputProps) {
+export function MessageInput({ channel, conversationId, jidType, readOnly }: MessageInputProps) {
   // HD-01: canal de UNA VÍA (status/newsletter/broadcast) → sin respuesta externa.
   const isOneWayChannel = jidType === 'newsletter' || jidType === 'broadcast';
+  const composerBrand = useBandejaBrand();
   const [mode, setMode] = useState<ComposerMode>(isOneWayChannel ? 'internal' : 'reply');
   const [text, setText] = useState(() => loadDraft(conversationId, 'reply'));
   // HD-01: si el canal es de una vía, forzar modo nota interna (no hay respuesta externa).
@@ -345,8 +385,17 @@ export function MessageInput({ channel, conversationId, jidType }: MessageInputP
   const charCount = text.length;
   const smsSegments = Math.ceil(charCount / SMS_MAX_CHARS) || 1;
 
+  // TICKET P1: canal no activo → banner solo-lectura + compositor deshabilitado
+  // (opacity .45 + pointer-events:none). El banner va FUERA del contenedor
+  // deshabilitado para que [Reconectar]/[Conexiones] sí sean clicables.
   return (
-    <div className="space-y-1">
+    <>
+      {readOnly && <ChannelInactiveBanner brandColor={composerBrand.brand} />}
+      <div
+        aria-disabled={readOnly || undefined}
+        className="space-y-1"
+        style={readOnly ? { opacity: 0.45, pointerEvents: 'none' } : undefined}
+      >
       {/* P5 Diseño — Picker plantillas HSM cuando ventana 24h WA expira */}
       {showTemplatePicker && (
         <WhatsAppTemplatePicker
@@ -634,6 +683,7 @@ export function MessageInput({ channel, conversationId, jidType }: MessageInputP
           </span>
         </div>
       )}
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
TICKET P1 front: estado solo-lectura para conversaciones de canal no activo. Sin leak del id interno. Banner [Reconectar] en color de marca. Raíz (canonicalizar channelId) = backend, coordinado. 🤖 Generated with [Claude Code](https://claude.com/claude-code)