### PR TITLE
✨ feat(chat/panel): F0 — getEventoDetalle (datos ricos de un evento)

### DIFF
--- a/apps/chat-ia/src/services/mcpApi/eventos.ts
+++ b/apps/chat-ia/src/services/mcpApi/eventos.ts
@@ -38,6 +38,24 @@ export interface GetEventosByUsuarioResponse {
   getEventosByUsuario: EventosResponse;
 }
 
+// Evento con los datos RICOS del evento (para el panel contextual del chat).
+// Los *_array y presupuesto_objeto son escalares JSON opacos en el schema api-mcp
+// (04-jul, EVT-01): sin subselección → el cliente los consume tal cual (arrays de
+// objetos). Verificado contra la query que appEventos ya usa en prod (Fetching.ts
+// getEventsByID → queryenEvento).
+export interface EventoDetalle extends Evento {
+  invitados_array?: unknown;
+  itinerarios_array?: unknown;
+  lugar?: { _id?: string; slug?: string; title?: string } | null;
+  menus_array?: unknown;
+  presupuesto_objeto?: unknown;
+  showChildrenGuest?: boolean;
+}
+
+export interface QueryenEventoResponse {
+  queryenEvento: EventoDetalle | null;
+}
+
 // ========================================
 // QUERIES
 // ========================================
@@ -54,6 +72,30 @@ const GET_EVENTOS_BY_USUARIO = `
         development
         usuario_id
       }
+    }
+  }
+`;
+
+// Lectura de UN evento con sus datos ricos (presupuesto/itinerario/invitados).
+// Espeja la query PROBADA de appEventos (Fetching.ts getEventsByID): resolver
+// `queryenEvento(variable, valor, development)`. variable="_id" + valor=eventoId.
+// IMPORTANTE: NO poner comentarios `#` dentro de este template (el proxy lo aplasta
+// a 1 línea → el `#` come hasta EOF → "Syntax Error: Expected Name, found <EOF>").
+const GET_EVENTO_DETALLE = `
+  query GetEventoDetalle($variable: String, $valor: String, $development: String!) {
+    queryenEvento(variable: $variable, valor: $valor, development: $development) {
+      _id
+      nombre
+      fecha
+      tipo
+      usuario_id
+      development
+      lugar { _id title slug }
+      itinerarios_array
+      presupuesto_objeto
+      invitados_array
+      menus_array
+      showChildrenGuest
     }
   }
 `;
@@ -78,6 +120,24 @@ export const getEventosByUsuario = async (
     usuario_id: usuarioId,
   });
   return data.getEventosByUsuario?.eventos ?? [];
+};
+
+/**
+ * Obtiene UN evento con sus datos ricos (presupuesto/itinerario/invitados/menús)
+ * para el panel contextual del chat. Devuelve null si no se resuelve.
+ * Nota: los *_array y presupuesto_objeto vuelven como JSON opaco (parsear en el consumidor).
+ */
+export const getEventoDetalle = async (
+  development: string,
+  eventoId: string,
+): Promise<EventoDetalle | null> => {
+  if (!eventoId) return null;
+  const data = await mcpClient.query<QueryenEventoResponse>(GET_EVENTO_DETALLE, {
+    development,
+    valor: eventoId,
+    variable: '_id',
+  });
+  return data.queryenEvento ?? null;
 };
 
 /**


### PR DESCRIPTION
## Contexto
F0 del roadmap "panel derecho del chat cambia solo al hablar del evento" (audit 3-ago,
`project_audit_chat_panel_contextual`). El chat solo disponía de la lista mínima de eventos
(`getEventosByUsuario`: `_id/nombre/fecha`). El panel necesita los datos ricos del evento.

## Qué hace
`getEventoDetalle(development, eventoId)` → trae `presupuesto_objeto`, `itinerarios_array`,
`invitados_array`, `menus_array`, `lugar`, `nombre/fecha/tipo` de UN evento.

## Por qué es seguro (sin adivinar schema)
Espeja **verbatim** la query que appEventos ya usa en producción: `getEventsByID` → resolver
`queryenEvento(variable, valor, development)` (`Fetching.ts:1402-1447`), con `variable="_id"`.
Mismo endpoint api-mcp que chat-ia ya consume (`getEventosByUsuario`). Campos escalares JSON
sin subselección (evita EVT-01); sin `#` dentro del template (evita el EOF del proxy).

## Alcance
- No toca `getEventosByUsuario` (la usa el selector CRM).
- Sin consumidor todavía: lo usará F1/F3 (el panel) — próximo PR. E2E real al integrarlo.
- ESLint 0 errores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)