### PR TITLE
🙈 fix(discover): ocultar marketplace MCP (hub público LobeHub caído) — QA #3

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/discover/(list)/(home)/HomePage.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/discover/(list)/(home)/HomePage.tsx
@@ -7,25 +7,22 @@ import { useDiscoverStore } from '@/store/discover';
 
 import Title from '../../components/Title';
 import AssistantList from '../assistant/features/List';
-import McpList from '../mcp/features/List';
 import Loading from './loading';
 
+// MCP oculto (decisión producto 1-ago): el marketplace MCP apunta al hub PÚBLICO de LobeHub
+// (MARKET_BASE_URL sin configurar) y su endpoint MCP falla → doble toast "Failed to fetch mcp
+// list" en /discover. Los asistentes usan el mismo hub y SÍ cargan. Se oculta la sección/tab MCP
+// hasta tener marketplace propio del cliente. Ver también useNav.tsx.
 const HomePage = memo<{ mobile?: boolean }>(() => {
   const { t } = useTranslation('discover');
   const useAssistantList = useDiscoverStore((s) => s.useAssistantList);
-  const useMcpList = useDiscoverStore((s) => s.useFetchMcpList);
 
   const { data: assistantList, isLoading: assistantLoading } = useAssistantList({
     page: 1,
     pageSize: 12,
   });
 
-  const { data: mcpList, isLoading: pluginLoading } = useMcpList({
-    page: 1,
-    pageSize: 12,
-  });
-
-  if (assistantLoading || pluginLoading) return <Loading />;
+  if (assistantLoading) return <Loading />;
 
   return (
     <>
@@ -33,11 +30,6 @@ const HomePage = memo<{ mobile?: boolean }>(() => {
         {t('home.featuredAssistants')}
       </Title>
       <AssistantList data={assistantList?.items ?? []} rows={4} />
-      <div />
-      <Title more={t('home.more')} moreLink={'/mcp'}>
-        {t('home.featuredTools')}
-      </Title>
-      <McpList data={mcpList?.items ?? []} rows={4} />
     </>
   );
 });

--- a/apps/chat-ia/src/app/[variants]/(main)/discover/features/useNav.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/discover/features/useNav.tsx
@@ -1,4 +1,3 @@
-import { MCP } from '@lobehub/icons';
 import { Icon } from '@lobehub/ui';
 import { Bot, Brain, BrainCircuit, House } from 'lucide-react';
 import { ReactNode, useMemo, useState, useEffect } from 'react';
@@ -55,15 +54,8 @@ export const useNav = () => {
           </Link>
         ),
       },
-      {
-        icon: <MCP className={'anticon'} size={ICON_SIZE} />,
-        key: DiscoverTab.Mcp,
-        label: (
-          <Link style={{ color: 'inherit' }} to={`/${DiscoverTab.Mcp}`}>
-            {`MCP ${t('tab.plugin')}`}
-          </Link>
-        ),
-      },
+      // MCP oculto (decisión producto 1-ago): el marketplace MCP (hub público LobeHub) falla
+      // su endpoint MCP; se oculta la pestaña hasta tener marketplace propio. Ver HomePage.tsx.
       {
         icon: <Icon icon={Brain} size={ICON_SIZE} />,
         key: DiscoverTab.Models,


### PR DESCRIPTION
## Problema (QA chat-dev 1-ago, #3)
Toast doble "Solicitud fallida" → "Failed to fetch mcp list" en `/discover`. El catálogo de
asistentes SÍ carga.

## Causa raíz
El marketplace usa `MarketSDK({ baseURL: process.env.MARKET_BASE_URL })` con `MARKET_BASE_URL`
**sin configurar** → default = **hub PÚBLICO de LobeHub**. Su endpoint MCP falla; el de
asistentes (mismo hub/baseURL) funciona → el fallo es **aislado al MCP y externo** (no api-ia
ni api-mcp). Es un feature experimental reactivado el 12-jun; el marketplace propio del cliente
es trabajo futuro.

## Fix (decisión de producto: ocultar MCP)
- `useNav.tsx`: quita el item **MCP** del nav del Discover (+ import de icono sin usar).
- `HomePage.tsx`: quita la sección "featuredTools" (`useFetchMcpList` + `<McpList>`) — era la que
  disparaba el fetch fallido en la home → desaparece el toast.

Sin cambios de backend. Las rutas `/mcp` quedan intactas pero inalcanzables por UI (reversible
en cuanto haya marketplace propio/estable).

## Verificación
- ESLint: 0 errores (1 warning `any` pre-existente en useNav, no tocado).
- Pendiente: build chat-dev + smoke `/discover` (sin toast, asistentes cargan, sin pestaña MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)