### PR TITLE
🐛 fix(mesas): 2º crash Mobiliario — cloneElement(undefined) en SvgWrapper

### DIFF
--- a/apps/appEventos/components/SvgWrapper.tsx
+++ b/apps/appEventos/components/SvgWrapper.tsx
@@ -138,7 +138,10 @@ const SvgWrapper: React.FC<SvgWrapperProps> = ({
         ...style
       }}
     >
-      {React.cloneElement(children, svgProps)}
+      {/* Guard: si children no es un React element válido (icono undefined/roto), NO
+          reventar con cloneElement ("The argument must be a React element, but you
+          passed undefined"). Degradar mostrando vacío. */}
+      {React.isValidElement(children) ? React.cloneElement(children, svgProps) : null}
     </div>
   );
 };

--- a/apps/appEventos/pages/mesas.tsx
+++ b/apps/appEventos/pages/mesas.tsx
@@ -57,15 +57,15 @@ export const ListElements: GalerySvg[] = [
 
 // Función helper para convertir SVGs del backend en elementos React
 export const convertBackendSvgsToReact = (backendSvgs: any[]): GalerySvg[] => {
-  return (Array.isArray(backendSvgs) ? backendSvgs : [])
-    // Solo convertir los que traen el SVG como STRING. Si `icon` ya es un React element
-    // (doble conversión) o falta, dejar el item tal cual → evita `undefined.match(...)`
-    // dentro de SvgFromString (crash CRÍTICO de la pestaña Mobiliario).
-    .map((svgItem: any) => (
-      typeof svgItem?.icon === 'string'
-        ? { ...svgItem, icon: <SvgFromString svgString={svgItem.icon} className="relative w-max" />, size: { width: 60, height: 60 } }
-        : svgItem
-    ));
+  // `icon` debe ser SIEMPRE un React element válido (DragTable/SvgWrapper le hacen
+  // cloneElement). Envolvemos en SvgFromString: si el string no es válido/está vacío,
+  // SvgFromString degrada a null (pero sigue siendo un element válido para cloneElement),
+  // evitando tanto `undefined.match(...)` como `cloneElement(undefined)`.
+  return (Array.isArray(backendSvgs) ? backendSvgs : []).map((svgItem: any) => ({
+    ...svgItem,
+    icon: <SvgFromString svgString={typeof svgItem?.icon === 'string' ? svgItem.icon : ''} className="relative w-max" />,
+    size: { width: 60, height: 60 },
+  }));
 };
 
 


### PR DESCRIPTION
Tras el guard de .match (PR #250), la pestaña seguía cayendo con 'The argument must be a React element, but you passed undefined'. Raíz: SvgWrapper.tsx cloneElement(children) sin validar + convertBackendSvgsToReact podía dejar icon:undefined. Fix: SvgWrapper valida isValidElement antes de cloneElement; convertBackendSvgsToReact envuelve SIEMPRE en SvgFromString. Desplegado app-dev 9WX76E2NUe4gfuYcTzBLq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)