### PR TITLE
✨ feat(chat-ia/agentes): feed SSE actividad/handoff en tiempo real

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
@@ -38,6 +38,7 @@ import { LobeSessionType, type LobeAgentSession } from '@/types/session';
 
 import { MessagesRail } from '../bandeja/components/MessagesRail';
 import { buildHeaders, getUserContext } from '../bandeja/utils/auth';
+import { useAgentActivity } from './useAgentActivity';
 
 // Colores canal (mismos que ConversationItem — coherencia con Fase A)
 const CHANNEL_DOT: Record<string, string> = {
@@ -128,6 +129,9 @@ export default function AgentesPage() {
   const switchSession = useSessionStore((s) => s.switchSession);
   const activeId = useSessionStore((s) => s.activeId);
   const isSessionListInit = useSessionStore(sessionSelectors.isSessionListInit);
+
+  // Feed en tiempo real de actividad/handoff del agente (SSE api-ia /api/messages/stream).
+  const activityEvents = useAgentActivity(getUserContext().development ?? 'bodasdehoy');
 
   // Prompt editable → escritura vía useAgentStore.updateAgentConfig
   // (persiste PATCH /chat/sessions/{id}). Actúa sobre `activeId`, por eso
@@ -672,7 +676,7 @@ export default function AgentesPage() {
                 />
               </div>
 
-              {/* Actividad reciente — mock hasta SSE handoff */}
+              {/* Actividad reciente — feed en vivo por SSE (api-ia /api/messages/stream). */}
               <div
                 className="rounded-lg p-4"
                 style={{ backgroundColor: '#FFFFFF', border: '1px solid #EDEDF0' }}
@@ -682,17 +686,45 @@ export default function AgentesPage() {
                     Actividad reciente
                   </h3>
                   <span
-                    className="rounded px-1.5 py-0.5 text-[10px] font-semibold"
-                    style={{ backgroundColor: '#FEF3C7', color: '#92400E' }}
-                    title="Feed de actividad pendiente en SSE"
+                    className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                    style={{ backgroundColor: '#DCFCE7', color: '#166534' }}
+                    title="Feed de actividad en tiempo real (SSE)"
                   >
-                    PRÓXIMAMENTE
+                    <span
+                      className="inline-block h-1.5 w-1.5 rounded-full"
+                      style={{ backgroundColor: '#16A34A' }}
+                    />
+                    EN VIVO
                   </span>
                 </div>
-                <p className="text-xs" style={{ color: '#9A9AA6' }}>
-                  Cuando el agente responda o se produzca un handoff aparecerá aquí. Feed en tiempo
-                  real por SSE (pendiente backend).
-                </p>
+                {activityEvents.length === 0 ? (
+                  <p className="text-xs" style={{ color: '#9A9AA6' }}>
+                    Cuando el agente responda o se produzca un handoff aparecerá aquí en tiempo real.
+                  </p>
+                ) : (
+                  <ul className="flex flex-col gap-2">
+                    {activityEvents.map((evt) => (
+                      <li className="flex items-start gap-2" key={evt.id}>
+                        <span
+                          className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+                          style={{
+                            backgroundColor: evt.type === 'handoff' ? '#DC2626' : '#16A34A',
+                          }}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-xs" style={{ color: '#1C1C22' }}>
+                            {evt.text}
+                          </p>
+                          {evt.timestamp ? (
+                            <p className="text-[10px]" style={{ color: '#9A9AA6' }}>
+                              {evt.timestamp}
+                            </p>
+                          ) : null}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
 
               {/* Nota al pie */}

--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/useAgentActivity.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/useAgentActivity.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { buildHeaders } from '../bandeja/utils/auth';
+
+/**
+ * Actividad/handoff en tiempo real para /agentes.
+ *
+ * api-ia emite `event: activity` y `event: handoff` en /api/messages/stream (verificado
+ * 25-jul: /api/messages/stream → 200). El store bandeja consume ese stream pero SOLO bajo
+ * el layout de bandeja; /agentes es otra ruta → suscripción propia, aislada al montar.
+ * Patrón fetch+ReadableStream (no EventSource) para mandar el JWT en Authorization.
+ * Parseo TOLERANTE del payload (varios nombres de campo) porque el shape exacto del evento
+ * no está documentado aún.
+ */
+export interface AgentActivityEvent {
+  agentId?: string;
+  id: string;
+  text: string;
+  timestamp: string;
+  type: 'activity' | 'handoff';
+}
+
+function toText(d: any, type: string): string {
+  return (
+    d?.text ??
+    d?.description ??
+    d?.message ??
+    d?.summary ??
+    (type === 'handoff' ? 'Handoff a un agente humano' : 'Actividad del agente')
+  );
+}
+
+export function useAgentActivity(development: string): AgentActivityEvent[] {
+  const [events, setEvents] = useState<AgentActivityEvent[]>([]);
+  const seq = useRef(0);
+
+  useEffect(() => {
+    if (!development || typeof window === 'undefined') return;
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/messages/stream?development=${encodeURIComponent(development)}`,
+          { headers: { Accept: 'text/event-stream', ...buildHeaders() }, signal: controller.signal },
+        );
+        if (!res.body) return;
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const blocks = buffer.split('\n\n');
+          buffer = blocks.pop() ?? '';
+
+          for (const block of blocks) {
+            let eventType = 'message';
+            let data = '';
+            for (const line of block.split('\n')) {
+              if (line.startsWith('event:')) eventType = line.slice(6).trim();
+              else if (line.startsWith('data:')) data += line.slice(5).trim();
+            }
+            if (eventType !== 'activity' && eventType !== 'handoff') continue;
+            let parsed: any = {};
+            try {
+              parsed = data ? JSON.parse(data) : {};
+            } catch {
+              /* payload no-JSON → texto por defecto */
+            }
+            seq.current += 1;
+            const evt: AgentActivityEvent = {
+              agentId: parsed.agentId ?? parsed.agent_id ?? parsed.sessionId,
+              id: `${eventType}-${parsed.id ?? parsed.timestamp ?? seq.current}`,
+              text: toText(parsed, eventType),
+              timestamp: parsed.timestamp ?? parsed.createdAt ?? '',
+              type: eventType as 'activity' | 'handoff',
+            };
+            setEvents((prev) => [evt, ...prev].slice(0, 30));
+          }
+        }
+      } catch {
+        /* abort al desmontar o corte de red → sin actividad en tiempo real */
+      }
+    })();
+
+    return () => controller.abort();
+  }, [development]);
+
+  return events;
+}


### PR DESCRIPTION
## Qué

Cablea la sección **Actividad reciente** de `/agentes` (era placeholder «PRÓXIMAMENTE») al stream SSE que **api-ia ya emite** en `/api/messages/stream` (`event: activity` + `event: handoff`, verificado → 200).

## Cómo

- **`useAgentActivity.ts`** — hook con suscripción SSE **propia** (fetch + `ReadableStream`, JWT en `Authorization`), aislada al montar `/agentes`. No reusa el singleton `getSSEManager` porque lo consume bandeja (colisión de conexión). Parseo tolerante del payload (shape del evento aún no documentado por api-ia).
- **`page.tsx`** — badge **EN VIVO** + feed real (verde = activity, rojo = handoff), máx. 30 eventos, más reciente arriba.

## Reglas

- Sin fallback: si no hay stream/eventos → estado vacío («aparecerá aquí en tiempo real»).
- Solo `apps/chat-ia` (mi dominio). No toca Mesas/appEventos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)