### PR TITLE
🔒 fix(shared/auth): auto-sanar cookie SSO envenenada (GAP 4 plan de sesión)

### DIFF
--- a/packages/shared/src/auth/SessionBridge.ts
+++ b/packages/shared/src/auth/SessionBridge.ts
@@ -116,20 +116,36 @@ export function setCrossAppDevelopment(development: string): void {
 }
 
 /**
- * Limpia las cookies cross-app en logout.
+ * Expira SOLO la cookie `idTokenV0.1.0`, en AMBAS variantes: con Domain (cross-app) y
+ * host-only (sin Domain). Por LO-3 de la auditoría, la cookie pudo escribirse con atributos
+ * distintos según el path (unos con Domain, otros host-only), y borrar solo una deja la otra
+ * viva. Se usa para auto-sanar una cookie envenenada (token muerto) sin tocar el resto de la
+ * sesión (no borra current_development).
+ */
+export function clearCrossAppIdToken(): void {
+  if (typeof document === 'undefined') return;
+  const domain = getCrossAppDomain();
+  const base = 'idTokenV0.1.0=; path=/; max-age=0; SameSite=Lax';
+  const variants = [base];
+  if (domain) variants.push(`${base}; Domain=${domain}`);
+  for (const c of variants) {
+    // eslint-disable-next-line unicorn/no-document-cookie
+    document.cookie = c;
+  }
+}
+
+/**
+ * Limpia las cookies cross-app en logout (idTokenV0.1.0 en todas sus variantes +
+ * current_development).
  */
 export function clearCrossAppSession(): void {
   if (typeof document === 'undefined') return;
 
-  const domain = getCrossAppDomain();
-  const buildExpired = (name: string) => {
-    const parts = [`${name}=`, 'path=/', 'max-age=0', 'SameSite=Lax'];
-    if (domain) parts.push(`Domain=${domain}`);
-    return parts.join('; ');
-  };
+  clearCrossAppIdToken();
 
+  const domain = getCrossAppDomain();
+  const parts = [`${CROSS_APP_DEVELOPMENT_COOKIE}=`, 'path=/', 'max-age=0', 'SameSite=Lax'];
+  if (domain) parts.push(`Domain=${domain}`);
   // eslint-disable-next-line unicorn/no-document-cookie
-  document.cookie = buildExpired('idTokenV0.1.0');
-  // eslint-disable-next-line unicorn/no-document-cookie
-  document.cookie = buildExpired(CROSS_APP_DEVELOPMENT_COOKIE);
+  document.cookie = parts.join('; ');
 }

--- a/packages/shared/src/auth/SessionManager.ts
+++ b/packages/shared/src/auth/SessionManager.ts
@@ -21,7 +21,34 @@ declare var window: any;
  * instancia con la forma mínima que usamos. Sin fallback silencioso: si el refresco falla,
  * se reporta por consola y NO se rompe el hilo (el backend rechazará y la UI podrá escalar).
  */
