### PR TITLE
🐛 fix(chat/persist): regla de oro — HTTP 200 con {success:false, errors[]} = FALLO

### DIFF
--- a/apps/chat-ia/src/services/message/apiIa.ts
+++ b/apps/chat-ia/src/services/message/apiIa.ts
@@ -55,7 +55,19 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
   if (!res.ok) throw new Error(`[message/apiIa] ${method} ${path} → HTTP ${res.status}`);
   // 204/empty → null
   const text = await res.text();
-  return text ? JSON.parse(text) : null;
+  const json = text ? JSON.parse(text) : null;
+  // REGLA DE ORO (contrato api-ia): un HTTP 200 puede traer { success:false, errors:[...] }
+  // (data:null + errors). Sin este chequeo se tragaba como éxito → el par no se persistía
+  // y el fallo quedaba oculto. Tratarlo como FALLO explícito con el error real.
+  if (
+    json &&
+    typeof json === 'object' &&
+    (json.success === false || (Array.isArray(json.errors) && json.errors.length > 0))
+  ) {
+    const msg = json.errors?.[0]?.message || 'operación no exitosa';
+    throw new Error(`[message/apiIa] ${method} ${path} → ${msg}`);
+  }
+  return json;
 }
 
 /**

--- a/apps/chat-ia/src/services/topic/apiIa.ts
+++ b/apps/chat-ia/src/services/topic/apiIa.ts
@@ -29,7 +29,17 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
   });
   if (!res.ok) throw new Error(`[topic/apiIa] ${method} ${path} → HTTP ${res.status}`);
   const text = await res.text();
-  return text ? JSON.parse(text) : null;
+  const json = text ? JSON.parse(text) : null;
+  // REGLA DE ORO (contrato api-ia): un HTTP 200 con { success:false, errors:[...] } es FALLO.
+  if (
+    json &&
+    typeof json === 'object' &&
+    (json.success === false || (Array.isArray(json.errors) && json.errors.length > 0))
+  ) {
+    const msg = json.errors?.[0]?.message || 'operación no exitosa';
+    throw new Error(`[topic/apiIa] ${method} ${path} → ${msg}`);
+  }
+  return json;
 }
 
 const unwrap = (res: any) => res?.data ?? res?.topics ?? res ?? [];


### PR DESCRIPTION
## Contexto
La "regla de oro" del contrato de api-ia: un HTTP **200** puede traer `data:null + errors[]`.
Los helpers `call` de `message/apiIa.ts` y `topic/apiIa.ts` solo miraban `!res.ok` → un 200 con
`success:false` se tragaba como éxito (el par no persistía, error oculto; solo se caía luego con
un genérico "sin id").

## Fix
Tras `res.ok`: si `json.success===false` o `errors[]` no vacío → `throw` con el mensaje real.
Centralizado en ambos helpers. Sin cambio en el happy-path.

## Emparejado con #230
#230 degrada a mensajes locales sin bloquear la respuesta. Con esto, el fallo de persistencia
se **surfacea** (no se esconde) y el asistente responde igual. Los dos cierran el #4.

ESLint: 0 errores nuevos (el `_note` de topic:87 y los `any` son pre-existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)