### PR TITLE
🔒 fix(appEventos/auth): adoptar startSessionRefresh — refresco proactivo cross-app (cierra el plan de sesión)

### DIFF
--- a/apps/appEventos/context/SocketContext.tsx
+++ b/apps/appEventos/context/SocketContext.tsx
@@ -5,7 +5,7 @@ import { api } from '../api';
 import { Dispatch } from 'react';
 import { getCookie } from '../utils/Cookies';
 import Cookies from "js-cookie";
-import { setCrossAppIdToken } from "@bodasdehoy/shared/auth";
+import { setCrossAppIdToken, startSessionRefresh } from "@bodasdehoy/shared/auth";
 import { useRouter, useSearchParams } from "next/navigation";
 import { parseJwt } from "../utils/Authentication"
 import { Notification, ResultNotifications } from "../utils/Interfaces";
@@ -81,6 +81,22 @@ const SocketProvider: FC<any> = ({ children }): React.ReactElement => {
       // Firebase no inicializado (SSR o anonymous)
     }
   }, [socket, config?.development])
+
+  // Refresco CENTRAL y PROACTIVO del token (SessionManager compartido). El efecto de
+  // arriba solo reacciona a la rotación natural del SDK (~1h) y reconecta el socket;
+  // startSessionRefresh añade además un timer que fuerza getIdToken(true) ~10 min antes
+  // de expirar → mantiene viva la cookie SSO cross-app aunque la pestaña esté en background
+  // (raíz de la incidencia 17-19jul). Es el MISMO primitivo que usa chat-ia → un único
+  // mecanismo de refresco en las 4 apps. No-op si no hay sesión.
+  useEffect(() => {
+    if (!config?.development) return
+    try {
+      const stop = startSessionRefresh(getAuth() as any)
+      return () => stop()
+    } catch (e) {
+      // Firebase no inicializado (SSR/anonymous)
+    }
+  }, [config?.development])
 
   useEffect(() => {
     if (!socket) return


### PR DESCRIPTION
Último paso del **plan de saneamiento de sesión**: appEventos adopta el primitivo compartido `startSessionRefresh` (SessionManager, PR #236) que ya usa chat-ia.

## Qué cambia
- `SocketContext` arranca `startSessionRefresh(getAuth())` cuando hay `development`.
- El efecto `onIdTokenChanged` existente (rotación ~1h + reconexión del socket) se mantiene; esto **añade el timer proactivo** (`getIdToken(true)` ~10 min antes de expirar) que cubre pestañas en background — la raíz de la incidencia 17-19 jul.
- **Un único mecanismo de refresco en las 4 apps** (appEventos + chat-ia; memories/editor son consumidores puros).

## Riesgo
Cambio **aditivo**: no toca la reconexión del socket. `startSessionRefresh` es no-op si no hay sesión. Build appEventos ✅, ESLint ✅.

Con esto el plan de sesión queda: F1-F3 (#231) · F4 (#232) · JWT cache (#235) · SessionManager (#236) · adopción appEventos (esta PR). Pendiente solo F5 (BFF HttpOnly, backend, bloqueada por acceso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)