-import { setCrossAppIdToken } from './SessionBridge';
+import { clearCrossAppIdToken, setCrossAppIdToken } from './SessionBridge';
+
+/** Lee una cookie por nombre (cliente). null si no existe. */
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const escaped = name.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+  const m = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/** true si el JWT está caducado o es ilegible. Sin verificar firma (solo `exp`). */
+function isExpiredJwt(token: string): boolean {
+  try {
+    const seg = token.split('.')[1];
+    if (!seg) return true;
+    const b64 = seg.replace(/-/g, '+').replace(/_/g, '/');
+    const json = decodeURIComponent(
+      atob(b64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join(''),
+    );
+    const payload = JSON.parse(json);
+    return typeof payload.exp === 'number' ? payload.exp < Date.now() / 1000 : false;
+  } catch {
+    return true;
+  }
+}
 
 export interface FirebaseUserLike {
   getIdToken: (forceRefresh?: boolean) => Promise<string>;
@@ -49,7 +76,19 @@ export function startSessionRefresh(auth: FirebaseAuthLike): () => void {
 
   // 1) Rotación natural del SDK → mantener la cookie cross-app al día.
   _unsub = auth.onIdTokenChanged(async (user) => {
-    if (!user) return;
+    if (!user) {
+      // AUTO-SANADO (incidente 17-19 jul): sin usuario Firebase pero con cookie SSO que trae
+      // un token CADUCADO → el navegador seguiría enviando un token muerto hasta 30 días
+      // ("sesión muerta" que obligaba a incógnito). La limpiamos para no servir el token
+      // muerto; el próximo login la vuelve a escribir fresca. Solo si está caducada (no si
+      // falta ni si es válida).
+      const stale = readCookie('idTokenV0.1.0');
+      if (stale && isExpiredJwt(stale)) {
+        clearCrossAppIdToken();
+        console.warn('[SessionManager] cookie SSO con token caducado y sin usuario → limpiada (auto-sanado)');
+      }
+      return;
+    }
     try {
       const token = await user.getIdToken();
       if (token) setCrossAppIdToken(token);

--- a/packages/shared/src/auth/__tests__/SessionManager.test.ts
+++ b/packages/shared/src/auth/__tests__/SessionManager.test.ts
@@ -3,12 +3,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Aislar SessionManager de la escritura real de cookie.
 vi.mock('../SessionBridge', () => ({
   setCrossAppIdToken: vi.fn(),
+  clearCrossAppIdToken: vi.fn(),
 }));
 
-import { setCrossAppIdToken } from '../SessionBridge';
+import { setCrossAppIdToken, clearCrossAppIdToken } from '../SessionBridge';
 import { startSessionRefresh, stopSessionRefresh, getFreshToken } from '../SessionManager';
 
 const mockSet = setCrossAppIdToken as unknown as ReturnType<typeof vi.fn>;
+const mockClear = clearCrossAppIdToken as unknown as ReturnType<typeof vi.fn>;
+
+// JWTs de prueba (sin firma real; solo el payload importa para isExpiredJwt).
+const b64url = (obj: unknown) =>
+  Buffer.from(JSON.stringify(obj)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+const jwtWithExp = (expSec: number) => `eyJhbGciOiJSUzI1NiJ9.${b64url({ exp: expSec })}.sig`;
+const EXPIRED_JWT = jwtWithExp(1); // exp en 1970 → caducado
+const VALID_JWT = jwtWithExp(9_999_999_999); // exp lejano → válido
 
 // Mock mínimo con la forma FirebaseAuthLike que usa SessionManager.
 function makeAuth(token: string | null) {
@@ -27,11 +36,13 @@ function makeAuth(token: string | null) {
 beforeEach(() => {
   (globalThis as any).window = (globalThis as any).window || {};
   mockSet.mockClear();
+  mockClear.mockClear();
   vi.useFakeTimers();
 });
 
 afterEach(() => {
   stopSessionRefresh();
+  delete (globalThis as any).document;
   vi.useRealTimers();
 });
 
@@ -75,6 +86,31 @@ describe('SessionManager — refresco central del token cross-app', () => {
     startSessionRefresh(auth);
     expect(() => stopSessionRefresh()).not.toThrow();
     expect(() => stopSessionRefresh()).not.toThrow();
+  });
+
+  it('AUTO-SANADO: sin usuario y cookie con token CADUCADO → limpia la cookie SSO', async () => {
+    (globalThis as any).document = { cookie: `idTokenV0.1.0=${EXPIRED_JWT}` };
+    const auth = makeAuth('x');
+    startSessionRefresh(auth);
+    await auth._cb!(null); // onIdTokenChanged sin usuario
+    expect(mockClear).toHaveBeenCalledTimes(1);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('AUTO-SANADO: sin usuario pero cookie VÁLIDA → NO limpia', async () => {
+    (globalThis as any).document = { cookie: `idTokenV0.1.0=${VALID_JWT}` };
+    const auth = makeAuth('x');
+    startSessionRefresh(auth);
+    await auth._cb!(null);
+    expect(mockClear).not.toHaveBeenCalled();
+  });
+
+  it('AUTO-SANADO: sin usuario y sin cookie → NO limpia', async () => {
+    (globalThis as any).document = { cookie: '' };
+    const auth = makeAuth('x');
+    startSessionRefresh(auth);
+    await auth._cb!(null);
+    expect(mockClear).not.toHaveBeenCalled();
   });
 
   it('sin window (SSR) no arranca nada y devuelve noop', () => {

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -11,6 +11,7 @@ export {
   setCrossAppIdToken,
   setCrossAppDevelopment,
   clearCrossAppSession,
+  clearCrossAppIdToken,
   CROSS_APP_DEVELOPMENT_COOKIE,
 } from './SessionBridge';
 export {


### PR DESCRIPTION
## GAP 4 del plan de sesión (auditoría 28-jul / consolidada 31-jul)

Los navegadores con la cookie `idTokenV0.1.0` **envenenada** durante el incidente securetoken 17-19 jul (token de 1 h muerto dentro de la cookie de 30 d) hoy siguen necesitando **incógnito / borrado manual**. Esto lo **auto-sana**.

### Cambios (solo `packages/shared/auth`, additivo)
- **`SessionManager.onIdTokenChanged`**: Firebase resuelve SIN usuario pero la cookie SSO trae un token **caducado** → la limpia (no sirve un token muerto 30 días). Solo si está caducado; no si falta ni si es válida. El próximo login la reescribe.
- **`SessionBridge.clearCrossAppIdToken()`** (nueva): expira `idTokenV0.1.0` en **ambas variantes** (Domain + host-only) → cierra también **LO-3** (variantes de cookie) en logout, ya que `clearCrossAppSession` la reutiliza.
- Exportada desde `shared/auth`.

### Verificación
- Tests `SessionManager` **6 → 9** (caducado→limpia · válido→no · ausente→no) ✅
- `tsc --noEmit` limpio · ESLint 0 errores.
- Complementa F1/F2 (SessionManager) + F3 (logout). Sin fallback. No toca appEventos ni el core del flujo.

> Nota: hecho en **git worktree aislado** para no colisionar con los actores concurrentes en el árbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)