### PR TITLE
🐛 fix(bandeja): useShallow en useBandejaStatus — último landmine React #185

### DIFF
--- a/apps/chat-ia/src/store/bandeja/selectors.ts
+++ b/apps/chat-ia/src/store/bandeja/selectors.ts
@@ -81,4 +81,7 @@ export const useTypingInConv = (convId: string) =>
 
 /** Loading + error global. */
 export const useBandejaStatus = () =>
-  useBandejaStore((s) => ({ loading: s.loading, error: s.error }));
+  // useShallow: devuelve un objeto nuevo cada llamada → sobre useBandejaStore (create() plano,
+  // igualdad Object.is) rompería el snapshot → React #185 en el componente que lo monte. (Las
+  // stores de LobeChat no lo necesitan: usan createWithEqualityFn(..., shallow).)
+  useBandejaStore(useShallow((s) => ({ error: s.error, loading: s.loading })));


### PR DESCRIPTION
## Contexto
Cierre del barrido de la clase de bug que tumbó `/pendientes` (React #185, Zustand 5). Verifiqué
TODA la app: la única store creada con `create()` plano (igualdad `Object.is`) es `useBandejaStore`
— las de LobeChat usan `createWithEqualityFn(..., shallow)` y son seguras. Enumerados todos sus
selectores, este era el **último** que devolvía una referencia nueva sin `useShallow`.

## Fix
`useBandejaStatus` devolvía `{ loading, error }` (objeto nuevo por llamada) → loop #185 en el
primer componente que lo montara (hoy sin consumidores → latente). Envuelto con `useShallow`;
reordeno claves de paso (limpia el `sort-keys` pre-existente). Sin cambio de comportamiento.

## Resultado del barrido
Codebase **limpio** de este footgun: todos los selectores de `useBandejaStore` ahora usan
`useShallow` o devuelven referencias existentes/escalares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)