### PR TITLE
🐛 fix(chat-ia): respuesta del asistente nunca bloqueada por fallo de guardado (P0 inbox) [NO MERGE hasta api-ia parte 1]

### DIFF
--- a/apps/chat-ia/src/services/aiChat.ts
+++ b/apps/chat-ia/src/services/aiChat.ts
@@ -67,16 +67,25 @@ class AiChatService {
     void _abortController;
     const sessionId = params.sessionId;
 
-    // 1) Topic: crear si viene newTopic; si no, usar el activo.
+    // 1) Topic: BEST-EFFORT. /chat/messages NO usa topicId (verificado SSH api-ia
+    //    rest_chat_handler.py:6885 — el input a sendMessage solo lleva role/content/type),
+    //    así que el topic es solo para la lista de topics. Si falla (p.ej. inbox sin sesión
+    //    api-mcp → POST /chat/topics 422), NO debe abortar la persistencia del mensaje ni la
+    //    respuesta del asistente: se continúa sin topic y se reporta. NO es un fallback
+    //    try{nuevo}catch{viejo} — es un efecto secundario best-effort.
     let topicId = params.topicId;
     let isCreateNewTopic = false;
     if (params.newTopic) {
-      topicId = await topicService.createTopic({
-        sessionId,
-        title: params.newTopic.title,
-        // TODO api-ia: mover params.newTopic.topicMessageIds al topic nuevo (server-side antes).
-      } as any);
-      isCreateNewTopic = true;
+      try {
+        topicId = await topicService.createTopic({
+          sessionId,
+          title: params.newTopic.title,
+          // TODO api-ia: mover params.newTopic.topicMessageIds al topic nuevo (server-side antes).
+        } as any);
+        isCreateNewTopic = true;
+      } catch (e) {
+        console.error('[aiChat] createTopic falló; se continúa sin topic:', e);
+      }
     }
 
     // 2) Mensaje de usuario.

--- a/apps/chat-ia/src/store/chat/slices/aiChat/actions/__tests__/generateAIChatV2.test.ts
+++ b/apps/chat-ia/src/store/chat/slices/aiChat/actions/__tests__/generateAIChatV2.test.ts
@@ -291,21 +291,20 @@ describe('generateAIChatV2 actions', () => {
         expect(result.current.internal_execAgentRuntime).not.toHaveBeenCalled();
       });
 
-      it('should handle message creation errors gracefully', async () => {
+      it('should degrade to a local response when persistence fails (never block the assistant)', async () => {
         const { result } = renderHook(() => useChatStore());
         vi.spyOn(aiChatService, 'sendMessageInServer').mockRejectedValue(
           new Error('create message error'),
         );
 
         await act(async () => {
-          try {
-            await result.current.sendMessage({ message: TEST_CONTENT.USER_MESSAGE });
-          } catch {
-            // Expected to throw
-          }
+          await result.current.sendMessage({ message: TEST_CONTENT.USER_MESSAGE });
         });
 
-        expect(result.current.internal_execAgentRuntime).not.toHaveBeenCalled();
+        // P0 (27-jul): un fallo de guardado (p.ej. inbox sin sesión api-mcp → 422) NO debe
+        // impedir la respuesta. sendMessageInServer degrada a mensajes locales y el runtime
+        // IGUAL se ejecuta para que el asistente responda.
+        expect(result.current.internal_execAgentRuntime).toHaveBeenCalled();
       });
     });
 
@@ -395,10 +394,9 @@ describe('generateAIChatV2 actions', () => {
   });
 
   describe('error handling', () => {
-    it('should set error message when sendMessageInServer throws a regular error', async () => {
+    it('should degrade to a local response (not surface a banner) when sendMessageInServer throws a regular error', async () => {
       const { result } = renderHook(() => useChatStore());
-      const errorMessage = 'Network error';
-      const mockError = new TRPCClientError(errorMessage);
+      const mockError = new TRPCClientError('Network error');
       (mockError as any).data = { code: 'BAD_REQUEST' };
 
       vi.spyOn(aiChatService, 'sendMessageInServer').mockRejectedValue(mockError);
@@ -408,9 +406,12 @@ describe('generateAIChatV2 actions', () => {
       });
 
       const operationKey = messageMapKey(TEST_IDS.SESSION_ID, TEST_IDS.TOPIC_ID);
-      expect(result.current.mainSendMessageOperations[operationKey]?.inputSendErrorMsg).toBe(
-        errorMessage,
-      );
+      // Nuevo contrato (P0 27-jul): un error de persistencia NO bloquea ni muestra banner de
+      // error; se degrada a respuesta local. El asistente responde y no se setea inputSendErrorMsg.
+      expect(
+        result.current.mainSendMessageOperations[operationKey]?.inputSendErrorMsg,
+      ).toBeUndefined();
+      expect(result.current.internal_execAgentRuntime).toHaveBeenCalled();
     });
 
     it('should not set error message when receiving a cancel signal', async () => {

--- a/apps/chat-ia/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
+++ b/apps/chat-ia/src/store/chat/slices/aiChat/actions/generateAIChatV2.ts
@@ -12,7 +12,6 @@ import {
   TraceNameMap,
   UIChatMessage,
 } from '@lobechat/types';
-import { TRPCClientError } from '@trpc/client';
 import { t } from 'i18next';
 import { produce } from 'immer';
 import { StateCreator } from 'zustand/vanilla';
@@ -172,16 +171,17 @@ export const generateAIChatV2: StateCreator<
       'creatingMessage/start',
     );
 
+    // BUG-01 root cause (api-ia diagnóstico 27-jun): si agentConfig no tiene
+    // model/provider (sesiones legacy o agentes mal inicializados), cleanObject
+    // en aiChatService los quita → backend recibe newAssistantMessage incompleto.
+    // Guard: usar defaults sane si vienen undefined. (Hoisteado fuera del try
+    // para que el path degradado del catch también pueda usarlos.)
+    const cfg = agentSelectors.currentAgentConfig(getAgentStoreState());
+    const safeModel = cfg.model ?? 'llama-3.3-70b-versatile';
+    const safeProvider = cfg.provider ?? 'groq';
+
     let data: SendMessageServerResponse | undefined;
     try {
-      // BUG-01 root cause (api-ia diagnóstico 27-jun): si agentConfig no tiene
-      // model/provider (sesiones legacy o agentes mal inicializados), cleanObject
-      // en aiChatService los quita → backend recibe newAssistantMessage incompleto
-      // → 500 → topic no se persiste → toast "Failed query insert into topics"
-      // que ve el usuario. Guard: usar defaults sane si vienen undefined.
-      const cfg = agentSelectors.currentAgentConfig(getAgentStoreState());
-      const safeModel = cfg.model ?? 'llama-3.3-70b-versatile';
-      const safeProvider = cfg.provider ?? 'groq';
       data = await aiChatService.sendMessageInServer(
         {
           newUserMessage: {
@@ -214,14 +214,40 @@ export const generateAIChatV2: StateCreator<
         await get().switchTopic(data.topicId, true);
       }
     } catch (e) {
-      if (e instanceof TRPCClientError) {
-        const isAbort = e.message.includes('aborted') || e.name === 'AbortError';
-        // Check if error is due to cancellation
-        if (!isAbort) {
-          get().internal_updateSendMessageOperation(operationKey, { inputSendErrorMsg: e.message });
-          get().mainInputEditor?.setJSONState(jsonState);
-        }
+      const msg = e instanceof Error ? e.message : String(e);
+      const isAbort = msg.includes('aborted') || (e as any)?.name === 'AbortError';
+      if (isAbort) {
+        // Cancelado por el usuario: no degradar ni responder.
+        get().internal_toggleMessageLoading(false, tempId);
+        get().internal_toggleSendMessageOperation(operationKey, false);
+        return;
       }
+
+      // PERSISTENCIA no disponible (P0 27-jul: el inbox no tiene sesión api-mcp →
+      // POST /chat/messages y /chat/topics dan 422). REGLA: un fallo de guardado NUNCA
+      // debe impedir la respuesta del asistente. Reportamos (no lo tragamos) y
+      // DEGRADAMOS a mensajes LOCALES: creamos el placeholder del asistente para que
+      // internal_execAgentRuntime pueda streamear la respuesta. El mensaje de usuario ya
+      // existe optimista (tempId). Cuando api-ia resuelva sessionId vacío → sesión del
+      // user, el happy-path de arriba volverá a persistir SIN tocar esto. No es
+      // fallback try{nuevo}catch{viejo} — es degradación de un efecto secundario.
+      console.error('[persistencia] no se pudo guardar el mensaje; se responde en local:', e);
+      const assistantTmpId = get().internal_createTmpMessage({
+        content: '',
+        fromModel: safeModel,
+        fromProvider: safeProvider,
+        role: 'assistant',
+        sessionId: activeId,
+        threadId: activeThreadId,
+        topicId: activeTopicId,
+      });
+      data = {
+        assistantMessageId: assistantTmpId,
+        isCreateNewTopic: false,
+        messages: chatSelectors.activeBaseChats(get()),
+        topicId: activeTopicId ?? '',
+        userMessageId: tempId,
+      };
     } finally {
       // Stop tracking sendMessageInServer operation
       get().internal_toggleSendMessageOperation(operationKey, false);


### PR DESCRIPTION
## ⚠️ DRAFT — no mergear hasta que api-ia confirme la parte 1

## P0 (QA 27-jul)
Enviar en `/asistente` (inbox) → el asistente **no responde** y el mensaje **no se guarda** (desaparece al recargar). Dato duro: `POST /api/backend/chat/topics → 422`.

## Raíz (SSH read-only api-ia `/opt/backend`)
El **inbox** no tiene sesión en api-mcp → el front manda `sessionId` vacío. Los proxies exigen sessionId:
- `rest_chat_handler.py:7216` `POST /chat/topics` → 422 si vacío (su test `test_chat_endpoints_real.py:352`).
- `rest_chat_handler.py:6885` `POST /chat/messages` → 422 si vacío.

`sendMessageInServer` lanzaba → `generateAIChatV2` solo capturaba `TRPCClientError` → tragaba el `Error` → `data=undefined` → `if(!data) return` **antes** de `internal_execAgentRuntime`. **Un bug, dos síntomas.**

## Fix (front, resiliencia — sin fallback)
- `services/aiChat.ts`: topic **best-effort** (`/chat/messages` ni usa topicId).
- `generateAIChatV2.ts`: fallo de guardado (no-abort) → **reporta** (no traga) + **degrada** a mensajes locales para que el asistente responda. Abort → return limpio.
- Tests: 2 casos al contrato nuevo. `generateAIChatV2.test.ts` 31/31 ✅.

## Depende de (parte 1, api-ia)
Que `/chat/messages` y `/chat/topics`, con `sessionId` vacío, **resuelvan/creen la sesión default del user** (`createLobeSession`, `rest_chat_handler.py:6763`, desde el JWT). Con eso el happy-path persiste sin tocar el front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)