### PR TITLE
🔒 fix(shared/auth): Fase 4 — fail-closed del issuer Firebase (quita default obsoleto)

### DIFF
--- a/packages/shared/src/auth/AuthBridge.ts
+++ b/packages/shared/src/auth/AuthBridge.ts
@@ -36,8 +36,10 @@ export interface AuthBridgeConfig {
 }
 
 // Firebase JWKS for token signature validation
-const FIREBASE_PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'eventosorganizador-55d58';
-const FIREBASE_ISSUER = `https://securetoken.google.com/${FIREBASE_PROJECT_ID}`;
+// Fase 4 (fail-closed): SIN default. El proyecto Firebase (issuer) se exige por env y
+// se deriva dentro de validateFirebaseToken (comprobación diferida), para no validar
+// contra un proyecto obsoleto en silencio ni crashear al importar en apps que no hacen
+// validación server-side.
 const FIREBASE_JWKS_URL = 'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com';
 let _jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
 
@@ -54,9 +56,14 @@ function getJWKS() {
  */
 export async function validateFirebaseToken(token: string): Promise<JWTPayload | null> {
   if (!token) return null;
+  // Fase 4 (fail-closed): exigir el proyecto Firebase por env; sin default obsoleto.
+  const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  if (!projectId) {
+    throw new Error('[AuthBridge] NEXT_PUBLIC_FIREBASE_PROJECT_ID no configurado — no se puede validar el issuer de Firebase (no hay default seguro).');
+  }
   try {
     const { payload } = await jwtVerify(token, getJWKS(), {
-      issuer: FIREBASE_ISSUER,
+      issuer: `https://securetoken.google.com/${projectId}`,
       algorithms: ['RS256'],
     });
     if (payload.exp && payload.exp < Date.now() / 1000) return null;


### PR DESCRIPTION
## Fase 4 — Config fail-closed del issuer Firebase (packages/shared)

`AuthBridge.validateFirebaseToken` validaba el issuer del ID token contra un **default obsoleto** (`eventosorganizador-55d58`) cuando faltaba `NEXT_PUBLIC_FIREBASE_PROJECT_ID`.

### Corrección al informe de auditoría
La auditoría marcó esto CRÍTICO/mina "dormido (env puesto)". **Verificado: el env NO está puesto en 3 de 4 apps** (solo chat-ia). En realidad está dormido porque **`validateFirebaseToken` no tiene NINGÚN llamador en las 4 apps** — es código muerto reservado para middleware. Hoy es **inerte**.

### Cambio (footgun-removal, seguro)
- Quita el default → el proyecto se exige por env.
- El issuer se deriva **dentro de la función** (throw diferido) → **no crashea al importar** en appEventos/memories/editor (que no setean el env ni validan server-side).
- Sin env + validación → `Error` claro (fail-closed), en vez de validar silenciosamente contra el proyecto equivocado.

### Para el equipo shared (decisión de diseño pendiente)
Si en el futuro se usa `validateFirebaseToken` en memories/editor/appEventos, hay que resolver: **appEventos usa múltiples proyectos Firebase por whitelabel** (bodasdehoy-1063, eventosplanificador-74e59, …) → un único `NEXT_PUBLIC_FIREBASE_PROJECT_ID` no sirve; requiere resolución del issuer **per-tenant**.

## Verificación
- 0 referencias huérfanas, `tsc --noEmit` y ESLint limpios en shared.
- Cambio inerte (función sin llamadores) → no requiere rebuild inmediato de apps; incluir en el próximo build multi-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
