### PR TITLE
✨ feat(chat/panel): F1+F3 — show_event_section + portal (presupuesto/itinerario)

### DIFF
--- a/apps/chat-ia/src/store/chat/slices/builtinTool/actions/eventPanel.ts
+++ b/apps/chat-ia/src/store/chat/slices/builtinTool/actions/eventPanel.ts
@@ -1,0 +1,71 @@
+import { StateCreator } from 'zustand/vanilla';
+
+import { getEventoDetalle } from '@/services/mcpApi/eventos';
+import { ChatStore } from '@/store/chat/store';
+
+interface ShowEventSectionData {
+  eventoId: string;
+  section: string;
+}
+
+/** Estado que consume el Portal (event-panel/Portal). */
+export interface EventPanelState {
+  error?: 'not_found' | 'fetch_failed';
+  evento?: unknown;
+  loading?: boolean;
+  section?: string;
+}
+
+export interface ChatEventPanelAction {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  show_event_section: (id: string, data: ShowEventSectionData) => Promise<void>;
+}
+
+/** development del usuario (misma fuente que useAuthCheck: dev-user-config en localStorage). */
+function resolveDevelopment(): string {
+  if (typeof window === 'undefined') return 'bodasdehoy';
+  try {
+    const raw = localStorage.getItem('dev-user-config');
+    const cfg = raw ? JSON.parse(raw) : null;
+    return cfg?.development || 'bodasdehoy';
+  } catch {
+    return 'bodasdehoy';
+  }
+}
+
+export const eventPanelSlice: StateCreator<
+  ChatStore,
+  [['zustand/devtools', never]],
+  [],
+  ChatEventPanelAction
+> = (set, get) => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  show_event_section: async (id, data) => {
+    const { section, eventoId } = data ?? ({} as ShowEventSectionData);
+    const { updatePluginState, openToolUI } = get();
+
+    // Abrir el panel de inmediato en estado "cargando" (UX: no esperar al fetch).
+    openToolUI(id, 'lobe-event-panel');
+    await updatePluginState(id, { loading: true, section } as EventPanelState);
+
+    if (!eventoId) {
+      await updatePluginState(id, { error: 'not_found', section } as EventPanelState);
+      return;
+    }
+
+    try {
+      const evento = await getEventoDetalle(resolveDevelopment(), eventoId);
+      // BUG#5 (api-mcp DB caída): distinguir "no encontrado" de "error de servidor"
+      // no es posible aquí sin más señal → si no hay evento, marcarlo como not_found
+      // (el consumer muestra estado honesto + reintento, no miente con datos vacíos).
+      await updatePluginState(id, {
+        error: evento ? undefined : 'not_found',
+        evento: evento ?? undefined,
+        loading: false,
+        section,
+      } as EventPanelState);
+    } catch {
+      await updatePluginState(id, { error: 'fetch_failed', loading: false, section } as EventPanelState);
+    }
+  },
+});

--- a/apps/chat-ia/src/store/chat/slices/builtinTool/actions/index.ts
+++ b/apps/chat-ia/src/store/chat/slices/builtinTool/actions/index.ts
@@ -3,6 +3,7 @@ import { StateCreator } from 'zustand/vanilla';
 import { ChatStore } from '@/store/chat/store';
 
 import { ChatDallEAction, dalleSlice } from './dalle';
+import { ChatEventPanelAction, eventPanelSlice } from './eventPanel';
 import { ChatFilterAppViewAction, filterAppViewSlice } from './filterAppView';
 import { ChatFloorPlanEditorAction, floorPlanEditorSlice } from './floorPlanEditor';
 import { ChatCodeInterpreterAction, codeInterpreterSlice } from './interpreter';
@@ -18,6 +19,7 @@ export interface ChatBuiltinToolAction
     ChatCodeInterpreterAction,
     ChatVenueVisualizerAction,
     ChatFilterAppViewAction,
+    ChatEventPanelAction,
     ChatFloorPlanEditorAction {}
 
 export const chatToolSlice: StateCreator<
@@ -31,5 +33,6 @@ export const chatToolSlice: StateCreator<
   ...codeInterpreterSlice(...params),
   ...venueVisualizerSlice(...params),
   ...filterAppViewSlice(...params),
+  ...eventPanelSlice(...params),
   ...floorPlanEditorSlice(...params),
 });

--- a/apps/chat-ia/src/store/tool/slices/builtin/action.ts
+++ b/apps/chat-ia/src/store/tool/slices/builtin/action.ts
@@ -30,12 +30,19 @@ interface FilterViewParams {
   query?: string;
 }
 
