### PR TITLE
🐛 fix(mesas): crash pestaña Mobiliario (SvgFromString .match sobre null)

### DIFF
--- a/apps/appEventos/components/SvgFromString.tsx
+++ b/apps/appEventos/components/SvgFromString.tsx
@@ -13,6 +13,12 @@ const SvgFromString: React.FC<SvgFromStringProps> = ({
   style = {},
   ...props
 }) => {
+  // Guard: si el svgString no es un string válido (galerySvg sin `icon`, dato roto del
+  // backend), NO reventar toda la pestaña Mobiliario con `undefined.match(...)`. Degradar
+  // ocultando solo este icono. (Crash CRÍTico informe QA: "Cannot read properties of
+  // undefined (reading 'match')").
+  if (typeof svgString !== 'string' || !svgString.trim()) return null;
+
   // Función para limpiar y convertir atributos HTML a React
   const convertHtmlAttributesToReact = (attributes: Record<string, string>): Record<string, string> => {
     const reactAttributes: Record<string, string> = {};

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -57,12 +57,15 @@ export const ListElements: GalerySvg[] = [
 
 // Función helper para convertir SVGs del backend en elementos React
 export const convertBackendSvgsToReact = (backendSvgs: any[]): GalerySvg[] => {
-  return backendSvgs.map((svgItem: any) => ({
-    ...svgItem,
-    // Convertir el string SVG del backend en un componente React usando SvgFromString
-    icon: <SvgFromString svgString={svgItem.icon} className="relative w-max" />,
-    size: { width: 60, height: 60 }
-  }));
+  return (Array.isArray(backendSvgs) ? backendSvgs : [])
+    // Solo convertir los que traen el SVG como STRING. Si `icon` ya es un React element
+    // (doble conversión) o falta, dejar el item tal cual → evita `undefined.match(...)`
+    // dentro de SvgFromString (crash CRÍTICO de la pestaña Mobiliario).
+    .map((svgItem: any) => (
+      typeof svgItem?.icon === 'string'
+        ? { ...svgItem, icon: <SvgFromString svgString={svgItem.icon} className="relative w-max" />, size: { width: 60, height: 60 } }
+        : svgItem
+    ));
 };
 
 


### PR DESCRIPTION
QA CRÍTICO: abrir Mobiliario rompía toda la pantalla con 'Cannot read properties of undefined (reading match)'. Raíz (confirmada en bundle: los 2 únicos .match son de SvgFromString): default svgString='' no aplica a null → null.match() crashea. Fix: guard en SvgFromString (return null si no es string) + convertBackendSvgsToReact solo envuelve strings. Desplegado app-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)