### PR TITLE
🐛 fix(mesas): modo banco en el modal de edición (no tratar bancos como mesa)

### DIFF
--- a/apps/appEventos/components/Forms/TableConfigurator.tsx
+++ b/apps/appEventos/components/Forms/TableConfigurator.tsx
@@ -257,6 +257,25 @@ function genTableId(): string {
   return ts + rest;
 }
 
+// Preview LINEAL para bancos: una sola fila de sillas sobre una barra (coherente con
+// cómo se dibuja el banco en el plano), en vez de una mesa con figura geométrica.
+function benchPreviewSVG(seats: number): string {
+  const n = Math.max(1, Math.min(40, Math.floor(seats || 1)));
+  const W = 290, H = 230, pad = 20;
+  const gap = (W - pad * 2) / n;
+  const r = Math.max(5, Math.min(11, gap * 0.36));
+  const cy = H / 2 - 16;
+  const barY = cy + r + 8;
+  let chairs = '';
+  for (let i = 0; i < n; i++) {
+    const cx = pad + gap * (i + 0.5);
+    chairs += `<circle cx="${cx.toFixed(1)}" cy="${cy}" r="${r.toFixed(1)}" fill="#ffffff" stroke="#B4B4BC" stroke-width="1.5"/>`;
+  }
+  const bar = `<rect x="${pad}" y="${barY}" width="${W - pad * 2}" height="16" rx="6" fill="#F0F0F2" stroke="#4a4a52" stroke-width="1.2"/>`;
+  const label = `<text x="${W / 2}" y="${barY + 42}" font-size="12" fill="#8a8a90" text-anchor="middle" font-family="Poppins, sans-serif">Banco lineal · ${n} sillas</text>`;
+  return `<svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg">${bar}${chairs}${label}</svg>`;
+}
+
 export default function TableConfigurator({ initialConfig, onConfirm, onCancel, nextTableNumber = 1 }: TableConfiguratorProps) {
   const defaultShape = (initialConfig?.shape ?? 'round') as TableShape;
   const [config, setConfig] = useState<TableConfig>(() => {
@@ -315,6 +334,9 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
 
   const maxSeats = getMaxSeats(config);
   const isRect = config.shape === 'rectangular' || config.shape === 'square';
+  // Banco = fila lineal de sillas sueltas: el modal oculta Forma/Tamaño/Tipo-mesa
+  // y muestra solo Nombre + Sillas + Estilo silla, con una preview lineal.
+  const isBench = !!(config as any).isBench;
   const totalSize = getTableTotalSize(config);
 
   if (typeof document === 'undefined') return null;
@@ -323,7 +345,7 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
       <div style={s.modal}>
         <style>{`.tc-round-check{appearance:none;-webkit-appearance:none;width:17px;height:17px;border:1.6px solid #c4c4cc;border-radius:50%;cursor:pointer;position:relative;flex:none;vertical-align:middle}.tc-round-check:checked{background:#EF5B94;border-color:#EF5B94}.tc-round-check:checked::after{content:'';position:absolute;left:5px;top:2.5px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}.tc-slider{-webkit-appearance:none;appearance:none;height:6px;border-radius:6px;background:#E7E7EA;width:100%;outline:none}.tc-slider::-webkit-slider-thumb{-webkit-appearance:none;width:16px;height:16px;border-radius:50%;background:#EF5B94;cursor:pointer;box-shadow:0 1px 3px rgba(0,0,0,.25)}.tc-slider::-moz-range-thumb{width:16px;height:16px;border:none;border-radius:50%;background:#EF5B94;cursor:pointer}.tc-scroll::-webkit-scrollbar{width:0;height:0;display:none}`}</style>
         <div style={s.header}>
-          <h2 style={s.title}>{initialConfig ? 'Editar mesa' : 'Diseñar mesa'}</h2>
+          <h2 style={s.title}>{isBench ? 'Editar banco' : (initialConfig ? 'Editar mesa' : 'Diseñar mesa')}</h2>
           <button style={s.closeBtn} type="button" onClick={onCancel}>✕</button>
         </div>
 
@@ -335,7 +357,8 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
               <input type="text" value={config.tableName ?? ''} placeholder="Ej: Mesa 1" onChange={e => update('tableName', e.target.value)} style={{ ...s.textInput, width: '100%', boxSizing: 'border-box' }} />
             </section>
 
-            {/* FORMA */}
+            {/* FORMA — no aplica a un banco (fila lineal) */}
+            {!isBench && (
             <section style={s.section}>
               <div style={s.sectionTitle}>Forma</div>
               <div style={s.shapeGrid}>
@@ -346,8 +369,10 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
                 ))}
               </div>
             </section>
+            )}
 
