### PR TITLE
🔧 fix(chat-ia/#4): host api-ia → eventosorganizador.com

### DIFF
--- a/apps/chat-ia/.env.development.local.example
+++ b/apps/chat-ia/.env.development.local.example
@@ -11,8 +11,8 @@
 APP_URL=http://chat-test.bodasdehoy.com:3210
 NEXT_PUBLIC_API_MCP_GRAPHQL_URL=https://api-mcp.eventosorganizador.com/graphql
 API_MCP_GRAPHQL_URL=https://api-mcp.eventosorganizador.com/graphql
-NEXT_PUBLIC_API_IA_URL=https://api-ia.bodasdehoy.com
-API_IA_URL=https://api-ia.bodasdehoy.com
+NEXT_PUBLIC_API_IA_URL=https://api-ia.eventosorganizador.com
+API_IA_URL=https://api-ia.eventosorganizador.com
 
 # ========================================
 # OBSERVABILIDAD (opcional — Sentry)

--- a/apps/chat-ia/.env.example
+++ b/apps/chat-ia/.env.example
@@ -294,8 +294,8 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 # API IA — única variante pública aceptada.
 # Aliases legacy (NEXT_PUBLIC_BACKEND_URL, PYTHON_BACKEND_URL, etc.) RETIRADOS 2026-05-14.
 # Ver docs/ENV-ENDPOINTS-STANDARD.md
-NEXT_PUBLIC_API_IA_URL=https://api-ia.bodasdehoy.com
-API_IA_URL=https://api-ia.bodasdehoy.com
+NEXT_PUBLIC_API_IA_URL=https://api-ia.eventosorganizador.com
+API_IA_URL=https://api-ia.eventosorganizador.com
 
 # RAG / KB semántico: solo API IA (POST /api/lobechat-kb/search). Sin vectores en Postgres.
 # USE_MIDDLEWARE_FOR_LOBECHAT_KB=true

--- a/apps/chat-ia/.env.production.example
+++ b/apps/chat-ia/.env.production.example
@@ -17,8 +17,8 @@ NEXT_PUBLIC_BASE_PATH=
 # ========================================
 
 # API IA (chat IA, memories, leads sub-router, tools)
-API_IA_URL=https://api-ia.bodasdehoy.com
-NEXT_PUBLIC_API_IA_URL=https://api-ia.bodasdehoy.com
+API_IA_URL=https://api-ia.eventosorganizador.com
+NEXT_PUBLIC_API_IA_URL=https://api-ia.eventosorganizador.com
 
 # API MCP GraphQL (datos: eventos, invitados, mesas, presupuesto, notificaciones)
 API_MCP_GRAPHQL_URL=https://api-mcp.eventosorganizador.com/graphql

--- a/apps/chat-ia/.env.vercel
+++ b/apps/chat-ia/.env.vercel
@@ -24,8 +24,8 @@ KEY_VAULTS_SECRET=BdkgVXBys7cLMn0lIXms5NBc86CxC+ywLkhjiO4gVVA=
 # ========================================
 # API IA (chat IA, memories, leads, tools)
 # ========================================
-NEXT_PUBLIC_API_IA_URL=https://api-ia.bodasdehoy.com
-API_IA_URL=https://api-ia.bodasdehoy.com
+NEXT_PUBLIC_API_IA_URL=https://api-ia.eventosorganizador.com
+API_IA_URL=https://api-ia.eventosorganizador.com
 USE_PYTHON_BACKEND=true
 
 # ========================================

--- a/apps/chat-ia/src/const/backendEndpoints.ts
+++ b/apps/chat-ia/src/const/backendEndpoints.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_API_IA_ORIGIN = 'https://api-ia.bodasdehoy.com';
+// 2026-08-03 (informe integración api-ia #4): host canónico = zona eventosorganizador.com.
+// La zona bodasdehoy sufre 526 intermitente (Cloudflare↔origin); el origin es el MISMO backend.
+export const DEFAULT_API_IA_ORIGIN = 'https://api-ia.eventosorganizador.com';
 
 const LEGACY_ALIASES = [
   'NEXT_PUBLIC_API3_IA_URL',


### PR DESCRIPTION
Informe integración api-ia #4: host canónico eventosorganizador.com (zona bodasdehoy tiene 526 intermitente). Central DEFAULT_API_IA_ORIGIN + .env. Efecto en rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)