### PR TITLE
🐛 fix(mesas): drag al plano — overlap:'pointer' (el drop no se disparaba)

### DIFF
--- a/apps/appEventos/components/Mesas/FuntionsDragable.tsx
+++ b/apps/appEventos/components/Mesas/FuntionsDragable.tsx
@@ -38,6 +38,11 @@ export const setupDropzone = ({ target, accept, handleOnDrop, setEvent, event: e
     interact(target)
       .dropzone({
         accept: accept,
+        // El item arrastrable (sidebar) NO se mueve — solo el "espejo" (dragM) sigue al
+        // cursor. Con overlap por elemento (default) el dropzone del canvas nunca detecta
+        // el item (queda en el sidebar) → el evento 'drop' no se disparaba. overlap:'pointer'
+        // = soltar donde está el CURSOR (patrón paleta→lienzo). Así el drop sí se registra.
+        overlap: 'pointer',
         ondropactivate: function (event) {
         },
         ondropdeactivate: function (event) {


### PR DESCRIPTION
El item arrastrable del sidebar no se mueve (solo el espejo dragM sigue al cursor); el dropzone usaba overlap por elemento (default) → nunca detectaba el item → 'drop' no se disparaba → nada se añadía. Fix: overlap:'pointer' (soltar donde está el cursor). Desplegado app-dev. Requiere confirmación visual en navegador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)