-            {/* TAMAÑO */}
+            {/* TAMAÑO — no aplica a un banco (fila lineal) */}
+            {!isBench && (
             <section style={s.section}>
               <div style={s.sectionTitle}>Tamaño</div>
               {(config.shape === 'round') && (
@@ -366,12 +391,13 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
               )}
               <div style={s.sizeHint}>Espacio total con sillas: <strong>{Math.round(totalSize.widthCm)} × {Math.round(totalSize.heightCm)} cm</strong></div>
             </section>
+            )}
 
             {/* SILLAS */}
             <section style={s.section}>
               <div style={s.sectionTitle}>Sillas</div>
-              <NumberStepper label="Número de sillas" value={config.seats} min={1} max={maxSeats} onChange={v => update('seats', v)} />
-              <div style={s.maxHint}>Máximo recomendado: {maxSeats} personas</div>
+              <NumberStepper label="Número de sillas" value={config.seats} min={1} max={isBench ? 60 : maxSeats} onChange={v => update('seats', v)} />
+              {!isBench && <div style={s.maxHint}>Máximo recomendado: {maxSeats} personas</div>}
               <div style={s.fieldRow}>
                 <label style={s.label}>Estilo silla</label>
                 <select style={s.select} value={config.chairStyle ?? 'chiavari'}
@@ -385,7 +411,8 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
               </div>
             </section>
 
-            {/* TIPO DE MESA — el usuario pidió mantener Novios / Infantil */}
+            {/* TIPO DE MESA — no aplica a un banco (fila lineal) */}
+            {!isBench && (
             <section style={s.section}>
               <div style={s.sectionTitle}>Tipo de mesa</div>
               <div style={s.toggleRow}>
@@ -396,17 +423,20 @@ export default function TableConfigurator({ initialConfig, onConfirm, onCancel, 
                 ))}
               </div>
             </section>
+            )}
           </div>
 
           {/* Preview */}
           <div style={s.preview}>
             <div style={s.previewCanvas}>
-              {previewSVG && <div style={s.previewSVG} dangerouslySetInnerHTML={{ __html: previewSVG }} />}
+              {isBench
+                ? <div style={s.previewSVG} dangerouslySetInnerHTML={{ __html: benchPreviewSVG(config.seats) }} />
+                : (previewSVG && <div style={s.previewSVG} dangerouslySetInnerHTML={{ __html: previewSVG }} />)}
             </div>
             <div style={s.previewInfo}>
-              <span>🪑 {config.seats} personas</span>
+              <span>🪑 {config.seats} {isBench ? 'sillas' : 'personas'}</span>
               {config.tableName && <span>📋 {config.tableName}</span>}
