### PR TITLE
🔒 fix(shared/auth): SessionManager — refresco central del token cross-app (cierra el plan de sesión)

### DIFF
--- a/apps/chat-ia/src/layout/GlobalProvider/StoreInitialization.tsx
+++ b/apps/chat-ia/src/layout/GlobalProvider/StoreInitialization.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { startSessionRefresh } from '@bodasdehoy/shared';
 import { useRouter } from 'next/navigation';
 import { memo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +23,25 @@ const StoreInitialization = memo(() => {
   useTranslation('error');
 
   useTokenRefresh();
+
+  // FASE 1 auth (fallback FB-2 de la auditoría 28-jul): refresco CENTRAL y proactivo de la
+  // cookie SSO `idTokenV0.1.0`. Antes SOLO appEventos la refrescaba (SocketContext), así que
+  // en chat-ia el token de 1 h moría dentro de la cookie de 30 d → sesión "muerta" en silencio.
+  // Ahora chat-ia también la mantiene al día vía el primitivo compartido startSessionRefresh
+  // (onIdTokenChanged + timer proactivo). Import diferido de firebase para no romper SSR.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let stop: (() => void) | undefined;
+    (async () => {
+      try {
+        const { auth } = await import('@/libs/firebase');
+        if (auth) stop = startSessionRefresh(auth as any);
+      } catch (e) {
+        console.warn('[StoreInitialization] no se pudo arrancar el refresco de sesión central:', e);
+      }
+    })();
+    return () => stop?.();
+  }, []);
 
   const router = useRouter();
   const useInitUserState = useUserStore((s) => s.useInitUserState);

--- a/packages/shared/src/auth/SessionManager.ts
+++ b/packages/shared/src/auth/SessionManager.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-var */
+declare var window: any;
+/**
+ * SessionManager — renovación CENTRAL y PROACTIVA del ID token de Firebase.
+ *
+ * Problema (auditoría auth 28-jul, fallback FB-2): el token de Firebase vive 1 h pero
+ * la cookie SSO `idTokenV0.1.0` vive 30 días, y HOY solo appEventos la refresca
+ * (SocketContext.onIdTokenChanged), con pestaña abierta y si `securetoken` responde.
+ * Cuando cualquier eslabón cae, la cookie sirve un token muerto hasta 30 días → sesión
+ * "muerta" en silencio en el resto de apps (chat-ia/memories/editor solo LEEN la cookie).
+ *
+ * Solución: una primitiva compartida que CUALQUIER app arranca una vez. Mantiene la cookie
+ * cross-app al día por dos vías redundantes:
+ *   1. `onIdTokenChanged` — Firebase rota el token (~1 h) → reescribimos la cookie.
+ *   2. timer proactivo — fuerza `getIdToken(true)` ~10 min antes de expirar, por si la
+ *      pestaña estuvo en background y el SDK no rotó.
+ * Y `getFreshToken()` para el patrón "nunca enviar un token caducado": pídelo justo antes
+ * de llamar al backend (Firebase auto-refresca si está por expirar).
+ *
+ * No importa `firebase/auth` (para no atar el paquete shared a una versión); recibe una
+ * instancia con la forma mínima que usamos. Sin fallback silencioso: si el refresco falla,
+ * se reporta por consola y NO se rompe el hilo (el backend rechazará y la UI podrá escalar).
+ */
+import { setCrossAppIdToken } from './SessionBridge';
+
+export interface FirebaseUserLike {
+  getIdToken: (forceRefresh?: boolean) => Promise<string>;
+}
+
+export interface FirebaseAuthLike {
+  currentUser: FirebaseUserLike | null;
+  onIdTokenChanged: (cb: (user: FirebaseUserLike | null) => void) => () => void;
+}
+
+// Token de Firebase: 60 min. Refrescamos ~10 min antes → ventana de 50 min.
+const PROACTIVE_REFRESH_MS = 50 * 60 * 1000;
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+let _unsub: (() => void) | null = null;
+
+/**
+ * Arranca la renovación central. Idempotente por app (llamar una vez; re-llamar
+ * reinicia limpio). Devuelve un `stop()` para desmontar.
+ */
+export function startSessionRefresh(auth: FirebaseAuthLike): () => void {
+  if (typeof window === 'undefined' || !auth) return () => undefined;
+
+  stopSessionRefresh();
+
+  // 1) Rotación natural del SDK → mantener la cookie cross-app al día.
+  _unsub = auth.onIdTokenChanged(async (user) => {
+    if (!user) return;
+    try {
+      const token = await user.getIdToken();
+      if (token) setCrossAppIdToken(token);
+    } catch (e) {
+      console.warn('[SessionManager] onIdTokenChanged: no se pudo refrescar la cookie SSO:', e);
+    }
+  });
+
+  // 2) Refresco proactivo forzado (cubre pestañas en background donde el SDK no rota).
+  _timer = setInterval(async () => {
+    const u = auth.currentUser;
+    if (!u) return;
+    try {
+      const token = await u.getIdToken(true);
+      if (token) setCrossAppIdToken(token);
+    } catch (e) {
+      console.warn('[SessionManager] refresco proactivo falló (securetoken?):', e);
+    }
+  }, PROACTIVE_REFRESH_MS);
+
+  return stopSessionRefresh;
+}
+
+export function stopSessionRefresh(): void {
+  if (_unsub) {
+    try {
+      _unsub();
+    } catch {
+      /* noop */
+    }
+    _unsub = null;
+  }
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+/**
+ * Token de Firebase SIEMPRE fresco: `getIdToken()` auto-refresca si está por expirar.
+ * Devuelve null si no hay sesión. De paso, mantiene la cookie SSO al día. Úsalo justo
+ * antes de cualquier llamada al backend para no enviar nunca un token caducado.
+ */
+export async function getFreshToken(auth: FirebaseAuthLike): Promise<string | null> {
+  if (typeof window === 'undefined' || !auth?.currentUser) return null;
+  try {
+    const token = await auth.currentUser.getIdToken();
+    if (token) setCrossAppIdToken(token);
+    return token || null;
+  } catch (e) {
+    console.warn('[SessionManager] getFreshToken falló:', e);
+    return null;
+  }
+}

--- a/packages/shared/src/auth/__tests__/SessionManager.test.ts
+++ b/packages/shared/src/auth/__tests__/SessionManager.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Aislar SessionManager de la escritura real de cookie.
+vi.mock('../SessionBridge', () => ({
+  setCrossAppIdToken: vi.fn(),
+}));
+
+import { setCrossAppIdToken } from '../SessionBridge';
+import { startSessionRefresh, stopSessionRefresh, getFreshToken } from '../SessionManager';
+
+const mockSet = setCrossAppIdToken as unknown as ReturnType<typeof vi.fn>;
+
+// Mock mínimo con la forma FirebaseAuthLike que usa SessionManager.
+function makeAuth(token: string | null) {
+  const user = token ? { getIdToken: vi.fn(async (_force?: boolean) => token) } : null;
+  const auth: any = {
+    currentUser: user,
+    _cb: null as null | ((u: any) => void),
+    onIdTokenChanged: vi.fn((cb: (u: any) => void) => {
+      auth._cb = cb;
+      return vi.fn(); // función de desuscripción
+    }),
+  };
+  return auth;
+}
+
+beforeEach(() => {
+  (globalThis as any).window = (globalThis as any).window || {};
+  mockSet.mockClear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  stopSessionRefresh();
+  vi.useRealTimers();
+});
+
+describe('SessionManager — refresco central del token cross-app', () => {
+  it('getFreshToken devuelve el token y mantiene la cookie SSO al día', async () => {
+    const auth = makeAuth('tok-123');
+    const t = await getFreshToken(auth);
+    expect(t).toBe('tok-123');
+    expect(auth.currentUser.getIdToken).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalledWith('tok-123');
+  });
+
+  it('getFreshToken devuelve null si no hay sesión (no escribe cookie)', async () => {
+    const auth = makeAuth(null);
+    const t = await getFreshToken(auth);
+    expect(t).toBeNull();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('startSessionRefresh se suscribe a onIdTokenChanged y refresca la cookie al rotar el SDK', async () => {
+    const auth = makeAuth('tok-A');
+    const stop = startSessionRefresh(auth);
+    expect(auth.onIdTokenChanged).toHaveBeenCalledTimes(1);
+    expect(typeof stop).toBe('function');
+    // simular rotación natural del token (~1h)
+    await auth._cb!(auth.currentUser);
+    expect(mockSet).toHaveBeenCalledWith('tok-A');
+  });
+
+  it('el timer proactivo fuerza getIdToken(true) antes de expirar (cubre pestaña en background)', async () => {
+    const auth = makeAuth('tok-P');
+    startSessionRefresh(auth);
+    mockSet.mockClear();
+    await vi.advanceTimersByTimeAsync(50 * 60 * 1000); // ventana proactiva
+    expect(auth.currentUser.getIdToken).toHaveBeenCalledWith(true);
+    expect(mockSet).toHaveBeenCalledWith('tok-P');
+  });
+
+  it('stopSessionRefresh desuscribe y limpia el timer (idempotente)', () => {
+    const auth = makeAuth('tok-S');
+    startSessionRefresh(auth);
+    expect(() => stopSessionRefresh()).not.toThrow();
+    expect(() => stopSessionRefresh()).not.toThrow();
+  });
+
+  it('sin window (SSR) no arranca nada y devuelve noop', () => {
+    const saved = (globalThis as any).window;
+    delete (globalThis as any).window;
+    const auth = makeAuth('tok-SSR');
+    const stop = startSessionRefresh(auth);
+    expect(auth.onIdTokenChanged).not.toHaveBeenCalled();
+    expect(typeof stop).toBe('function');
+    (globalThis as any).window = saved;
+  });
+});

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -13,3 +13,9 @@ export {
   clearCrossAppSession,
   CROSS_APP_DEVELOPMENT_COOKIE,
 } from './SessionBridge';
+export {
+  startSessionRefresh,
+  stopSessionRefresh,
+  getFreshToken,
+} from './SessionManager';
+export type { FirebaseAuthLike, FirebaseUserLike } from './SessionManager';


### PR DESCRIPTION
## Contexto
Cierra la pieza que faltaba del **plan de saneamiento de sesión** (incidencia 17-19 jul, pico 2.880 `id-token-expired`).

**Raíz de la incidencia:** el token Firebase (1h) vive dentro de la cookie SSO `idTokenV0.1.0` (30d) y **solo appEventos la refrescaba** (SocketContext) → chat-ia/memories/editor solo LEEN la cookie → cuando el token muere, la sesión muere en silencio en esas apps.

Las Fases 1-3 (PR #231) resolvieron esto **solo para appEventos**. Esta PR aporta la **pieza cross-app** que faltaba.

## Qué añade
- **`packages/shared/src/auth/SessionManager.ts`** — primitiva compartida `startSessionRefresh(auth)` que CUALQUIER app arranca una vez. Mantiene la cookie cross-app al día por dos vías redundantes:
  1. `onIdTokenChanged` (rotación natural del SDK ~1h)
  2. timer proactivo (`getIdToken(true)` ~10 min antes de expirar — cubre pestañas en background)
  + `getFreshToken()` para "nunca enviar un token caducado".
  Sin atar `firebase/auth` (inyección de dependencia). Sin fallback silencioso.
- **chat-ia** (`StoreInitialization`) arranca `startSessionRefresh` → chat-ia deja de servir un token muerto de la cookie.
- **6 tests** (`SessionManager.test.ts`) — deuda de test del plan.

## Pendiente (follow-up, NO en esta PR)
- Adoptar en appEventos (migrar `SocketContext.onIdTokenChanged` a `startSessionRefresh`) → un único punto de refresco en las 4 apps. memories/editor son consumidores puros (no requieren cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)