### PR TITLE
🔒 fix(shared/auth): validateFirebaseToken multi-tenant (projectId por whitelabel) — GAP 5 parte segura

### DIFF
--- a/packages/shared/src/auth/AuthBridge.ts
+++ b/packages/shared/src/auth/AuthBridge.ts
@@ -51,19 +51,33 @@ function getJWKS() {
 }
 
 /**
- * Validates a Firebase ID token with full signature verification.
- * Use in middleware/API routes for server-side validation.
+ * Valida un Firebase ID token con verificación completa de firma.
+ * Uso: middleware / API routes para validación server-side.
+ *
+ * MULTI-TENANT (GAP 5): appEventos usa un proyecto Firebase DISTINTO por whitelabel, así que
+ * un único `NEXT_PUBLIC_FIREBASE_PROJECT_ID` no vale para validar el issuer de todos. El
+ * llamador que sea multi-tenant debe PASAR el `projectId` correcto (lo conoce por su config,
+ * p.ej. appEventos/firebase.tsx → fileConfig.projectId del development). Si no se pasa, se cae
+ * al env (correcto para apps de un solo proyecto, p.ej. chat-ia = bodasdehoy-1063). Fail-closed:
+ * sin `projectId` ni env → throw (no validar contra un proyecto obsoleto en silencio).
+ *
+ * @param token    Firebase ID token a validar.
+ * @param projectId Proyecto Firebase esperado (opcional). Si se omite, usa el env.
  */
-export async function validateFirebaseToken(token: string): Promise<JWTPayload | null> {
+export async function validateFirebaseToken(
+  token: string,
+  projectId?: string,
+): Promise<JWTPayload | null> {
   if (!token) return null;
-  // Fase 4 (fail-closed): exigir el proyecto Firebase por env; sin default obsoleto.
-  const projectId = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
-  if (!projectId) {
-    throw new Error('[AuthBridge] NEXT_PUBLIC_FIREBASE_PROJECT_ID no configurado — no se puede validar el issuer de Firebase (no hay default seguro).');
+  const resolvedProjectId = projectId || process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  if (!resolvedProjectId) {
+    throw new Error(
+      '[AuthBridge] validateFirebaseToken: falta projectId (ni argumento ni NEXT_PUBLIC_FIREBASE_PROJECT_ID) — no se puede resolver el issuer de Firebase sin default seguro.',
+    );
   }
   try {
     const { payload } = await jwtVerify(token, getJWKS(), {
-      issuer: `https://securetoken.google.com/${projectId}`,
+      issuer: `https://securetoken.google.com/${resolvedProjectId}`,
       algorithms: ['RS256'],
     });
     if (payload.exp && payload.exp < Date.now() / 1000) return null;

--- a/packages/shared/src/auth/__tests__/validateFirebaseToken.test.ts
+++ b/packages/shared/src/auth/__tests__/validateFirebaseToken.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mockear jose para no hacer verificación criptográfica real contra JWKS.
+const jwtVerify = vi.fn();
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => 'mock-jwks'),
+  jwtVerify: (...args: any[]) => jwtVerify(...args),
+}));
+
+import { validateFirebaseToken } from '../AuthBridge';
+
+const OLD_ENV = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+
+beforeEach(() => {
+  jwtVerify.mockReset();
+});
+afterEach(() => {
+  if (OLD_ENV === undefined) delete process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  else process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = OLD_ENV;
+});
+
+describe('validateFirebaseToken — multi-tenant (GAP 5)', () => {
+  it('usa el projectId PASADO como argumento para el issuer (per-tenant)', async () => {
+    jwtVerify.mockResolvedValue({ payload: { sub: 'u1', exp: 9_999_999_999 } });
+    const p = await validateFirebaseToken('tok', 'tenant-A-123');
+    expect(p).toMatchObject({ sub: 'u1' });
+    expect(jwtVerify).toHaveBeenCalledWith(
+      'tok',
+      'mock-jwks',
+      expect.objectContaining({
+        issuer: 'https://securetoken.google.com/tenant-A-123',
+        algorithms: ['RS256'],
+      }),
+    );
+  });
+
+  it('cae al env NEXT_PUBLIC_FIREBASE_PROJECT_ID si no se pasa projectId', async () => {
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID = 'env-proj';
+    jwtVerify.mockResolvedValue({ payload: { sub: 'u2', exp: 9_999_999_999 } });
+    await validateFirebaseToken('tok');
+    expect(jwtVerify).toHaveBeenCalledWith(
+      'tok',
+      'mock-jwks',
+      expect.objectContaining({ issuer: 'https://securetoken.google.com/env-proj' }),
+    );
+  });
+
+  it('fail-closed: sin projectId ni env → throw (no valida contra proyecto obsoleto)', async () => {
+    delete process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+    await expect(validateFirebaseToken('tok')).rejects.toThrow(/projectId/);
+  });
+
+  it('token vacío → null sin llamar a jwtVerify', async () => {
+    const p = await validateFirebaseToken('');
+    expect(p).toBeNull();
+    expect(jwtVerify).not.toHaveBeenCalled();
+  });
+
+  it('token inválido (jwtVerify lanza) → null', async () => {
+    jwtVerify.mockRejectedValue(new Error('bad signature'));
+    const p = await validateFirebaseToken('tok', 'proj');
+    expect(p).toBeNull();
+  });
+
+  it('token caducado (exp en el pasado) → null', async () => {
+    jwtVerify.mockResolvedValue({ payload: { sub: 'u3', exp: 1 } });
+    const p = await validateFirebaseToken('tok', 'proj');
+    expect(p).toBeNull();
+  });
+});


### PR DESCRIPTION
## GAP 5 (parte segura) — `validateFirebaseToken` multi-tenant

La auditoría marcó `validateFirebaseToken` como **código muerto + roto para multi-tenant**: usaba un único `NEXT_PUBLIC_FIREBASE_PROJECT_ID` para el issuer, pero **appEventos usa un proyecto Firebase distinto por whitelabel**.

- **`validateFirebaseToken(token, projectId?)`**: el llamador multi-tenant pasa el `projectId` correcto (lo conoce por su config); si no, cae al env (chat-ia = 1 proyecto). **Fail-closed** si falta todo.
- **Retro-compatible** (param opcional) y **sin llamadores** → **zero riesgo** sobre flujos vivos. Deja la función lista para adopción.
- Tests: **6 casos** ✅ · `tsc` limpio · ESLint 0.

### Lo que NO hace (a propósito)
No activa un llamador vivo: appEventos ya valida server-side con `firebaseAdmin`; forzar validación estricta a ciegas con actores concurrentes podría **rechazar tokens válidos**. La activación queda como **decisión coordinada**.

> Hecho en **git worktree aislado** (sin tocar el árbol de los actores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)