### PR TITLE
🐛 fix(appEventos/mesas): mobiliario no se deforma (resize solo +/−) + tarjeta arrastrable completa (incl. Texto)

### DIFF
--- a/apps/appEventos/components/Mesas/DragTable.tsx
+++ b/apps/appEventos/components/Mesas/DragTable.tsx
@@ -51,42 +51,54 @@ interface propsDragTable {
   label?: string
 }
 const DragTable: FC<propsDragTable> = ({ item, label }) => {
-
-  return (
-    <div className={label
-      ? "w-full flex flex-col items-center gap-1.5 py-3 px-1 bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors cursor-grab"
-      : "w-14 h-14 static bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors"}>
-      <div id={`icon${item.title}_${item.tipo}`} className="hidden">
-        <div className="bg-gray-100 opacity-80 rounded-lg w-16 h-16 flex justify-center items-center">
-          <SvgWrapper
-            width={"75%"}
-            height={"75%"}
-            autoScale={true}
-          >
-            {item.icon}
-          </SvgWrapper>
-          <PlusIcon className={`absolute inset-0 m-auto text-primary w-3 h-3`} />
-        </div>
+  // Handlers de drag (crean el espejo dragM y lo limpian). Comunes a ambos modos.
+  const dragHandlers = {
+    onMouseDown: (e: MouseEvent<HTMLDivElement>) => { onMouseDown(e, item) },
+    onMouseUp: () => { onUp(item) },
+    onTouchStart: (e: TouchEvent<HTMLDivElement>) => { onTouchStart(e, item) },
+    onTouchEnd: () => { onUp(item) },
+  }
+  // Espejo oculto que se clona al arrastrar (común a ambos modos).
+  const mirror = (
+    <div id={`icon${item.title}_${item.tipo}`} className="hidden">
+      <div className="bg-gray-100 opacity-80 rounded-lg w-16 h-16 flex justify-center items-center">
+        <SvgWrapper width={"75%"} height={"75%"} autoScale={true}>{item.icon}</SvgWrapper>
+        <PlusIcon className={`absolute inset-0 m-auto text-primary w-3 h-3`} />
       </div>
-      <div className={label ? "flex justify-center items-center text-[#EF5B94]" : "w-full h-full flex-col justify-center items-center cursor-pointer relative"}>
-        <div className={label ? "flex justify-center items-center" : "w-full h-full flex transform hover:scale-105 transition justify-center items-center relative"}>
-          <div id={`dragN${item.title}_${item.tipo}`} className={label ? "js-dragDefault w-7 h-7 flex justify-center items-center" : "js-dragDefault w-full h-12 flex justify-center items-center"}
-            onMouseDown={(e) => { onMouseDown(e, item) }}
-            onMouseUp={() => { onUp(item) }}
-            onTouchStart={(e) => { onTouchStart(e, item) }}
-            onTouchEnd={() => { onUp(item) }} >
-            <SvgWrapper
-              width={label ? "100%" : "85%"}
-              height={label ? "100%" : "85%"}
-              autoScale={true}
-            >
-              {item.icon}
-            </SvgWrapper>
+    </div>
+  )
+
+  // Modo TARJETA (menú Mobiliario, fiel al HTML): TODA la tarjeta es el área arrastrable
+  // (js-dragDefault + #dragN + handlers en el CONTENEDOR). Antes el área era solo el icono
+  // de 28px → agarrando la tarjeta/nombre no arrastraba (Texto/Árbol/etc.).
+  if (label) {
+    return (
+      <div
+        id={`dragN${item.title}_${item.tipo}`}
+        {...dragHandlers}
+        className="js-dragDefault w-full flex flex-col items-center gap-1.5 py-3 px-1 bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors cursor-grab"
+      >
+        {mirror}
+        <div className="w-7 h-7 flex justify-center items-center text-[#EF5B94]">
+          <SvgWrapper width={"100%"} height={"100%"} autoScale={true}>{item.icon}</SvgWrapper>
+        </div>
+        <span className="text-[10px] font-semibold text-[#3A3A42] text-center leading-tight">{label}</span>
+      </div>
+    )
+  }
+
+  // Modo icono (original — sin cambios).
+  return (
+    <div className="w-14 h-14 static bg-[#faf9fb] border-[1.5px] border-[#f0f0f2] hover:border-[#e2e2e6] rounded-[12px] transition-colors">
+      {mirror}
+      <div className="w-full h-full flex-col justify-center items-center cursor-pointer relative">
+        <div className="w-full h-full flex transform hover:scale-105 transition justify-center items-center relative">
+          <div id={`dragN${item.title}_${item.tipo}`} {...dragHandlers} className="js-dragDefault w-full h-12 flex justify-center items-center">
+            <SvgWrapper width={"85%"} height={"85%"} autoScale={true}>{item.icon}</SvgWrapper>
             {item.tipo === "table" && <PlusIcon className={`absolute inset-0 m-auto text-primary w-3 h-3 `} />}
           </div>
         </div>
       </div>
-      {label && <span className="text-[10px] font-semibold text-[#3A3A42] text-center leading-tight">{label}</span>}
     </div>
   );
 };

--- a/apps/appEventos/components/Mesas/LienzoDragable.tsx
+++ b/apps/appEventos/components/Mesas/LienzoDragable.tsx
@@ -243,6 +243,10 @@ export const LiezoDragable: FC<propsLienzoDragable> = ({ scale, lienzo, setDisab
   interact('.js-dragElement')
     .draggable(optionsDrag)
     .resizable({
+      // DESHABILITADO: el resize por arrastre de bordes deformaba el vector
+      // (preserveAspectRatio:false). El tamaño solo cambia con los botones +/−
+      // (handleScaleEl, escala width y height por el mismo factor → proporcional).
+      enabled: false,
       inertia: {
         resistance: 30,
         minSpeed: 200,


### PR DESCRIPTION
2 fixes de Mobiliario, desplegados en app-dev (JTdkSgUxTb3Dk8-uT9ZBh):
- No se deforma: resize por arrastre deshabilitado (enabled:false); solo botones +/− (proporcional).
- Tarjeta ARRASTRABLE completa: js-dragDefault+handlers en el contenedor (antes solo el icono 28px). Aplica a Texto/Árbol/Planta/etc.
Motor interact.js intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)