### PR TITLE
🐛 fix(pendientes): corta loop React #185 (Zustand 5 + Object.values sin useShallow)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/pendientes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/pendientes/page.tsx
@@ -19,6 +19,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 import { useBandejaStore } from '@/store/bandeja';
@@ -77,7 +78,12 @@ function classifyNotification(type: string | undefined): SectionKey {
 
 export default function PendientesPage() {
   const router = useRouter();
-  const conversations = useBandejaStore((s) => Object.values(s.conversations));
+  // useShallow: Object.values() crea un array nuevo en cada llamada del selector.
+  // Con Zustand 5 (useSyncExternalStore sin memoización) eso rompe la estabilidad
+  // del snapshot → bucle "Maximum update depth exceeded" (React #185) que crasheaba
+  // /pendientes al 100%. useShallow devuelve la referencia anterior si el contenido
+  // es shallow-igual, cortando el loop. (Mismo patrón que useTypingInConv en el store.)
+  const conversations = useBandejaStore(useShallow((s) => Object.values(s.conversations)));
   const notifications = useBandejaStore((s) => s.notifications);
   const unreadCounts = useBandejaStore((s) => s.unreadCounts);
   const initBandeja = useBandejaStore((s) => s.initBandeja);


### PR DESCRIPTION
## Problema (QA chat-dev 1-ago, prioridad alta)
`/pendientes` renderiza pantalla de error genérica + toast "sesión renovada"; consola con
**React #185 "Maximum update depth exceeded"**, 100% reproducible, "Reintentar" no lo cura →
bloquea toda la sección Pendientes.

## Causa raíz
El selector inline `useBandejaStore((s) => Object.values(s.conversations))` (page.tsx:80) crea un
**array nuevo en cada llamada**. Con **Zustand 5.0.4** (`useSyncExternalStore` sin la memoización
que el shim `useSyncExternalStoreWithSelector` de v4 aportaba), el snapshot deja de ser
referencialmente estable → React detecta cambio en cada commit → **re-render en bucle**.
Bug latente desde 2026-06-27; se **activó al actualizar Zustand a v5**.

## Fix
Envolver el selector con `useShallow` (idéntico patrón al de `useTypingInConv` en
`src/store/bandeja/selectors.ts`, que ya documenta este mismo loop). Devuelve la referencia
anterior si el contenido es shallow-igual → snapshot estable → sin loop.
- Cero cambio de tipos (`Conversation[]`) ni de comportamiento visible.
- Diff mínimo: 1 import + 1 selector envuelto.

## Landmine relacionado (fuera de scope, REPORTADO)
`useConversationsList` / `useConversationsByChannel` / `useConversationsByScope` en
`selectors.ts` tienen el MISMO `Object.values` sin `useShallow`. Hoy no crashean porque no hay
componentes montados que los consuman, pero son una mina para el próximo consumidor. Recomiendo
hardenizarlos en un PR aparte.

## Verificación
- ESLint: sin errores nuevos (los 5 de sort-keys/jsx-sort-props ya existían en dev).
- Tipo preservado; `useShallow` ya probado en el mismo store.
- Pendiente: build chat-dev + smoke de `/pendientes` (no crash, lista pinta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)