### PR TITLE
🔒 fix(chat-ia/auth): acotar cache JWT al exp real (raíz del false-connected)

### DIFF
--- a/apps/chat-ia/src/utils/api-client-optimized.ts
+++ b/apps/chat-ia/src/utils/api-client-optimized.ts
@@ -42,6 +42,22 @@ interface RequestQueueItem {
   resolve: (value: any) => void;
 }
 
+/**
+ * Lee el claim `exp` de un JWT (ms epoch) sin verificar firma. null si no se puede.
+ * Se usa para acotar el cache al vencimiento REAL del token, no a 7 días fijos.
+ */
+function getJwtExpMs(token: string): number | null {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return null;
+    const b64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const json = JSON.parse(atob(b64));
+    return typeof json?.exp === 'number' ? json.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
 export class OptimizedApiClient {
   private tokenCache: TokenCache | null = null;
   private requestQueue: RequestQueueItem[] = [];
@@ -85,12 +101,18 @@ export class OptimizedApiClient {
   }
 
   /**
-   * Guardar token en cache con expiración de 7 días
+   * Guardar token en cache, acotado al vencimiento REAL del JWT (fallback 1h)
    */
   private saveTokenCache(token: string, userId?: string, development?: string): void {
     if (typeof window === 'undefined') return;
 
-    const expiry = Date.now() + (7 * 24 * 60 * 60 * 1000); // 7 días
+    // Acotar el cache al `exp` REAL del JWT (no 7 días fijos): así el cache no finge
+    // una sesión válida más allá de la vida real del token (raíz del "false-connected").
+    // Sin `exp` decodificable → fallback CORTO (1h), nunca 7 días.
+    const realExpMs = getJwtExpMs(token);
+    const expiry = realExpMs && realExpMs > Date.now()
+      ? realExpMs
+      : Date.now() + 60 * 60 * 1000;
     this.tokenCache = { development, expiry, token, userId };
 
     try {


### PR DESCRIPTION
## chat-ia · acotar el cache JWT a la expiración real (raíz del "false-connected")

Corrige la única causa-raíz sólida del *false-connected* que sobrevivió a la verificación de la auditoría 2026-07-30.

### Problema (verificado en código)
`src/utils/api-client-optimized.ts` cacheaba el JWT con `expiry = now + 7 días` **fijo**, ignorando el `exp` real del token, y lo re-guardaba "asumiendo" validez. Resultado: el cache fingía sesión válida más allá de la vida real del token → las rutas que validan de verdad (o cargan chunks) caían a visitante, mientras otras seguían "conectadas" → *"conectado en unas zonas, no en otras"*.

### Fix
- Nuevo helper `getJwtExpMs(token)` que lee el claim `exp` del JWT.
- `saveTokenCache`: `expiry = exp real` (no 7 días). Sin `exp` decodificable → fallback **corto de 1h**, nunca 7 días.

### Verificación
- ESLint 0 errores. Cambio mínimo (+24/−2), sin tocar la lógica de renovación (useTokenRefresh) ni el ReloginBanner.
- Deploy: chat-ia se compila en el portátil → **pendiente de build+deploy** para verlo en chat-dev.

### Correcciones a la auditoría (no bugs de código actual)
- `/files → producción`: el código actual maneja `-dev` → app-dev (`FileGuestGate.tsx:14`); lo observado era build viejo/caché.
- `ChunkLoadError` en /settings: el build actual tiene los chunks; es caché del navegador del auditor (mismo patrón que app-dev).
- "la UI no representa el estado degradado": sí lo hace, vía `ReloginBanner.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
