### PR TITLE
🐛 fix(mesas): CRUD de mesa persiste en planSpace.tables (no en el legacy mesas_array)

### DIFF
--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -73,33 +73,9 @@ export function TableConfiguratorFloating() {
       };
       const title = config.tableName || `Mesa ${config.tableNumber ?? planSpaceActive.tables.length + 1}`;
       const tipo = SHAPE_TO_TIPO[config.shape] ?? 'redonda';
-      const result: any = await fetchApiEventos({
-        query: queries.createTable,
-        variables: {
-          eventID: event._id,
-          planSpaceID: planSpaceActive._id,
-          values: JSON.stringify({
-            title,
-            numberChair: config.seats,
-            position,
-            rotation: 0,
-            size: { width: 100, height: 80 },
-            tipo,
-            // Datos del nuevo configurador (el canvas existente los ignora, quedan en DB)
-            tableConfig: JSON.stringify(config),
-            svgString,
-          }),
-        },
-      });
-      if (!result?.success) {
-        toast('error', result?.errors?.[0]?.message ?? 'Error al crear la mesa');
-        return;
-      }
-      // Construir la mesa LOCAL con los datos que el front conoce (no usar result crudo,
-      // que solo trae { success, errors, evento }). Garantiza que `position` existe y
-      // evita crashes en DragableDefault al renderizar la mesa recién creada.
+      // Mesa nueva dentro del planSpace (el front es dueño de planSpace[].tables).
       const newTable: any = {
-        _id: result?.table?._id ?? result?.evento?._id ?? `tmp_${Date.now()}`,
+        _id: genTableId(),
         title,
         nombre_mesa: title,
         tipo,
@@ -110,22 +86,27 @@ export function TableConfiguratorFloating() {
         size: { width: 100, height: 80 },
         tableConfig: config,
         svgString,
+        guests: [],
       };
       const nextPlanSpace = {
         ...planSpaceActive,
         tables: [...(planSpaceActive.tables ?? []), newTable],
       };
+      const nextPlanSpaces = (event.planSpace ?? []).map((ps: any) =>
+        (ps?._id === nextPlanSpace._id || ps?._id === planSpaceSelect) ? nextPlanSpace : ps
+      );
+      // Persistir vía updateEvento({planSpace}) — createTable escribe en el legacy
+      // mesas_array, desconectado de esta UI. Igual que eliminar/crear plano.
+      const result: any = await fetchApiEventos({
+        query: queries.eventUpdate,
+        variables: { idEvento: event._id, input: { planSpace: nextPlanSpaces } },
+      });
+      if (!result?.success) {
+        toast('error', result?.errors?.[0]?.message ?? 'Error al crear la mesa');
+        return;
+      }
       setPlanSpaceActive(nextPlanSpace);
-
-      const nextEvent = {
-        ...event,
-        planSpace: (event.planSpace ?? []).map((ps: any, idx: number) => {
-          if (ps?._id === nextPlanSpace._id) return nextPlanSpace;
-          if (ps?._id === planSpaceSelect) return nextPlanSpace;
-          return ps;
-        }),
-      };
-      setEvent(nextEvent);
+      setEvent({ ...event, planSpace: nextPlanSpaces });
       // Toast con «Deshacer» (MesasUndoToast escucha este evento).
       window.dispatchEvent(new CustomEvent('mesas-toast', { detail: { action: 'create', table: newTable } }));
     } catch {
@@ -142,28 +123,8 @@ export function TableConfiguratorFloating() {
         y: 240 + Math.round(Math.random() * 80),
       };
       const title = `Bancos ceremonia ${((planSpaceActive.tables?.length ?? 0) + 1)}`;
-      const result: any = await fetchApiEventos({
-        query: queries.createTable,
-        variables: {
-          eventID: event._id,
-          planSpaceID: planSpaceActive._id,
-          values: JSON.stringify({
-            title,
-            numberChair: 12,
-            position,
-            rotation: 0,
-            size: { width: 100, height: 40 },
-            tipo: 'bancos',
-          }),
-        },
-      });
-      if (!result?.success) {
-        toast('error', result?.errors?.[0]?.message ?? 'Error al añadir bancos al plano');
-        return;
-      }
-      // Mesa LOCAL (createTable devuelve { success, errors, evento }, no la mesa entera)
       const newTable: any = {
-        _id: result?.table?._id ?? result?.evento?._id ?? `tmp_${Date.now()}`,
+        _id: genTableId(),
         title,
         nombre_mesa: title,
         tipo: 'bancos',
@@ -172,20 +133,25 @@ export function TableConfiguratorFloating() {
         position,
         rotation: 0,
         size: { width: 100, height: 40 },
+        guests: [],
       };
       const nextPlanSpace = {
         ...planSpaceActive,
         tables: [...(planSpaceActive.tables ?? []), newTable],
       };
-      setPlanSpaceActive(nextPlanSpace);
-      setEvent({
-        ...event,
-        planSpace: (event.planSpace ?? []).map((ps: any, idx: number) => {
-          if (ps?._id === nextPlanSpace._id) return nextPlanSpace;
-          if (ps?._id === planSpaceSelect) return nextPlanSpace;
-          return ps;
-        }),
+      const nextPlanSpaces = (event.planSpace ?? []).map((ps: any) =>
+        (ps?._id === nextPlanSpace._id || ps?._id === planSpaceSelect) ? nextPlanSpace : ps
+      );
+      const result: any = await fetchApiEventos({
+        query: queries.eventUpdate,
+        variables: { idEvento: event._id, input: { planSpace: nextPlanSpaces } },
       });
+      if (!result?.success) {
+        toast('error', result?.errors?.[0]?.message ?? 'Error al añadir bancos al plano');
+        return;
+      }
+      setPlanSpaceActive(nextPlanSpace);
+      setEvent({ ...event, planSpace: nextPlanSpaces });
 
       toast('success', `"${title}" añadido al plano`);
     } catch {
@@ -278,6 +244,17 @@ function distributeSeatsBySide(total: number, shape: TableShape): { seatsTop: nu
   const ends = n >= 2 ? 1 : 0;
   const rest = n - ends * 2;
   return { seatsTop: Math.ceil(rest / 2), seatsBottom: Math.floor(rest / 2), seatsLeft: ends, seatsRight: ends };
+}
+
+// El front es dueño de planSpace[].tables. El backend createTable escribe en el
+// legacy `evento.mesas_array` (desconectado de esta UI), así que generamos aquí un
+// _id estilo ObjectId (24 hex) y persistimos la mesa dentro del planSpace vía
+// updateEvento({planSpace}) — el mismo mecanismo que eliminar/crear plano.
+function genTableId(): string {
+  const ts = Math.floor(Date.now() / 1000).toString(16).padStart(8, '0');
+  let rest = '';
+  for (let i = 0; i < 16; i++) rest += Math.floor(Math.random() * 16).toString(16);
+  return ts + rest;
 }
 
 export default function TableConfigurator({ initialConfig, onConfirm, onCancel, nextTableNumber = 1 }: TableConfiguratorProps) {

--- a/apps/appEventos/components/Mesas/EditDefault.tsx
+++ b/apps/appEventos/components/Mesas/EditDefault.tsx
@@ -30,13 +30,14 @@ export const EditDefault: FC<EditDefaultState> = ({ item, setShowFormEditar, ite
         ),
       }))
       if (itemTipo == "table") {
+        // Persistir vía updateEvento({planSpace}) — deleteTable escribe en el legacy
+        // evento.mesas_array (desconectado de esta UI de planos).
+        const nextPlanSpaces = (event.planSpace ?? []).map(ps =>
+          ps._id !== planSpaceActive._id ? ps : newPlanSpaceActive
+        )
         await fetchApiEventos({
-          query: queries.deleteTable,
-          variables: {
-            eventID: event._id,
-            planSpaceID: planSpaceActive._id,
-            tableID: item._id
-          }
+          query: queries.eventUpdate,
+          variables: { idEvento: event._id, input: { planSpace: nextPlanSpaces } }
         })
         // Toast con «Deshacer» (MesasUndoToast escucha este evento).
         window.dispatchEvent(new CustomEvent('mesas-toast', { detail: { action: 'delete', table: item } }))
@@ -80,19 +81,14 @@ export const EditDefault: FC<EditDefaultState> = ({ item, setShowFormEditar, ite
       ),
     }))
     if (itemTipo === "table") {
-      // BUG-M-03 (informe QA 22-jun): la mutación se disparaba pero no persistía.
-      // Causa: JSON.stringify(15) = "15" (string) y backend espera number. Si
-      // valor es number, va sin stringify; si el backend exige string, va el
-      // toString plano (no JSON-encoded).
+      // Persistir la rotación vía updateEvento({planSpace}) — editTable escribe en el
+      // legacy evento.mesas_array (desconectado de esta UI de planos).
+      const nextPlanSpaces = (event.planSpace ?? []).map(ps =>
+        ps._id !== planSpaceActive._id ? ps : newPlanSpaceActive
+      )
       await fetchApiEventos({
-        query: queries.editTable,
-        variables: {
-          eventID: event._id,
-          planSpaceID: planSpaceActive?._id,
-          tableID: item._id,
-          variable: "rotation",
-          valor: String(newRotation)
-        }
+        query: queries.eventUpdate,
+        variables: { idEvento: event._id, input: { planSpace: nextPlanSpaces } }
       })
     }
     if (itemTipo === "element") {

--- a/apps/appEventos/components/Mesas/MesasUndoToast.tsx
+++ b/apps/appEventos/components/Mesas/MesasUndoToast.tsx
@@ -31,46 +31,28 @@ export const MesasUndoToast = () => {
 
   if (!toast) return null;
 
-  const applyTables = (tables: any[]) => {
-    const nextPS = { ...planSpaceActive, tables };
-    setPlanSpaceActive(nextPS);
-    setEvent((prev: any) => ({
-      ...prev,
-      planSpace: (prev?.planSpace ?? []).map((ps: any) => ps?._id === nextPS._id ? nextPS : ps),
-    }));
-  };
-
   const handleUndo = async () => {
     const { action, table } = toast;
     setToast(null);
     clearTimeout(timerRef.current);
     try {
-      if (action === 'create') {
-        // Deshacer creación: quitar la mesa (estado + backend).
-        applyTables((planSpaceActive?.tables ?? []).filter((tb: any) => tb._id !== table._id));
-        await fetchApiEventos({
-          query: queries.deleteTable,
-          variables: { eventID: event._id, planSpaceID: planSpaceActive._id, tableID: table._id },
-        });
-      } else {
-        // Deshacer borrado: recrear la mesa con sus propiedades (misma mutación que el alta).
-        applyTables([...(planSpaceActive?.tables ?? []), table]);
-        await fetchApiEventos({
-          query: queries.createTable,
-          variables: {
-            eventID: event._id,
-            planSpaceID: planSpaceActive._id,
-            values: JSON.stringify({
-              title: table.title || table.nombre_mesa,
-              numberChair: table.numberChair ?? table.cantidad_sillas,
-              position: table.position,
-              rotation: table.rotation ?? 0,
-              size: table.size ?? { width: 100, height: 80 },
-              tipo: table.tipo,
-            }),
-          },
-        });
-      }
+      // Deshacer creación → quitar la mesa; deshacer borrado → recrearla.
+      const nextTables = action === 'create'
+        ? (planSpaceActive?.tables ?? []).filter((tb: any) => tb._id !== table._id)
+        : [...(planSpaceActive?.tables ?? []), table];
+      const nextPS = { ...planSpaceActive, tables: nextTables };
+      const nextPlanSpaces = (event.planSpace ?? []).map((ps: any) => ps?._id === nextPS._id ? nextPS : ps);
+      setPlanSpaceActive(nextPS);
+      setEvent((prev: any) => ({
+        ...prev,
+        planSpace: (prev?.planSpace ?? []).map((ps: any) => ps?._id === nextPS._id ? nextPS : ps),
+      }));
+      // Persistir vía updateEvento({planSpace}) — create/deleteTable escriben en el
+      // legacy evento.mesas_array (desconectado de esta UI de planos).
+      await fetchApiEventos({
+        query: queries.eventUpdate,
+        variables: { idEvento: event._id, input: { planSpace: nextPlanSpaces } },
+      });
     } catch { /* noop — el estado local ya refleja el undo */ }
   };
 

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -135,27 +135,25 @@ const Mesas: FC = () => {
     const newTitle = (config?.tableName || table.title || '').toString()
     const newTipo = SHAPE_TO_TIPO_EDIT[config?.shape] ?? table.tipo
     const newSeats = Number(config?.seats ?? table.numberChair) || table.numberChair
-    const baseVars = { eventID: event._id, planSpaceID: planSpaceActive._id, tableID: table._id }
     try {
-      if (newTitle !== table.title) {
-        await fetchApiEventos({ query: queries.editTable, variables: { ...baseVars, variable: 'title', valor: JSON.stringify(newTitle) } })
-      }
-      if (newTipo !== table.tipo) {
-        await fetchApiEventos({ query: queries.editTable, variables: { ...baseVars, variable: 'tipo', valor: JSON.stringify(newTipo) } })
-      }
+      // Reducir sillas → quitar invitados de las sillas eliminadas (chair >= newSeats).
       let newGuests = table.guests
-      if (newSeats !== table.numberChair) {
-        // Reducir sillas → quitar invitados de las sillas eliminadas (chair >= newSeats).
-        if (newSeats < (table.numberChair ?? 0) && Array.isArray(table.guests)) {
-          newGuests = table.guests.filter((g: any) => (g?.chair ?? 0) < newSeats)
-          if (newGuests.length !== table.guests.length) {
-            await fetchApiEventos({ query: queries.editTable, variables: { ...baseVars, variable: 'guests', valor: JSON.stringify(newGuests) } })
-          }
-        }
-        await fetchApiEventos({ query: queries.editTable, variables: { ...baseVars, variable: 'numberChair', valor: JSON.stringify(newSeats) } })
+      if (newSeats < (table.numberChair ?? 0) && Array.isArray(table.guests)) {
+        newGuests = table.guests.filter((g: any) => (g?.chair ?? 0) < newSeats)
       }
-      const updatedTable = { ...table, title: newTitle, nombre_mesa: newTitle, tipo: newTipo, numberChair: newSeats, guests: newGuests }
+      const updatedTable = { ...table, title: newTitle, nombre_mesa: newTitle, tipo: newTipo, numberChair: newSeats, cantidad_sillas: newSeats, guests: newGuests }
       const nps: any = { ...planSpaceActive, tables: (planSpaceActive.tables ?? []).map((tb: any) => tb._id === table._id ? updatedTable : tb) }
+      const nextPlanSpaces = (event.planSpace ?? []).map((ps: any) => ps._id === planSpaceActive._id ? nps : ps)
+      // Persistir vía updateEvento({planSpace}) — editTable escribe en el legacy
+      // evento.mesas_array (desconectado de esta UI de planos).
+      const res: any = await fetchApiEventos({
+        query: queries.eventUpdate,
+        variables: { idEvento: event._id, input: { planSpace: nextPlanSpaces } },
+      })
+      if (!res?.success) {
+        toast('error', res?.errors?.[0]?.message ?? t('Ha ocurrido un error al editar la mesa'))
+        return
+      }
       setPlanSpaceActive(nps)
       setEvent((prev: any) => ({ ...prev, planSpace: prev.planSpace.map((ps: any) => ps._id === planSpaceActive._id ? nps : ps) }))
     } catch {


### PR DESCRIPTION
## Bug
"+ Añadir mesa" → "Nombre de mesa requerido" y la mesa nunca aparece (ni tras F5). Editar/borrar tampoco persistían de verdad.

## Raíz (verificada por SSH + Mongo en backend)
- El front (UI de planos) usa `evento.planSpace[].tables` — la fuente REAL: **731 eventos** la usan; `mesas_array` solo **4** (muerto); **0 con ambos**.
- `createTable`/`editTable`/`deleteTable` del backend operan sobre el legacy `evento.mesas_array` (`creaMesa` hace `push` a `mesas_array`, ignora `planSpaceID`, exige `nombre`). **Desconectados del planSpace.**
- **No existe resolver atómico** de `planSpace.tables`; el único camino sancionado para persistir el planSpace es `updateEvento(input.planSpace)` — el que ya usan eliminar/crear plano.

## Fix (front, usa la API sancionada)
- Crear + bancos (`TableConfiguratorFloating`), editar (`guardarEdicion`), borrar + rotar (`EditDefault`), deshacer (`MesasUndoToast`) → todos persisten vía `updateEvento({planSpace})`.
- Verificado end-to-end: añadir mesa vía updateEvento → `success:true` y aparece en `planSpace.tables` ✅.

## Pendiente backend (coordinado)
Resolvers **atómicos** de `planSpace.tables` ($push/$set/$pull por planSpaceID) para evitar el last-write-wins del array completo bajo edición concurrente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)