+interface ShowEventSectionParams {
+  eventoId: string;
+  section: string;
+}
+
 /**
  * 代理行为接口
  */
 export interface BuiltinToolAction {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   filter_view: (params: FilterViewParams) => FilterViewParams;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  show_event_section: (params: ShowEventSectionParams) => ShowEventSectionParams;
   text2image: (params: Text2ImageParams) => DallEImageItem[];
   toggleBuiltinToolLoading: (key: string, value: boolean) => void;
   transformApiArgumentsToAiState: (key: string, params: any) => Promise<string | undefined>;
@@ -51,6 +58,9 @@ export const createBuiltinToolSlice: StateCreator<
 > = (set, get) => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
 filter_view: ({ entity, ids, query }) => ({ entity, ids, query }),
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  show_event_section: ({ section, eventoId }) => ({ eventoId, section }),
 
   
   

--- a/apps/chat-ia/src/tools/event-panel/Portal/index.tsx
+++ b/apps/chat-ia/src/tools/event-panel/Portal/index.tsx
@@ -1,0 +1,125 @@
+import { BuiltinPortalProps } from '@lobechat/types';
+import { type CSSProperties, memo } from 'react';
+
+import type { EventPanelState } from '@/store/chat/slices/builtinTool/actions/eventPanel';
+
+/** Los *_array / presupuesto_objeto son JSON opacos: pueden venir como objeto ya
+ *  parseado o como string. Normalizar defensivamente sin romper. */
+function asObj<T = any>(v: unknown): T | undefined {
+  if (v === null || v === undefined) return undefined;
+  if (typeof v === 'string') {
+    try {
+      return JSON.parse(v) as T;
+    } catch {
+      return undefined;
+    }
+  }
+  return v as T;
+}
+
+const eur = (n: unknown): string => {
+  const x = typeof n === 'number' ? n : Number(n);
+  if (!Number.isFinite(x)) return '—';
+  return x.toLocaleString('es-ES', { currency: 'EUR', style: 'currency' });
+};
+
+const wrap: CSSProperties = { fontSize: 13, padding: 16 };
+const h: CSSProperties = { fontSize: 15, fontWeight: 600, marginBottom: 12 };
+const row: CSSProperties = {
+  borderBottom: '1px solid rgba(0,0,0,0.06)',
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '6px 0',
+};
+
+const Presupuesto = ({ evento }: { evento: any }) => {
+  const p = asObj<any>(evento?.presupuesto_objeto) ?? {};
+  const total = p.presupuesto_total ?? p.presupuesto_estimado ?? 0;
+  const gastado = p.coste_final ?? 0;
+  const restante = Number(total) - Number(gastado);
+  const cats: any[] = Array.isArray(p.categorias_array) ? p.categorias_array : [];
+  return (
+    <div style={wrap}>
+      <div style={h}>💰 Presupuesto — {evento?.nombre ?? 'Evento'}</div>
+      <div style={row}><span>Presupuesto total</span><b>{eur(total)}</b></div>
+      <div style={row}><span>Gastado</span><b>{eur(gastado)}</b></div>
+      <div style={{ ...row, color: restante < 0 ? '#dc2626' : '#16a34a' }}>
+        <span>Restante</span><b>{eur(restante)}</b>
+      </div>
+      {cats.length > 0 && (
+        <div style={{ marginTop: 16 }}>
+          <div style={{ fontWeight: 600, marginBottom: 8 }}>Categorías</div>
+          {cats.map((c, i) => (
+            <div key={c?._id ?? i} style={row}>
+              <span>{c?.nombre ?? `Categoría ${i + 1}`}</span>
+              <b>{eur(c?.coste_final ?? c?.coste_estimado ?? 0)}</b>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ color: '#9ca3af', fontSize: 11, marginTop: 16 }}>Solo lectura</div>
+    </div>
+  );
+};
+
+const Itinerario = ({ evento }: { evento: any }) => {
+  const arr = asObj<any[]>(evento?.itinerarios_array);
+  const items: any[] = Array.isArray(arr) ? arr : [];
+  return (
+    <div style={wrap}>
+      <div style={h}>📅 Itinerario — {evento?.nombre ?? 'Evento'}</div>
+      {items.length === 0 ? (
+        <div style={{ color: '#9ca3af' }}>Sin itinerarios registrados.</div>
+      ) : (
+        items.map((it, i) => {
+          const tasks = Array.isArray(it?.tasks)
+            ? it.tasks
+            : Array.isArray(it?.tips)
+              ? it.tips
+              : [];
+          return (
+            <div key={it?._id ?? i} style={row}>
+              <span>{it?.title ?? it?.nombre ?? `Itinerario ${i + 1}`}</span>
+              <b>{tasks.length} tareas</b>
+            </div>
+          );
+        })
+      )}
+      <div style={{ color: '#9ca3af', fontSize: 11, marginTop: 16 }}>Solo lectura</div>
+    </div>
+  );
+};
+
+const EventPanelPortal = memo<BuiltinPortalProps<{ eventoId?: string; section?: string }, EventPanelState>>(
+  ({ arguments: args, state }) => {
+    const section = state?.section ?? args?.section;
+    const { error, evento, loading } = state ?? {};
+
+    if (error === 'fetch_failed') {
+      return (
+        <div style={wrap}>
+          <div style={{ color: '#dc2626', fontWeight: 600 }}>Servidor no disponible</div>
+          <div style={{ color: '#6b7280', marginTop: 8 }}>
+            No pude cargar el evento ahora mismo. Vuelve a intentarlo en unos segundos.
+          </div>
+        </div>
+      );
+    }
+    if (error === 'not_found') {
+      return (
+        <div style={wrap}>
+          <div style={{ color: '#6b7280' }}>No encontré ese evento.</div>
+        </div>
+      );
+    }
+    if (loading || !evento) {
+      return <div style={wrap}><div style={{ color: '#9ca3af' }}>Cargando…</div></div>;
+    }
+
+    return section === 'itinerario' ? <Itinerario evento={evento} /> : <Presupuesto evento={evento} />;
+  },
+);
+
+EventPanelPortal.displayName = 'EventPanelPortal';
+
+export default EventPanelPortal;

--- a/apps/chat-ia/src/tools/event-panel/Render/index.tsx
+++ b/apps/chat-ia/src/tools/event-panel/Render/index.tsx
@@ -1,0 +1,40 @@
+import { BuiltinRenderProps } from '@lobechat/types';
+import { memo } from 'react';
+
+interface ShowEventSectionContent {
+  eventoId?: string;
+  section?: string;
+}
+
+const LABEL: Record<string, string> = {
+  itinerario: 'itinerario',
+  presupuesto: 'presupuesto',
+};
+
+/** Resumen inline en el cuerpo del chat; el detalle vive en el Portal (panel lateral). */
+const EventPanelRender = memo<BuiltinRenderProps<ShowEventSectionContent>>(({ content }) => {
+  const section = content?.section;
+  if (!section) return null;
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        background: 'rgba(0,0,0,0.03)',
+        borderRadius: 8,
+        display: 'flex',
+        fontSize: 13,
+        gap: 8,
+        padding: '8px 12px',
+      }}
+    >
+      <span style={{ fontSize: 16 }}>📊</span>
+      <span>
+        Mostrando <b>{LABEL[section] ?? section}</b> del evento en el panel lateral →
+      </span>
+    </div>
+  );
+});
+
+EventPanelRender.displayName = 'EventPanelRender';
+
+export default EventPanelRender;

--- a/apps/chat-ia/src/tools/event-panel/index.ts
+++ b/apps/chat-ia/src/tools/event-panel/index.ts
@@ -1,0 +1,45 @@
+import { BuiltinToolManifest } from '@lobechat/types';
+
+/**
+ * lobe-event-panel — F1/F3 del panel contextual del chat.
+ * La IA invoca `show_event_section` cuando el usuario habla del presupuesto o
+ * itinerario del evento → se abre el PORTAL (panel lateral del propio chat) con
+ * los datos reales (getEventoDetalle). Funciona en standalone por diseño (portal
+ * chat-side, no depende de postMessage al parent).
+ */
+export const EventPanelManifest: BuiltinToolManifest = {
+  api: [
+    {
+      description:
+        'Abre el panel lateral del chat mostrando una sección del evento actual (presupuesto o itinerario) con sus datos reales. Úsalo cuando el usuario hable de su presupuesto/gastos/pagos o de su itinerario/agenda y quiera verlo.',
+      name: 'show_event_section',
+      parameters: {
+        properties: {
+          eventoId: {
+            description:
+              'ID del evento (Mongo _id). Tómalo del contexto de página (screenData) del evento actual.',
+            type: 'string',
+          },
+          section: {
+            description: 'Sección del evento a mostrar en el panel.',
+            enum: ['presupuesto', 'itinerario'],
+            type: 'string',
+          },
+        },
+        required: ['section', 'eventoId'],
+        type: 'object',
+      },
+    },
+  ],
+  identifier: 'lobe-event-panel',
+  meta: {
+    avatar: '📊',
+    title: 'Panel del evento',
+  },
+  systemRole: `Cuando el usuario hable del PRESUPUESTO (gastos, coste, pagos, cuánto llevo) o del ITINERARIO (agenda, tareas, timing) de su evento y quiera verlo, invoca show_event_section con { section, eventoId }.
+- El eventoId está en el contexto de página (screenData) del evento actual.
+- Tras invocarlo, el panel lateral del chat muestra la sección con los datos REALES (solo lectura por ahora).
+- En tu respuesta menciónalo brevemente: "Te muestro el presupuesto en el panel derecho."
+NO uses esta herramienta si el usuario no se refiere a un evento concreto o no hay eventoId disponible.`,
+  type: 'builtin',
+};

--- a/apps/chat-ia/src/tools/index.ts
+++ b/apps/chat-ia/src/tools/index.ts
@@ -3,6 +3,7 @@ import { LobeBuiltinTool } from '@lobechat/types';
 import { ArtifactsManifest } from './artifacts';
 import { CodeInterpreterManifest } from './code-interpreter';
 import { DalleManifest } from './dalle';
+import { EventPanelManifest } from './event-panel';
 import { FilterAppViewManifest } from './filter-app-view';
 import { FloorPlanEditorManifest } from './floor-plan-editor';
 import { VenueVisualizerManifest } from './venue-visualizer';
@@ -22,6 +23,12 @@ export const builtinTools: LobeBuiltinTool[] = [
   {
     identifier: DalleManifest.identifier,
     manifest: DalleManifest,
+    type: 'builtin',
+  },
+  {
+    hidden: true,
+    identifier: EventPanelManifest.identifier,
+    manifest: EventPanelManifest,
     type: 'builtin',
   },
   {

--- a/apps/chat-ia/src/tools/portals.ts
+++ b/apps/chat-ia/src/tools/portals.ts
@@ -1,8 +1,11 @@
 import { BuiltinPortal } from '@lobechat/types';
 
+import { EventPanelManifest } from './event-panel';
+import EventPanelPortal from './event-panel/Portal';
 import { WebBrowsingManifest } from './web-browsing';
 import WebBrowsing from './web-browsing/Portal';
 
 export const BuiltinToolsPortals: Record<string, BuiltinPortal> = {
+  [EventPanelManifest.identifier]: EventPanelPortal as BuiltinPortal,
   [WebBrowsingManifest.identifier]: WebBrowsing as BuiltinPortal,
 };

--- a/apps/chat-ia/src/tools/renders.ts
+++ b/apps/chat-ia/src/tools/renders.ts
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic';
 
 import { CodeInterpreterManifest } from './code-interpreter';
 import { DalleManifest } from './dalle';
+import { EventPanelManifest } from './event-panel';
 import { FilterAppViewManifest } from './filter-app-view';
 import { FloorPlanEditorManifest } from './floor-plan-editor';
 import { VenueVisualizerManifest } from './venue-visualizer';
@@ -30,8 +31,12 @@ const FloorPlanEditorRender = dynamic(() => import('./floor-plan-editor/Render')
 const FilterAppViewRender = dynamic(() => import('./filter-app-view/Render'), {
   ssr: false,
 }) as BuiltinRender;
+const EventPanelRender = dynamic(() => import('./event-panel/Render'), {
+  ssr: false,
+}) as BuiltinRender;
 
 export const BuiltinToolsRenders: Record<string, BuiltinRender> = {
+  [EventPanelManifest.identifier]: EventPanelRender,
   [DalleManifest.identifier]: DalleRender,
   [WebBrowsingManifest.identifier]: WebBrowsing,
   [CodeInterpreterManifest.identifier]: CodeInterpreterRender,


### PR DESCRIPTION
## Qué es
F1+F3 del panel contextual. Nuevo builtin tool `show_event_section` con **portal** (panel
lateral del propio chat) que muestra el **presupuesto** o el **itinerario** del evento con datos
reales (`getEventoDetalle`, F0/#256). Standalone-native (portal chat-side; resuelve el no-op de F1).

## Piezas
- `tools/event-panel/` → manifest + Render (resumen inline) + Portal (vista lateral, solo-lectura).
- `builtinTool/actions/eventPanel.ts` → `show_event_section`: abre portal, fetch, `updatePluginState`.
  BUG#5 (DB caída) → estado de error honesto + reintento (no muestra datos vacíos falsos).
- 5 registros: `tools/index`, `renders`, `portals`, `builtinTool/actions/index`, `store/tool` transform.
- Dispatch confirmado: `invokeBuiltinTool` → `get()[apiName]` (`plugin/action.ts:152`).

## Verificación
- ESLint **0 errores** (warnings `any` = JSON opaco, igual que filter-app-view).
- ⚠️ **NO mergear aún:** necesita build chat-dev + smoke interactivo (la IA invoca el tool → el
  panel abre y renderiza). No verificable headless.

## Siguiente
F2 (extraer las vistas ricas a `@bodasdehoy/event-views`), F4 (billing + UX), servicios como 3ª sección.

🤖 Generated with [Claude Code](https://claude.com/claude-code)