-              {config.isHeadTable && <span>💍 Novios</span>}
+              {!isBench && config.isHeadTable && <span>💍 Novios</span>}
             </div>
           </div>
         </div>

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -70,16 +70,25 @@ export const convertBackendSvgsToReact = (backendSvgs: any[]): GalerySvg[] => {
 // panel del HTML (TableConfigurator con initialConfig = modo "Editar mesa", línea 324).
 const SHAPE_TO_TIPO_EDIT: Record<string, string> = { round: 'redonda', rectangular: 'imperial', oval: 'redonda', square: 'cuadrada', semicircle: 'podio', head: 'podio' }
 const TIPO_TO_SHAPE_EDIT: Record<string, string> = { redonda: 'round', cuadrada: 'square', imperial: 'rectangular', podio: 'round', militar: 'rectangular', bancos: 'rectangular', banco: 'rectangular' }
-const mesaAConfig = (table: any, num?: number): any => ({
-  // 'podio' (antigua forma "media luna"/Novios) ya no es una forma seleccionable:
-  // se muestra como redonda + se marca el toggle "Mesa de novios".
-  shape: TIPO_TO_SHAPE_EDIT[table?.tipo] ?? 'round',
-  seats: table?.numberChair ?? 8,
-  tableName: table?.title ?? '',
-  // Número REAL de la mesa (índice+1 en el plano), para que el preview no muestre siempre "1"
-  ...(typeof num === 'number' && num > 0 ? { tableNumber: num } : {}),
-  isHeadTable: table?.tipo === 'podio',
-})
+// Tipos lineales (sillas sueltas en fila) — no son mesas con forma geométrica.
+const BENCH_TIPOS = ['bancos', 'banco', 'militar']
+const mesaAConfig = (table: any, num?: number): any => {
+  const isBench = BENCH_TIPOS.includes(table?.tipo)
+  return {
+    // 'podio' (antigua forma "media luna"/Novios) ya no es una forma seleccionable:
+    // se muestra como redonda + se marca el toggle "Mesa de novios".
+    shape: TIPO_TO_SHAPE_EDIT[table?.tipo] ?? 'round',
+    seats: table?.numberChair ?? 8,
+    tableName: table?.title ?? '',
+    // Número REAL de la mesa (índice+1 en el plano), para que el preview no muestre siempre "1"
+    ...(typeof num === 'number' && num > 0 ? { tableNumber: num } : {}),
+    isHeadTable: table?.tipo === 'podio',
+    // Banco = fila lineal de sillas sueltas → el modal muestra un modo simplificado
+    // (sin Forma/Tamaño/Tipo-mesa) y preselecciona el estilo de silla "Banco".
+    isBench,
+    ...(isBench ? { chairStyle: table?.tableConfig?.chairStyle ?? 'bench' } : {}),
+  }
+}
 
 const Mesas: FC = () => {
   const { t } = useTranslation();
@@ -133,7 +142,10 @@ const Mesas: FC = () => {
     const table = showFormEditar?.table
     if (!table?._id) { setShowFormEditar({ table: {}, visible: false }); return }
     const newTitle = (config?.tableName || table.title || '').toString()
-    const newTipo = SHAPE_TO_TIPO_EDIT[config?.shape] ?? table.tipo
+    // Banco = tipo lineal: NUNCA remapear desde la forma (evita banco→imperial que
+    // destruiría el layout lineal). Se conserva el tipo original.
+    const isBench = BENCH_TIPOS.includes(table?.tipo)
+    const newTipo = isBench ? table.tipo : (SHAPE_TO_TIPO_EDIT[config?.shape] ?? table.tipo)
     const newSeats = Number(config?.seats ?? table.numberChair) || table.numberChair
     try {
       // Reducir sillas → quitar invitados de las sillas eliminadas (chair >= newSeats).


### PR DESCRIPTION
QA: editar un banco abría el modal genérico de mesa (Forma/Tamaño/Novios) y al Actualizar lo convertía en `imperial` (destruyendo el layout lineal).

Fix: mesaAConfig marca `isBench` (bancos/banco/militar) + preselecciona estilo 'Banco'; guardarEdicion PRESERVA el tipo (no más banco→imperial); TableConfigurator en modo banco oculta Forma/Tamaño/Tipo-mesa, título 'Editar banco', preview LINEAL. Desplegado app-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)