### PR TITLE
💄 fix(mesas): rediseño modal + eliminar plano + QA #1-4 + fix front error-conexión eventos

### DIFF
--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -271,7 +271,7 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
     tableNumber: nextTableNumber,
     ...(TABLE_DEFAULTS[defaultShape] ?? TABLE_DEFAULTS.round),
     // Look del prototipo: mesa y sillas en GRIS (no beige) — sobrescribe los defaults beige.
-    tableColor: '#e6e6ea', chairColor: '#c9c9cf', chairStyle: 'modern',
+    tableColor: '#ececef', chairColor: '#ffffff', chairStyle: 'modern',
     ...initialConfig,
   });
   const [previewSVG, setPreviewSVG] = useState('');

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -11,6 +11,7 @@
  * + datos adicionales (svgString, tableConfig) que el sistema actual ignora.
  */
 import { useState, useEffect, useCallback, CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import { generateTableSVG, getMaxSeats, TABLE_DEFAULTS, getTableTotalSize } from '@bodasdehoy/shared/utils';
 import type { TableConfig, ChairStyle, TableShape } from '@bodasdehoy/shared/utils';
 import { EventContextProvider } from '../../context';
@@ -318,9 +319,11 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
   const maxPerLongSide = isRect ? Math.floor((config.realWidthCm ?? 240) / 45) : 0;
   const totalSize = getTableTotalSize(config);
 
-  return (
+  if (typeof document === 'undefined') return null;
+  return createPortal(
     <div style={s.overlay}>
       <div style={s.modal}>
+        <style>{`.tc-round-check{appearance:none;-webkit-appearance:none;width:17px;height:17px;border:1.6px solid #c4c4cc;border-radius:50%;cursor:pointer;position:relative;flex:none;vertical-align:middle}.tc-round-check:checked{background:#EF5B94;border-color:#EF5B94}.tc-round-check:checked::after{content:'';position:absolute;left:5px;top:2.5px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}`}</style>
         <div style={s.header}>
           <h2 style={s.title}>{initialConfig ? 'Editar mesa' : 'Diseñar mesa'}</h2>
           <button style={s.closeBtn} type="button" onClick={onCancel}>✕</button>
@@ -396,7 +399,7 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
               <div style={s.toggleRow}>
                 {([['isHeadTable', 'Mesa de novios'], ['isKidsTable', 'Mesa infantil']] as [keyof TableConfig, string][]).map(([key, label]) => (
                   <label key={key} style={s.toggleLabel}>
-                    <input type="checkbox" checked={!!config[key]} onChange={e => update(key, e.target.checked as any)} />{' '}{label}
+                    <input type="checkbox" className="tc-round-check" checked={!!config[key]} onChange={e => update(key, e.target.checked as any)} />{' '}{label}
                   </label>
                 ))}
               </div>
@@ -424,7 +427,8 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -481,7 +485,7 @@ function SeatDistributor({ seatsTop, seatsBottom, seatsLeft, seatsRight, maxPerS
 const s: Record<string, CSSProperties> = {
   // Drawer desde la IZQUIERDA (fiel al HTML): full-height, no centrado → no se corta.
   overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'stretch', justifyContent: 'flex-start', zIndex: 99999, backdropFilter: 'blur(3px)' },
-  modal: { background: '#fff', borderTopRightRadius: 18, borderBottomRightRadius: 18, width: 'min(600px, 92vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
+  modal: { background: '#fff', borderTopRightRadius: 18, borderBottomRightRadius: 18, width: 'min(700px, 94vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
   header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 24px', borderBottom: '1px solid #f0f0f2', background: '#fff' },
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },
   closeBtn: { background: 'none', border: 'none', fontSize: 20, cursor: 'pointer', color: '#a0a0a8', padding: '4px 8px' },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -484,8 +484,9 @@ function SeatDistributor({ seatsTop, seatsBottom, seatsLeft, seatsRight, maxPerS
 
 const s: Record<string, CSSProperties> = {
   // Drawer desde la IZQUIERDA (fiel al HTML): full-height, no centrado → no se corta.
-  overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'stretch', justifyContent: 'flex-start', zIndex: 99999, backdropFilter: 'blur(3px)' },
-  modal: { background: '#fff', borderTopRightRadius: 18, borderBottomRightRadius: 18, width: 'min(700px, 94vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
+  // Card flotante a la izquierda (fiel al HTML): NO full-height, con márgenes + esquinas redondeadas.
+  overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'flex-start', padding: '20px 20px 20px 24px', zIndex: 99999, backdropFilter: 'blur(3px)' },
+  modal: { background: '#fff', borderRadius: 20, width: 'min(700px, 94vw)', maxHeight: '88vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '0 24px 80px rgba(0,0,0,0.3)' },
   header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 24px', borderBottom: '1px solid #f0f0f2', background: '#fff' },
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },
   closeBtn: { background: 'none', border: 'none', fontSize: 20, cursor: 'pointer', color: '#a0a0a8', padding: '4px 8px' },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -271,6 +271,8 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
   const [config, setConfig] = useState<TableConfig>({
     tableNumber: nextTableNumber,
     ...(TABLE_DEFAULTS[defaultShape] ?? TABLE_DEFAULTS.round),
+    // Look del prototipo: mesa y sillas en GRIS (no beige) — sobrescribe los defaults beige.
+    tableColor: '#e6e6ea', chairColor: '#c9c9cf', chairStyle: 'modern',
     ...initialConfig,
   });
   const [previewSVG, setPreviewSVG] = useState('');
@@ -327,6 +329,12 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
 
         <div style={s.body}>
           <div style={s.controls}>
+            {/* NOMBRE DE LA MESA */}
+            <section style={s.section}>
+              <div style={s.sectionTitle}>Nombre de la mesa</div>
+              <input type="text" value={config.tableName ?? ''} placeholder="Ej: Mesa 1" onChange={e => update('tableName', e.target.value)} style={{ ...s.textInput, width: '100%', boxSizing: 'border-box' }} />
+            </section>
+
             {/* FORMA */}
             <section style={s.section}>
               <div style={s.sectionTitle}>Forma</div>
@@ -381,29 +389,13 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
                   <option value="none">Sin sillas</option>
                 </select>
               </div>
-              <div style={s.fieldRow}>
-                <label style={s.label}>Color sillas</label>
-                <input type="color" value={config.chairColor ?? '#E8D5B7'} onChange={e => update('chairColor', e.target.value)} style={s.colorPicker} />
-              </div>
             </section>
 
-            {/* ASPECTO */}
+            {/* TIPO DE MESA — el usuario pidió mantener Novios / Infantil */}
             <section style={s.section}>
-              <div style={s.sectionTitle}>Aspecto</div>
-              <div style={s.fieldRow}>
-                <label style={s.label}>Color mesa</label>
-                <input type="color" value={config.tableColor ?? '#F5F0E8'} onChange={e => update('tableColor', e.target.value)} style={s.colorPicker} />
-              </div>
-              <div style={s.fieldRow}>
-                <label style={s.label}>Nº de mesa</label>
-                <input type="number" value={config.tableNumber ?? 1} min={1} max={999} onChange={e => update('tableNumber', Number(e.target.value))} style={s.numInput} />
-              </div>
-              <div style={s.fieldRow}>
-                <label style={s.label}>Nombre</label>
-                <input type="text" value={config.tableName ?? ''} placeholder="Ej: Mesa Familia García" onChange={e => update('tableName', e.target.value)} style={s.textInput} />
-              </div>
+              <div style={s.sectionTitle}>Tipo de mesa</div>
               <div style={s.toggleRow}>
-                {([['showNumber', 'Mostrar número'], ['showName', 'Mostrar nombre'], ['isHeadTable', 'Mesa de novios'], ['isKidsTable', 'Mesa infantil']] as [keyof TableConfig, string][]).map(([key, label]) => (
+                {([['isHeadTable', 'Mesa de novios'], ['isKidsTable', 'Mesa infantil']] as [keyof TableConfig, string][]).map(([key, label]) => (
                   <label key={key} style={s.toggleLabel}>
                     <input type="checkbox" checked={!!config[key]} onChange={e => update(key, e.target.checked as any)} />{' '}{label}
                   </label>
@@ -490,7 +482,7 @@ function SeatDistributor({ seatsTop, seatsBottom, seatsLeft, seatsRight, maxPerS
 const s: Record<string, CSSProperties> = {
   // Drawer desde la IZQUIERDA (fiel al HTML): full-height, no centrado → no se corta.
   overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'stretch', justifyContent: 'flex-start', zIndex: 1000, backdropFilter: 'blur(3px)' },
-  modal: { background: '#fff', borderRadius: 0, width: 'min(760px, 94vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
+  modal: { background: '#fff', borderTopRightRadius: 18, borderBottomRightRadius: 18, width: 'min(600px, 92vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
   header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 24px', borderBottom: '1px solid #f0f0f2', background: '#fff' },
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },
   closeBtn: { background: 'none', border: 'none', fontSize: 20, cursor: 'pointer', color: '#a0a0a8', padding: '4px 8px' },
@@ -522,7 +514,7 @@ const s: Record<string, CSSProperties> = {
   textInput: { flex: 1, padding: '9px 10px', border: '1px solid #E7E7EA', borderRadius: 10, fontSize: 13, color: '#3A3A42' },
   toggleRow: { display: 'flex', flexWrap: 'wrap', gap: 12, marginTop: 8 },
   toggleLabel: { fontSize: 13, color: '#6b6b72', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 },
-  preview: { width: 320, padding: 20, background: '#FAFAFB', display: 'flex', flexDirection: 'column' },
+  preview: { width: 250, flexShrink: 0, padding: 16, background: '#FAFAFB', display: 'flex', flexDirection: 'column' },
   previewTitle: { fontSize: 11, fontWeight: 700, color: '#b3b3ba', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 12 },
   previewCanvas: { flex: 1, background: '#fff', borderRadius: 16, border: '1px solid #E7E7EA', display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', padding: 12, backgroundImage: 'radial-gradient(circle, #e2e2e6 1px, transparent 1px)', backgroundSize: '15px 15px' },
   previewSVG: { maxWidth: '100%', maxHeight: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -263,7 +263,6 @@ const SHAPES: { id: TableShape; label: string }[] = [
   { id: 'rectangular', label: 'Rectangular' },
   { id: 'oval', label: 'Oval' },
   { id: 'square', label: 'Cuadrada' },
-  { id: 'semicircle', label: 'Novios' },
 ];
 
 export default function TableConfigurator({ initialConfig, onConfirm, onCancel, nextTableNumber = 1 }: TableConfiguratorProps) {
@@ -481,7 +480,7 @@ function SeatDistributor({ seatsTop, seatsBottom, seatsLeft, seatsRight, maxPerS
 
 const s: Record<string, CSSProperties> = {
   // Drawer desde la IZQUIERDA (fiel al HTML): full-height, no centrado → no se corta.
-  overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'stretch', justifyContent: 'flex-start', zIndex: 1000, backdropFilter: 'blur(3px)' },
+  overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'stretch', justifyContent: 'flex-start', zIndex: 99999, backdropFilter: 'blur(3px)' },
   modal: { background: '#fff', borderTopRightRadius: 18, borderBottomRightRadius: 18, width: 'min(600px, 92vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
   header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 24px', borderBottom: '1px solid #f0f0f2', background: '#fff' },
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -488,8 +488,9 @@ function SeatDistributor({ seatsTop, seatsBottom, seatsLeft, seatsRight, maxPerS
 // ─── Estilos ───────────────────────────────────────────────────────────────
 
 const s: Record<string, CSSProperties> = {
-  overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, backdropFilter: 'blur(3px)' },
-  modal: { background: '#fff', borderRadius: 16, width: '90vw', maxWidth: 900, maxHeight: '90vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '0 24px 80px rgba(0,0,0,0.3)' },
+  // Drawer desde la IZQUIERDA (fiel al HTML): full-height, no centrado → no se corta.
+  overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.45)', display: 'flex', alignItems: 'stretch', justifyContent: 'flex-start', zIndex: 1000, backdropFilter: 'blur(3px)' },
+  modal: { background: '#fff', borderRadius: 0, width: 'min(760px, 94vw)', height: '100vh', maxHeight: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '24px 0 80px rgba(0,0,0,0.3)' },
   header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 24px', borderBottom: '1px solid #f0f0f2', background: '#fff' },
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },
   closeBtn: { background: 'none', border: 'none', fontSize: 20, cursor: 'pointer', color: '#a0a0a8', padding: '4px 8px' },
@@ -498,8 +499,8 @@ const s: Record<string, CSSProperties> = {
   section: { marginBottom: 20, paddingBottom: 16, borderBottom: '1px solid #f2f2f4' },
   sectionTitle: { fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#b3b3ba', marginBottom: 12 },
   shapeGrid: { display: 'flex', flexWrap: 'wrap', gap: 7 },
-  shapeBtn: { padding: '8px 13px', border: '1.5px solid #E7E7EA', borderRadius: 9, background: '#fff', cursor: 'pointer', fontSize: 12, fontWeight: 600, color: '#6b6b72' },
-  shapeBtnActive: { borderColor: '#EF5B94', background: '#FCF2F6', color: '#EF5B94', fontWeight: 600 },
+  shapeBtn: { padding: '8px 13px', border: '1.5px solid #E7E7EA', borderRadius: 9, background: '#f7f7f9', cursor: 'pointer', fontSize: 12, fontWeight: 600, color: '#6b6b72' },
+  shapeBtnActive: { borderColor: '#c4c4cc', background: '#e9e9ee', color: '#3A3A42', fontWeight: 700 },
   fieldRow: { display: 'flex', alignItems: 'center', gap: 12, marginBottom: 10 },
   label: { fontSize: 13, color: '#6b6b72', minWidth: 100, flexShrink: 0 },
   sliderWrap: { flex: 1, display: 'flex', alignItems: 'center', gap: 10 },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -272,7 +272,7 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
     tableNumber: nextTableNumber,
     ...(TABLE_DEFAULTS[defaultShape] ?? TABLE_DEFAULTS.round),
     // Look del prototipo: mesa y sillas en GRIS (no beige) — sobrescribe los defaults beige.
-    tableColor: '#ececef', chairColor: '#ffffff', chairStyle: 'modern',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     ...initialConfig,
   });
   const [previewSVG, setPreviewSVG] = useState('');
@@ -323,7 +323,7 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
   return createPortal(
     <div style={s.overlay}>
       <div style={s.modal}>
-        <style>{`.tc-round-check{appearance:none;-webkit-appearance:none;width:17px;height:17px;border:1.6px solid #c4c4cc;border-radius:50%;cursor:pointer;position:relative;flex:none;vertical-align:middle}.tc-round-check:checked{background:#EF5B94;border-color:#EF5B94}.tc-round-check:checked::after{content:'';position:absolute;left:5px;top:2.5px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}`}</style>
+        <style>{`.tc-round-check{appearance:none;-webkit-appearance:none;width:17px;height:17px;border:1.6px solid #c4c4cc;border-radius:50%;cursor:pointer;position:relative;flex:none;vertical-align:middle}.tc-round-check:checked{background:#EF5B94;border-color:#EF5B94}.tc-round-check:checked::after{content:'';position:absolute;left:5px;top:2.5px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}.tc-slider{-webkit-appearance:none;appearance:none;height:6px;border-radius:6px;background:#E7E7EA;width:100%;outline:none}.tc-slider::-webkit-slider-thumb{-webkit-appearance:none;width:16px;height:16px;border-radius:50%;background:#EF5B94;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.25)}.tc-slider::-moz-range-thumb{width:16px;height:16px;border:none;border-radius:50%;background:#EF5B94;cursor:pointer}`}</style>
         <div style={s.header}>
           <h2 style={s.title}>{initialConfig ? 'Editar mesa' : 'Diseñar mesa'}</h2>
           <button style={s.closeBtn} type="button" onClick={onCancel}>✕</button>
@@ -408,7 +408,6 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
 
           {/* Preview */}
           <div style={s.preview}>
-            <div style={s.previewTitle}>Vista previa</div>
             <div style={s.previewCanvas}>
               {previewSVG && <div style={s.previewSVG} dangerouslySetInnerHTML={{ __html: previewSVG }} />}
             </div>
@@ -439,7 +438,7 @@ function SliderField({ label, value, min, max, step = 1, unit = '', onChange }: 
     <div style={s.fieldRow}>
       <label style={s.label}>{label}</label>
       <div style={s.sliderWrap}>
-        <input type="range" min={min} max={max} step={step} value={value} onChange={e => onChange(Number(e.target.value))} style={s.slider} />
+        <input type="range" className="tc-slider" min={min} max={max} step={step} value={value} onChange={e => onChange(Number(e.target.value))} style={s.slider} />
         <span style={s.sliderValue}>{value}{unit}</span>
       </div>
     </div>
@@ -486,14 +485,14 @@ const s: Record<string, CSSProperties> = {
   // Drawer desde la IZQUIERDA (fiel al HTML): full-height, no centrado → no se corta.
   // Card flotante a la izquierda (fiel al HTML): NO full-height, con márgenes + esquinas redondeadas.
   overlay: { position: 'fixed', inset: 0, background: 'rgba(43,43,48,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'flex-start', padding: '20px 20px 20px 24px', zIndex: 99999, backdropFilter: 'blur(3px)' },
-  modal: { background: '#fff', borderRadius: 20, width: 'min(700px, 94vw)', maxHeight: '88vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '0 24px 80px rgba(0,0,0,0.3)' },
+  modal: { background: '#fff', borderRadius: 20, width: 'min(700px, 94vw)', maxHeight: '88vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxShadow: '0 24px 80px rgba(0,0,0,0.3)', fontFamily: 'Poppins, system-ui, -apple-system, sans-serif' },
   header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '16px 24px', borderBottom: '1px solid #f0f0f2', background: '#fff' },
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },
   closeBtn: { background: 'none', border: 'none', fontSize: 20, cursor: 'pointer', color: '#a0a0a8', padding: '4px 8px' },
   body: { display: 'flex', flex: 1, overflow: 'hidden' },
-  controls: { flex: 1, overflowY: 'auto', padding: '16px 20px', borderRight: '1px solid #f2f2f4' },
-  section: { marginBottom: 20, paddingBottom: 16, borderBottom: '1px solid #f2f2f4' },
-  sectionTitle: { fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#b3b3ba', marginBottom: 12 },
+  controls: { width: 296, flexShrink: 0, overflowY: 'auto', padding: 20, borderRight: '1px solid #f2f2f4', display: 'flex', flexDirection: 'column', gap: 18 },
+  section: {},
+  sectionTitle: { fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '1px', color: '#b3b3ba', marginBottom: 10 },
   shapeGrid: { display: 'flex', flexWrap: 'wrap', gap: 7 },
   shapeBtn: { padding: '8px 13px', border: '1.5px solid #E7E7EA', borderRadius: 9, background: '#f7f7f9', cursor: 'pointer', fontSize: 12, fontWeight: 600, color: '#6b6b72' },
   shapeBtnActive: { borderColor: '#c4c4cc', background: '#e9e9ee', color: '#3A3A42', fontWeight: 700 },
@@ -503,7 +502,7 @@ const s: Record<string, CSSProperties> = {
   slider: { flex: 1, accentColor: '#EF5B94' } as CSSProperties,
   sliderValue: { fontSize: 13, fontWeight: 700, color: '#3A3A42', minWidth: 50, textAlign: 'right' },
   stepper: { display: 'flex', alignItems: 'center', gap: 8 },
-  stepBtn: { width: 32, height: 32, border: 'none', borderRadius: 10, background: '#f7f7f9', fontSize: 18, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#EF5B94', fontWeight: 700 },
+  stepBtn: { width: 38, height: 38, border: 'none', borderRadius: 10, background: '#f7f7f9', fontSize: 20, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#EF5B94', fontWeight: 700 },
   stepValue: { fontSize: 16, fontWeight: 700, color: '#3A3A42', minWidth: 28, textAlign: 'center' },
   maxHint: { fontSize: 11, color: '#b3b3ba', marginTop: 2, marginBottom: 8 },
   sizeHint: { fontSize: 12, color: '#8a8a90', marginTop: 8, background: '#F0F0F2', padding: '8px 12px', borderRadius: 9 },
@@ -518,9 +517,9 @@ const s: Record<string, CSSProperties> = {
   textInput: { flex: 1, padding: '9px 10px', border: '1px solid #E7E7EA', borderRadius: 10, fontSize: 13, color: '#3A3A42' },
   toggleRow: { display: 'flex', flexWrap: 'wrap', gap: 12, marginTop: 8 },
   toggleLabel: { fontSize: 13, color: '#6b6b72', cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 4 },
-  preview: { width: 250, flexShrink: 0, padding: 16, background: '#FAFAFB', display: 'flex', flexDirection: 'column' },
+  preview: { flex: 1, padding: 20, background: '#FAFAFB', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 14 },
   previewTitle: { fontSize: 11, fontWeight: 700, color: '#b3b3ba', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 12 },
-  previewCanvas: { flex: 1, background: '#fff', borderRadius: 16, border: '1px solid #E7E7EA', display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', padding: 12, backgroundImage: 'radial-gradient(circle, #e2e2e6 1px, transparent 1px)', backgroundSize: '15px 15px' },
+  previewCanvas: { width: 290, height: 230, background: '#fff', borderRadius: 16, border: '1px solid #E7E7EA', display: 'flex', alignItems: 'center', justifyContent: 'center', overflow: 'hidden', padding: 12, backgroundImage: 'radial-gradient(#e2e2e6 1px, transparent 1px)', backgroundSize: '15px 15px' },
   previewSVG: { maxWidth: '100%', maxHeight: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' },
   previewInfo: { marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: 8, fontSize: 12, color: '#6b6b72' },
   footer: { display: 'flex', justifyContent: 'flex-end', gap: 12, padding: '14px 24px', borderTop: '1px solid #f0f0f2', background: '#fff' },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -323,14 +323,14 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
   return createPortal(
     <div style={s.overlay}>
       <div style={s.modal}>
-        <style>{`.tc-round-check{appearance:none;-webkit-appearance:none;width:17px;height:17px;border:1.6px solid #c4c4cc;border-radius:50%;cursor:pointer;position:relative;flex:none;vertical-align:middle}.tc-round-check:checked{background:#EF5B94;border-color:#EF5B94}.tc-round-check:checked::after{content:'';position:absolute;left:5px;top:2.5px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}.tc-slider{-webkit-appearance:none;appearance:none;height:6px;border-radius:6px;background:#E7E7EA;width:100%;outline:none}.tc-slider::-webkit-slider-thumb{-webkit-appearance:none;width:16px;height:16px;border-radius:50%;background:#EF5B94;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.25)}.tc-slider::-moz-range-thumb{width:16px;height:16px;border:none;border-radius:50%;background:#EF5B94;cursor:pointer}`}</style>
+        <style>{`.tc-round-check{appearance:none;-webkit-appearance:none;width:17px;height:17px;border:1.6px solid #c4c4cc;border-radius:50%;cursor:pointer;position:relative;flex:none;vertical-align:middle}.tc-round-check:checked{background:#EF5B94;border-color:#EF5B94}.tc-round-check:checked::after{content:'';position:absolute;left:5px;top:2.5px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}.tc-slider{-webkit-appearance:none;appearance:none;height:6px;border-radius:6px;background:#E7E7EA;width:100%;outline:none}.tc-slider::-webkit-slider-thumb{-webkit-appearance:none;width:16px;height:16px;border-radius:50%;background:#EF5B94;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.25)}.tc-slider::-moz-range-thumb{width:16px;height:16px;border:none;border-radius:50%;background:#EF5B94;cursor:pointer}.tc-scroll::-webkit-scrollbar{width:0;height:0;display:none}`}</style>
         <div style={s.header}>
           <h2 style={s.title}>{initialConfig ? 'Editar mesa' : 'Diseñar mesa'}</h2>
           <button style={s.closeBtn} type="button" onClick={onCancel}>✕</button>
         </div>
 
         <div style={s.body}>
-          <div style={s.controls}>
+          <div className="tc-scroll" style={s.controls}>
             {/* NOMBRE DE LA MESA */}
             <section style={s.section}>
               <div style={s.sectionTitle}>Nombre de la mesa</div>
@@ -490,7 +490,7 @@ const s: Record<string, CSSProperties> = {
   title: { margin: 0, fontSize: 17, fontWeight: 700, color: '#3A3A42' },
   closeBtn: { background: 'none', border: 'none', fontSize: 20, cursor: 'pointer', color: '#a0a0a8', padding: '4px 8px' },
   body: { display: 'flex', flex: 1, overflow: 'hidden' },
-  controls: { width: 296, flexShrink: 0, overflowY: 'auto', padding: 20, borderRight: '1px solid #f2f2f4', display: 'flex', flexDirection: 'column', gap: 18 },
+  controls: { width: 296, flexShrink: 0, overflowY: 'auto', padding: 20, borderRight: '1px solid #f2f2f4', display: 'flex', flexDirection: 'column', gap: 18, scrollbarWidth: 'none', msOverflowStyle: 'none' } as CSSProperties,
   section: {},
   sectionTitle: { fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '1px', color: '#b3b3ba', marginBottom: 10 },
   shapeGrid: { display: 'flex', flexWrap: 'wrap', gap: 7 },
@@ -508,7 +508,7 @@ const s: Record<string, CSSProperties> = {
   sizeHint: { fontSize: 12, color: '#8a8a90', marginTop: 8, background: '#F0F0F2', padding: '8px 12px', borderRadius: 9 },
   seatDistrib: { background: '#faf9fb', borderRadius: 9, padding: 12, marginBottom: 10 },
   distribLabel: { fontSize: 13, color: '#6b6b72', marginBottom: 10 },
-  distribGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 },
+  distribGrid: { display: 'flex', flexDirection: 'column', gap: 8 },
   distribRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between' },
   distribSide: { fontSize: 12, color: '#8a8a90', minWidth: 32 },
   select: { flex: 1, padding: '9px 10px', border: '1px solid #E7E7EA', borderRadius: 10, fontSize: 13, background: '#fff', color: '#3A3A42' },

--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -262,7 +262,6 @@ export function TableConfiguratorFloating() {
 const SHAPES: { id: TableShape; label: string }[] = [
   { id: 'round', label: 'Redonda' },
   { id: 'rectangular', label: 'Rectangular' },
-  { id: 'oval', label: 'Oval' },
   { id: 'square', label: 'Cuadrada' },
 ];
 

--- a/apps/appEventos/components/Mesas/BlockInvitados.tsx
+++ b/apps/appEventos/components/Mesas/BlockInvitados.tsx
@@ -45,7 +45,7 @@ const BlockInvitados: FC<propsBlockInvitados> = ({ set, setEditInv, editInv, set
     ]
 
     return (
-        <div className="w-full h-full flex flex-col bg-white relative">
+        <div className={`w-full h-full flex flex-col bg-white relative ${open ? '' : 'justify-end'}`}>
             <div onClick={() => setOpen(!open)} className="flex items-center justify-between px-3 pt-2 pb-1 cursor-pointer select-none flex-none">
                 <div className="flex items-center gap-1.5">
                     <HiChevronDown className={`w-4 h-4 text-[#6b6b72] transition-transform ${open ? '' : '-rotate-90'}`} />

--- a/apps/appEventos/components/Mesas/BlockPlanos.tsx
+++ b/apps/appEventos/components/Mesas/BlockPlanos.tsx
@@ -94,8 +94,22 @@ export const BlockPlanos: FC = () => {
         setCreateNotice(t('createplanoerror', 'No se pudo crear el plano. Inténtalo de nuevo.'))
         return
       }
-      // Reflejar en el front: añadir el nuevo espacio y seleccionarlo (el backend ya hizo el select).
-      setEvent((prev: any) => ({ ...prev, planSpace: [...(prev?.planSpace ?? []), nuevo] }))
+      // createPlanSpace NO asigna `size` → el lienzo saldría vacío ("No hay un plano cargado").
+      // Le damos un tamaño por defecto (como los planos existentes ~1500×800) para que la
+      // cuadrícula aparezca lista para colocar mesas, y lo persistimos vía updateEvento.
+      const nuevoConLienzo = {
+        ...nuevo,
+        size: nuevo.size ?? { width: 1500, height: 800 },
+        tables: nuevo.tables ?? [],
+        elements: nuevo.elements ?? [],
+      }
+      const planSpaceNuevo = [...(event?.planSpace ?? []), nuevoConLienzo]
+      await fetchApiEventos({
+        query: queries.eventUpdate,
+        variables: { idEvento: event?._id, input: { planSpace: planSpaceNuevo } },
+      })
+      // Reflejar en el front: añadir el nuevo espacio (con lienzo) y seleccionarlo.
+      setEvent((prev: any) => ({ ...prev, planSpace: planSpaceNuevo }))
       setPlanSpaceSelect(nuevo._id)
       closeNewPlano()
     } catch {
@@ -130,6 +144,11 @@ export const BlockPlanos: FC = () => {
                 <div className="text-[12.5px] font-semibold text-[#3A3A42] truncate capitalize">{t(item?.title)}</div>
                 <div className="text-[10.5px] font-medium text-[#a0a0a8]">{mesas} {mesasLabel} · {sentados} {seatedLabel}</div>
               </div>
+              {active &&
+                <div className="w-[18px] h-[18px] rounded-full flex-none bg-[#EF5B94] flex items-center justify-center">
+                  <svg className="w-[11px] h-[11px]" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
+                </div>
+              }
               <button
                 onClick={(e) => handleDeletePlano(e, item)}
                 title={t('deleteplano', 'Eliminar plano')}
@@ -137,11 +156,6 @@ export const BlockPlanos: FC = () => {
               >
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
               </button>
-              {active &&
-                <div className="w-[18px] h-[18px] rounded-full flex-none bg-[#EF5B94] flex items-center justify-center">
-                  <svg className="w-[11px] h-[11px]" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>
-                </div>
-              }
             </div>
           )
         })}

--- a/apps/appEventos/components/Mesas/BlockPlanos.tsx
+++ b/apps/appEventos/components/Mesas/BlockPlanos.tsx
@@ -47,6 +47,32 @@ export const BlockPlanos: FC = () => {
   const seatedCount = (item: any): number =>
     (item?.tables || []).reduce((n: number, tb: any) => n + (tb?.guests?.length || 0), 0)
 
+  // Eliminar un plano. api-mcp NO tiene deletePlanSpace (sí deleteTable/deleteElement);
+  // se persiste vía updateEvento con el array planSpace ya filtrado
+  // (EventoUpdateInput.planSpace: [JSON!]). Solo se aplica en UI si el backend confirma.
+  const handleDeletePlano = async (e: any, item: planSpace) => {
+    e.stopPropagation()
+    const mesas = (item as any)?.tables?.length || 0
+    const nombre = t((item as any)?.title) || t('thisplan', 'este plano')
+    const msg = mesas > 0
+      ? t('confirmdeleteplanotables', `¿Eliminar el plano «${nombre}»? Se borrarán también sus ${mesas} mesa(s). Esta acción no se puede deshacer.`)
+      : t('confirmdeleteplano', `¿Eliminar el plano «${nombre}»? Esta acción no se puede deshacer.`)
+    if (typeof window !== 'undefined' && !window.confirm(msg)) return
+    const nuevos = (event?.planSpace || []).filter((ps: any) => ps?._id !== item?._id)
+    try {
+      const res: any = await fetchApiEventos({
+        query: queries.eventUpdate,
+        variables: { idEvento: event?._id, input: { planSpace: nuevos } },
+      })
+      if (!res?.success) return
+      setEvent((prev: any) => ({ ...prev, planSpace: nuevos }))
+      // Si borramos el plano activo, seleccionar el primero restante (o ninguno).
+      if (planSpaceSelect === item?._id) setPlanSpaceSelect(nuevos[0]?._id ?? null)
+    } catch {
+      /* error de red: no se aplica el borrado en UI (no queda inconsistente) */
+    }
+  }
+
   const openNewPlano = () => {
     setNewPlanoName('')
     setCreateNotice(null)
@@ -104,6 +130,13 @@ export const BlockPlanos: FC = () => {
                 <div className="text-[12.5px] font-semibold text-[#3A3A42] truncate capitalize">{t(item?.title)}</div>
                 <div className="text-[10.5px] font-medium text-[#a0a0a8]">{mesas} {mesasLabel} · {sentados} {seatedLabel}</div>
               </div>
+              <button
+                onClick={(e) => handleDeletePlano(e, item)}
+                title={t('deleteplano', 'Eliminar plano')}
+                className="flex-none w-[24px] h-[24px] rounded-md flex items-center justify-center text-[#c2c2ca] hover:text-[#EF5B94] hover:bg-[#FCE7F0] transition"
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
+              </button>
               {active &&
                 <div className="w-[18px] h-[18px] rounded-full flex-none bg-[#EF5B94] flex items-center justify-center">
                   <svg className="w-[11px] h-[11px]" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>

--- a/apps/appEventos/context/EventsGroupContext.tsx
+++ b/apps/appEventos/context/EventsGroupContext.tsx
@@ -259,8 +259,23 @@ const EventsGroupProvider = ({ children }) => {
               // Tratar ese null como FALLO, no como "0 eventos": si no, un refresh con token
               // stale pinta lista vacía engañosa (y obligaba a logout/login para recuperar).
               if (settled.status === "fulfilled" && settled.value !== null) {
-                hadFulfilled = true
-                list.push(...coerceQueryenEventoList(settled.value))
+                // El resolver puede responder success:false con el error DENTRO de data
+                // (p.ej. DATABASE_CONNECTION_ERROR: la BD de api-mcp no está conectada, o
+                // "Client must be connected"). Eso NO es "0 eventos" — es un FALLO del backend:
+                // tratarlo como error para reintentar y NO pintar lista vacía engañosa.
+                const val = settled.value as any
+                if (val?.success === false) {
+                  if (!firstError) {
+                    const dbErr: any = new Error(
+                      val?.errors?.[0]?.message || "No se pudieron obtener los eventos (error del servidor)"
+                    )
+                    dbErr.code = val?.errors?.[0]?.code
+                    firstError = dbErr
+                  }
+                } else {
+                  hadFulfilled = true
+                  list.push(...coerceQueryenEventoList(settled.value))
+                }
               } else if (!firstError) {
                 firstError = settled.status === "rejected"
                   ? settled.reason

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -69,11 +69,14 @@ export const convertBackendSvgsToReact = (backendSvgs: any[]): GalerySvg[] => {
 // Mapa forma(TableConfigurator) ↔ tipo(backend), para editar una mesa reutilizando el
 // panel del HTML (TableConfigurator con initialConfig = modo "Editar mesa", línea 324).
 const SHAPE_TO_TIPO_EDIT: Record<string, string> = { round: 'redonda', rectangular: 'imperial', oval: 'redonda', square: 'cuadrada', semicircle: 'podio', head: 'podio' }
-const TIPO_TO_SHAPE_EDIT: Record<string, string> = { redonda: 'round', cuadrada: 'square', imperial: 'rectangular', podio: 'semicircle', militar: 'rectangular', bancos: 'rectangular', banco: 'rectangular' }
+const TIPO_TO_SHAPE_EDIT: Record<string, string> = { redonda: 'round', cuadrada: 'square', imperial: 'rectangular', podio: 'round', militar: 'rectangular', bancos: 'rectangular', banco: 'rectangular' }
 const mesaAConfig = (table: any): any => ({
+  // 'podio' (antigua forma "media luna"/Novios) ya no es una forma seleccionable:
+  // se muestra como redonda + se marca el toggle "Mesa de novios".
   shape: TIPO_TO_SHAPE_EDIT[table?.tipo] ?? 'round',
   seats: table?.numberChair ?? 8,
   tableName: table?.title ?? '',
+  isHeadTable: table?.tipo === 'podio',
 })
 
 const Mesas: FC = () => {

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -70,12 +70,14 @@ export const convertBackendSvgsToReact = (backendSvgs: any[]): GalerySvg[] => {
 // panel del HTML (TableConfigurator con initialConfig = modo "Editar mesa", línea 324).
 const SHAPE_TO_TIPO_EDIT: Record<string, string> = { round: 'redonda', rectangular: 'imperial', oval: 'redonda', square: 'cuadrada', semicircle: 'podio', head: 'podio' }
 const TIPO_TO_SHAPE_EDIT: Record<string, string> = { redonda: 'round', cuadrada: 'square', imperial: 'rectangular', podio: 'round', militar: 'rectangular', bancos: 'rectangular', banco: 'rectangular' }
-const mesaAConfig = (table: any): any => ({
+const mesaAConfig = (table: any, num?: number): any => ({
   // 'podio' (antigua forma "media luna"/Novios) ya no es una forma seleccionable:
   // se muestra como redonda + se marca el toggle "Mesa de novios".
   shape: TIPO_TO_SHAPE_EDIT[table?.tipo] ?? 'round',
   seats: table?.numberChair ?? 8,
   tableName: table?.title ?? '',
+  // Número REAL de la mesa (índice+1 en el plano), para que el preview no muestre siempre "1"
+  ...(typeof num === 'number' && num > 0 ? { tableNumber: num } : {}),
   isHeadTable: table?.tipo === 'podio',
 })
 
@@ -288,7 +290,10 @@ const Mesas: FC = () => {
           // Modal "Editar mesa" fiel al HTML: reutiliza TableConfigurator (initialConfig →
           // header "Editar mesa"). onConfirm guarda vía editTable (guardarEdicion).
           <TableConfigurator
-            initialConfig={mesaAConfig(showFormEditar.table)}
+            initialConfig={mesaAConfig(
+              showFormEditar.table,
+              (planSpaceActive?.tables ?? []).findIndex((tb: any) => tb?._id === showFormEditar.table?._id) + 1
+            )}
             onConfirm={guardarEdicion}
             onCancel={() => setShowFormEditar({ table: {}, visible: false })}
           />

--- a/apps/appEventos/utils/Fetching.ts
+++ b/apps/appEventos/utils/Fetching.ts
@@ -79,6 +79,16 @@ export function getApiErrorMessage(error: any): string | null {
   if (error?.code === 'ECONNREFUSED' || error?.message?.includes('Network Error')) {
     return 'No se pudo conectar con el servidor. Comprueba tu conexión.';
   }
+  // El servidor (api-mcp) puede responder success:false con un error de conexión a su
+  // BD DENTRO de data (DATABASE_CONNECTION_ERROR / "Client must be connected"). No es
+  // "sin datos" ni sesión caducada: es un fallo temporal del backend → mensaje claro + reintento.
+  if (
+    error?.code === 'DATABASE_CONNECTION_ERROR' ||
+    error?.message?.includes('base de datos no está conectada') ||
+    error?.message?.includes('Client must be connected')
+  ) {
+    return 'Problema temporal de conexión con el servidor. Reintentando…';
+  }
   return null;
 }
 
@@ -1375,6 +1385,8 @@ export const queries = {
   // → se piden SIN subselección; devuelven el objeto completo (el front accede en runtime).
   getEventosByUsuario: `query ($uid: String!, $pag: CRM_PaginationInput!, $dev: String) {
     getEventosByUsuario(usuario_id: $uid, pagination: $pag, development: $dev){
+      success
+      errors{ message code }
       total
       eventos{
         _id development grupos_array compartido_array detalles_compartidos_array

--- a/packages/shared/src/utils/tableRenderer.ts
+++ b/packages/shared/src/utils/tableRenderer.ts
@@ -81,7 +81,7 @@ export const TABLE_DEFAULTS: Record<string, TableConfig> = {
     realDiameterCm: 150,
     seats: 8,
     minSeats: 4, maxSeats: 14,
-    tableColor: '#F5F0E8', chairColor: '#E8D5B7', chairStyle: 'chiavari',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     showChairs: true, showNumber: true, showName: false,
     isHeadTable: false, isKidsTable: false,
   },
@@ -90,7 +90,7 @@ export const TABLE_DEFAULTS: Record<string, TableConfig> = {
     realDiameterCm: 180,
     seats: 10,
     minSeats: 6, maxSeats: 16,
-    tableColor: '#F5F0E8', chairColor: '#E8D5B7', chairStyle: 'chiavari',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     showChairs: true, showNumber: true, showName: false,
     isHeadTable: false, isKidsTable: false,
   },
@@ -100,7 +100,7 @@ export const TABLE_DEFAULTS: Record<string, TableConfig> = {
     seatsTop: 3, seatsBottom: 3, seatsLeft: 1, seatsRight: 1,
     seats: 8,
     minSeats: 2, maxSeats: 30,
-    tableColor: '#F5F0E8', chairColor: '#E8D5B7', chairStyle: 'chiavari',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     showChairs: true, showNumber: true, showName: false,
     isHeadTable: false, isKidsTable: false,
   },
@@ -109,7 +109,7 @@ export const TABLE_DEFAULTS: Record<string, TableConfig> = {
     realWidthCm: 220, realHeightCm: 110,
     seats: 10,
     minSeats: 6, maxSeats: 18,
-    tableColor: '#F5F0E8', chairColor: '#E8D5B7', chairStyle: 'chiavari',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     showChairs: true, showNumber: true, showName: false,
     isHeadTable: false, isKidsTable: false,
   },
@@ -119,7 +119,7 @@ export const TABLE_DEFAULTS: Record<string, TableConfig> = {
     seatsTop: 1, seatsBottom: 1, seatsLeft: 1, seatsRight: 1,
     seats: 4,
     minSeats: 2, maxSeats: 8,
-    tableColor: '#F5F0E8', chairColor: '#E8D5B7', chairStyle: 'chiavari',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     showChairs: true, showNumber: true, showName: false,
     isHeadTable: false, isKidsTable: false,
   },
@@ -139,7 +139,7 @@ export const TABLE_DEFAULTS: Record<string, TableConfig> = {
     seatsTop: 7, seatsBottom: 7, seatsLeft: 1, seatsRight: 1,
     seats: 16,
     minSeats: 6, maxSeats: 40,
-    tableColor: '#F5F0E8', chairColor: '#E8D5B7', chairStyle: 'chiavari',
+    tableColor: '#F0F0F2', chairColor: '#ffffff', chairStyle: 'modern',
     showChairs: true, showNumber: true, showName: false,
     isHeadTable: false, isKidsTable: false,
   },
@@ -191,8 +191,8 @@ function chairSVG(x: number, y: number, angleDeg: number, style: ChairStyle, col
 
 function generateRoundTableSVG(config: TableConfig): string {
   const {
-    realDiameterCm = 150, seats, tableColor = '#F5F0E8', chairColor,
-    chairStyle = 'chiavari', showNumber, showName, tableName, tableNumber,
+    realDiameterCm = 150, seats, tableColor = '#F0F0F2', chairColor,
+    chairStyle = 'modern', showNumber, showName, tableName, tableNumber,
     isHeadTable, isKidsTable,
   } = config;
 
@@ -247,7 +247,7 @@ function generateRectangularTableSVG(config: TableConfig): string {
   const {
     realWidthCm = 240, realHeightCm = 90,
     seatsTop = 0, seatsBottom = 0, seatsLeft = 0, seatsRight = 0,
-    tableColor = '#F5F0E8', chairColor, chairStyle = 'chiavari',
+    tableColor = '#F0F0F2', chairColor, chairStyle = 'modern',
     showNumber, showName, tableName, tableNumber,
     isHeadTable, isKidsTable,
   } = config;
@@ -321,7 +321,7 @@ function generateRectangularTableSVG(config: TableConfig): string {
 function generateOvalTableSVG(config: TableConfig): string {
   const {
     realWidthCm = 220, realHeightCm = 110, seats,
-    tableColor = '#F5F0E8', chairColor, chairStyle = 'chiavari',
+    tableColor = '#F0F0F2', chairColor, chairStyle = 'modern',
     showNumber, showName, tableName, tableNumber,
     isHeadTable, isKidsTable,
   } = config;
@@ -371,7 +371,7 @@ function generateOvalTableSVG(config: TableConfig): string {
 function generateHeadTableSVG(config: TableConfig): string {
   const {
     realWidthCm = 400, realHeightCm = 220, seats,
-    tableColor = '#FDF5EC', chairColor, chairStyle = 'chiavari',
+    tableColor = '#FDF5EC', chairColor, chairStyle = 'modern',
     showName, tableName,
   } = config;
 

--- a/packages/shared/src/utils/tableRenderer.ts
+++ b/packages/shared/src/utils/tableRenderer.ts
@@ -65,7 +65,7 @@ const MIN_CM_PER_SEAT = 42;
 
 const CHAIR_STYLES: Record<string, { fill: string; stroke: string; strokeWidth: number; rx: number } | null> = {
   chiavari: { fill: '#E8D5B7', stroke: '#8B6914', strokeWidth: 1.8, rx: 3 },
-  modern:   { fill: '#D0D0D0', stroke: '#555555', strokeWidth: 1.5, rx: 2 },
+  modern:   { fill: '#ffffff', stroke: '#c2c2ca', strokeWidth: 1.6, rx: 2 },
   ghost:    { fill: 'rgba(220,220,220,0.25)', stroke: '#AAAAAA', strokeWidth: 2, rx: 4 },
   bench:    { fill: '#C4A882', stroke: '#6B4226', strokeWidth: 2, rx: 2 },
   none:     null,
@@ -175,13 +175,13 @@ function chairSVG(x: number, y: number, angleDeg: number, style: ChairStyle, col
   const s = CHAIR_STYLES[style];
   if (!s) return '';
   const fill = color ?? s.fill;
+  // Sillas como el prototipo: círculo con contorno (no rect). angleDeg no aplica a un círculo.
+  void angleDeg;
+  const rChair = Math.min(CHAIR_W, CHAIR_H) / 2;
   return `
-    <rect
-      x="${-CHAIR_W / 2}" y="${-CHAIR_H / 2}"
-      width="${CHAIR_W}" height="${CHAIR_H}"
-      rx="${s.rx}"
+    <circle
+      cx="${x}" cy="${y}" r="${rChair}"
       fill="${fill}" stroke="${s.stroke}" stroke-width="${s.strokeWidth}"
-      transform="translate(${x},${y}) rotate(${angleDeg})"
     />`;
 }
 

--- a/packages/shared/src/utils/tableRenderer.ts
+++ b/packages/shared/src/utils/tableRenderer.ts
@@ -65,7 +65,7 @@ const MIN_CM_PER_SEAT = 42;
 
 const CHAIR_STYLES: Record<string, { fill: string; stroke: string; strokeWidth: number; rx: number } | null> = {
   chiavari: { fill: '#E8D5B7', stroke: '#8B6914', strokeWidth: 1.8, rx: 3 },
-  modern:   { fill: '#ffffff', stroke: '#c2c2ca', strokeWidth: 1.6, rx: 2 },
+  modern:   { fill: '#ffffff', stroke: '#B4B4BC', strokeWidth: 1.5, rx: 2 },
   ghost:    { fill: 'rgba(220,220,220,0.25)', stroke: '#AAAAAA', strokeWidth: 2, rx: 4 },
   bench:    { fill: '#C4A882', stroke: '#6B4226', strokeWidth: 2, rx: 2 },
   none:     null,
@@ -212,7 +212,7 @@ function generateRoundTableSVG(config: TableConfig): string {
     chairsSVG += chairSVG(sx, sy, angleDeg, chairStyle, chairColor);
   }
 
-  const strokeColor = isHeadTable ? '#8B4513' : isKidsTable ? '#FFD700' : '#2C2C2C';
+  const strokeColor = isHeadTable ? '#8B4513' : isKidsTable ? '#FFD700' : '#4a4a52';
   const strokeWidth = isHeadTable ? 3 : 2;
 
   let centerText = '';
@@ -287,7 +287,7 @@ function generateRectangularTableSVG(config: TableConfig): string {
     }
   }
 
-  const strokeColor = isHeadTable ? '#8B4513' : isKidsTable ? '#FFD700' : '#2C2C2C';
+  const strokeColor = isHeadTable ? '#8B4513' : isKidsTable ? '#FFD700' : '#4a4a52';
   const strokeWidth = isHeadTable ? 3 : 2;
   const textCx = mx + W / 2;
   const textCy = my + H / 2;
@@ -346,7 +346,7 @@ function generateOvalTableSVG(config: TableConfig): string {
     chairsSVG += chairSVG(cx + nx * dist, cy + ny * dist, (angle * 180) / Math.PI + 90, chairStyle, chairColor);
   }
 
-  const strokeColor = isHeadTable ? '#8B4513' : isKidsTable ? '#FFD700' : '#2C2C2C';
+  const strokeColor = isHeadTable ? '#8B4513' : isKidsTable ? '#FFD700' : '#4a4a52';
   let centerText = '';
   if (showNumber && tableNumber) {
     centerText = `<text x="${cx}" y="${cy + 6}" font-family="Georgia,serif"


### PR DESCRIPTION
Trabajo de **Mesas** (rediseño fiel al HTML) + fix de front de carga de eventos. La PR #233 se mergeó por error a otra base; esta la lleva a `dev`.

## Mesas
- Eliminar plano (papelera a la derecha) + plano nuevo con lienzo en blanco.
- Modal "Editar/Diseñar mesa" fiel al HTML: drawer izquierdo, card flotante, Poppins, slider + steppers, iconos de mesa/sillas en gris, checkboxes redondos, scroll invisible, distribución de sillas compacta, toggles Novios/Infantil.
- QA #1-4: número real en preview (#2), forma "Oval" no funcional eliminada (#1/#3/#4).

## Front eventos
- `getEventosByUsuario` distingue "error de conexión del servidor" (`DATABASE_CONNECTION_ERROR`) de "0 eventos": muestra "problema de conexión, reintentando…" + reintento + cache, en vez de lista vacía engañosa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)