### PR TITLE
✨ feat(chat-ia/#7): panel contextual (presupuesto/itinerario/servicios)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/default.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/default.tsx
@@ -1,6 +1,7 @@
 import { DynamicLayoutProps } from '@/types/next';
 import { RouteVariants } from '@/utils/server/routeVariants';
 import { EventosAutoAuth } from '@/features/EventosAutoAuth';
+import { EventPanel } from '@/features/EventPanel';
 
 import ConditionalChatView from './features/ConditionalChatView';
 import ConditionalHydration from './features/ConditionalHydration';
@@ -15,6 +16,7 @@ const ChatConversation = async (props: DynamicLayoutProps) => {
       <ZenModeToast />
       <ConditionalChatView mobile={isMobile} />
       <ConditionalHydration />
+      <EventPanel />
     </>
   );
 };

--- a/apps/chat-ia/src/features/EventPanel/EventPanel.tsx
+++ b/apps/chat-ia/src/features/EventPanel/EventPanel.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { getCurrentEventId } from './getCurrentEventId';
+import { ItinerarioSection } from './sections/ItinerarioSection';
+import { PresupuestoSection } from './sections/PresupuestoSection';
+import { ServiciosSection } from './sections/ServiciosSection';
+import { EmptyHint } from './sections/shared';
+import { EVENT_SECTIONS, EventSection, useEventPanelStore } from './store';
+import { useEventoDetalle } from './useEventoDetalle';
+
+const LABEL: Record<EventSection, string> = {
+  itinerario: 'Itinerario',
+  presupuesto: 'Presupuesto',
+  servicios: 'Servicios',
+};
+
+const THEME_VARS = `
+.ep-root{--ep-card:#fff;--ep-border:#ececef;--ep-bar-bg:#e5e7eb;--ep-muted:#6b7280;--ep-bg:#fafafa;--ep-fg:#111827;--ep-head:#fff}
+@media (prefers-color-scheme:dark){.ep-root{--ep-card:#1f1f23;--ep-border:#2e2e33;--ep-bar-bg:#333;--ep-muted:#9ca3af;--ep-bg:#161618;--ep-fg:#e5e7eb;--ep-head:#1a1a1d}}
+`;
+
+/**
+ * Panel contextual del chat (#7). Drawer derecho que muestra presupuesto/itinerario/
+ * servicios del evento actual, leyendo getEventoById DIRECTO de api-mcp (sin LLM).
+ * La IA lo abre vía filter_view (ver filterAppView.ts); el usuario cambia de sección
+ * con las pestañas. Montado una vez en el workspace del asistente.
+ */
+export const EventPanel = () => {
+  const isOpen = useEventPanelStore((s) => s.isOpen);
+  const section = useEventPanelStore((s) => s.section);
+  const storeEventId = useEventPanelStore((s) => s.eventId);
+  const close = useEventPanelStore((s) => s.close);
+  const setSection = useEventPanelStore((s) => s.setSection);
+
+  // Si el store no trae eventId (la IA no lo pasó), usar el evento actual del usuario.
+  const eventId = storeEventId || getCurrentEventId();
+  const { data, loading, error, reload } = useEventoDetalle(isOpen ? eventId : null);
+
+  // cerrar con ESC
+  useEffect(() => {
+    if (!isOpen) return;
+    const h = (e: KeyboardEvent) => e.key === 'Escape' && close();
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [isOpen, close]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <style>{THEME_VARS}</style>
+      <div
+        className="ep-root"
+        style={{
+          background: 'var(--ep-bg)',
+          borderLeft: '1px solid var(--ep-border)',
+          bottom: 0,
+          boxShadow: '-8px 0 24px rgba(0,0,0,.08)',
+          color: 'var(--ep-fg)',
+          display: 'flex',
+          flexDirection: 'column',
+          maxWidth: '92vw',
+          position: 'fixed',
+          right: 0,
+          top: 0,
+          width: 400,
+          zIndex: 1000,
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            alignItems: 'center',
+            background: 'var(--ep-head)',
+            borderBottom: '1px solid var(--ep-border)',
+            display: 'flex',
+            gap: 8,
+            justifyContent: 'space-between',
+            padding: '12px 14px',
+          }}
+        >
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 14, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {data?.nombre || 'Evento'}
+            </div>
+            {data?.fecha && (
+              <div style={{ color: 'var(--ep-muted)', fontSize: 11 }}>{String(data.fecha).slice(0, 16)}</div>
+            )}
+          </div>
+          <button
+            aria-label="Cerrar"
+            onClick={close}
+            style={{ background: 'none', border: 'none', color: 'var(--ep-muted)', cursor: 'pointer', fontSize: 20, lineHeight: 1, padding: 4 }}
+            type="button"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div style={{ borderBottom: '1px solid var(--ep-border)', display: 'flex', gap: 4, padding: '8px 10px' }}>
+          {EVENT_SECTIONS.map((s) => {
+            const active = s === section;
+            return (
+              <button
+                key={s}
+                onClick={() => setSection(s)}
+                style={{
+                  background: active ? 'var(--ep-fg)' : 'transparent',
+                  border: '1px solid var(--ep-border)',
+                  borderRadius: 999,
+                  color: active ? 'var(--ep-bg)' : 'var(--ep-muted)',
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  padding: '5px 12px',
+                }}
+                type="button"
+              >
+                {LABEL[s]}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Body */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: 12 }}>
+          {loading && <EmptyHint>Cargando…</EmptyHint>}
+          {!loading && error && (
+            <div style={{ padding: '24px 4px', textAlign: 'center' }}>
+              <div style={{ color: '#ef4444', fontSize: 13, marginBottom: 12 }}>{error}</div>
+              <button
+                onClick={reload}
+                style={{ background: 'var(--ep-fg)', border: 'none', borderRadius: 8, color: 'var(--ep-bg)', cursor: 'pointer', fontSize: 13, padding: '6px 14px' }}
+                type="button"
+              >
+                Reintentar
+              </button>
+            </div>
+          )}
+          {!loading && !error && !eventId && <EmptyHint>Selecciona un evento para ver sus datos.</EmptyHint>}
+          {!loading && !error && data && (
+            <>
+              {section === 'presupuesto' && <PresupuestoSection evento={data} />}
+              {section === 'itinerario' && <ItinerarioSection evento={data} />}
+              {section === 'servicios' && <ServiciosSection evento={data} />}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default EventPanel;

--- a/apps/chat-ia/src/features/EventPanel/EventPanel.tsx
+++ b/apps/chat-ia/src/features/EventPanel/EventPanel.tsx
@@ -46,7 +46,40 @@ export const EventPanel = () => {
     return () => window.removeEventListener('keydown', h);
   }, [isOpen, close]);
 
-  if (!isOpen) return null;
+  const openPanel = useEventPanelStore((s) => s.open);
+
+  // Disparador manual: mientras la IA no pueda abrirlo (dep. #1), un botón flotante
+  // permite abrir el panel del evento actual. También sirve como entrada directa.
+  if (!isOpen) {
+    return (
+      <button
+        aria-label="Ver datos del evento"
+        onClick={() => openPanel('presupuesto')}
+        style={{
+          alignItems: 'center',
+          background: '#6366f1',
+          border: 'none',
+          borderRadius: 999,
+          bottom: 88,
+          boxShadow: '0 4px 14px rgba(99,102,241,.4)',
+          color: '#fff',
+          cursor: 'pointer',
+          display: 'flex',
+          fontSize: 13,
+          fontWeight: 600,
+          gap: 6,
+          padding: '10px 16px',
+          position: 'fixed',
+          right: 20,
+          zIndex: 999,
+        }}
+        title="Ver presupuesto / itinerario / servicios del evento"
+        type="button"
+      >
+        📋 Evento
+      </button>
+    );
+  }
 
   return (
     <>

--- a/apps/chat-ia/src/features/EventPanel/getCurrentEventId.ts
+++ b/apps/chat-ia/src/features/EventPanel/getCurrentEventId.ts
@@ -1,0 +1,18 @@
+/**
+ * Resuelve el evento actual del usuario registrado desde `dev-user-config` (localStorage).
+ * Mismo origen que usa el upload de archivos (store/file/slices/upload/action.ts).
+ * Prioridad: current_event_id → primer evento de la lista.
+ */
+export function getCurrentEventId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem('dev-user-config');
+    if (!raw) return null;
+    const config = JSON.parse(raw);
+    if (config.current_event_id) return String(config.current_event_id);
+    const first = Array.isArray(config.eventos) ? config.eventos[0] : undefined;
+    return first ? String(first._id || first.id) : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/chat-ia/src/features/EventPanel/index.ts
+++ b/apps/chat-ia/src/features/EventPanel/index.ts
@@ -1,0 +1,3 @@
+export { default as EventPanel } from './EventPanel';
+export type { EventSection } from './store';
+export { ENTITY_TO_SECTION, EVENT_SECTIONS, useEventPanelStore } from './store';

--- a/apps/chat-ia/src/features/EventPanel/sections/ItinerarioSection.tsx
+++ b/apps/chat-ia/src/features/EventPanel/sections/ItinerarioSection.tsx
@@ -1,0 +1,54 @@
+import { EventoDetalle } from '@/services/mcpApi/eventos';
+
+import { Bar, Card, EmptyHint, StatusPill } from './shared';
+
+/**
+ * Itinerario: itinerarios_array con tipo 'itinerario' (verificado 3-ago).
+ * Cada itinerario: title + completion_percentage + tasks[{descripcion,fecha,responsable,estatus}].
+ */
+export const ItinerarioSection = ({ evento }: { evento: EventoDetalle }) => {
+  const all: any[] = Array.isArray(evento.itinerarios_array) ? evento.itinerarios_array : [];
+  const items = all.filter((i) => (i?.tipo || 'itinerario') === 'itinerario');
+
+  if (items.length === 0) return <EmptyHint>Este evento no tiene itinerario todavía.</EmptyHint>;
+
+  return (
+    <div>
+      {items.map((it, i) => {
+        const tasks: any[] = Array.isArray(it.tasks) ? it.tasks : [];
+        const pct = typeof it.completion_percentage === 'number' ? it.completion_percentage : 0;
+        return (
+          <Card key={it._id || i}>
+            <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between', marginBottom: 8 }}>
+              <strong style={{ fontSize: 14 }}>{it.title || 'Itinerario'}</strong>
+              <span style={{ color: 'var(--ep-muted,#9ca3af)', fontSize: 11 }}>{Math.round(pct)}%</span>
+            </div>
+            <Bar pct={pct} />
+            <div style={{ marginTop: 10 }}>
+              {tasks.length === 0 && (
+                <div style={{ color: 'var(--ep-muted,#9ca3af)', fontSize: 12 }}>Sin tareas.</div>
+              )}
+              {tasks.slice(0, 40).map((t, j) => (
+                <div
+                  key={t._id || j}
+                  style={{ borderTop: j ? '1px solid var(--ep-border,#f0f0f2)' : 'none', display: 'flex', gap: 8, padding: '7px 0' }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {t.descripcion || 'Tarea'}
+                    </div>
+                    <div style={{ color: 'var(--ep-muted,#9ca3af)', display: 'flex', fontSize: 11, gap: 8, marginTop: 2 }}>
+                      {t.fecha && <span>📅 {String(t.fecha).slice(0, 16)}</span>}
+                      {t.responsable && <span>👤 {t.responsable}</span>}
+                    </div>
+                  </div>
+                  <StatusPill value={t.estatus || t.estado} />
+                </div>
+              ))}
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/chat-ia/src/features/EventPanel/sections/PresupuestoSection.tsx
+++ b/apps/chat-ia/src/features/EventPanel/sections/PresupuestoSection.tsx
@@ -1,0 +1,61 @@
+import { EventoDetalle } from '@/services/mcpApi/eventos';
+
+import { Bar, Card, EmptyHint, money } from './shared';
+
+/**
+ * Presupuesto: presupuesto_objeto (verificado 3-ago).
+ * Totales (presupuesto_total/coste_estimado/coste_final/pagado) + categorias_array
+ * (nombre, coste_final, pagado) con barra pagado/coste.
+ */
+export const PresupuestoSection = ({ evento }: { evento: EventoDetalle }) => {
+  const p: any = evento.presupuesto_objeto;
+  if (!p || typeof p !== 'object') return <EmptyHint>Este evento no tiene presupuesto todavía.</EmptyHint>;
+
+  const currency = p.currency || 'EUR';
+  const total = p.presupuesto_total ?? p.coste_final ?? 0;
+  const estimado = p.coste_estimado ?? 0;
+  const final = p.coste_final ?? 0;
+  const pagado = p.pagado ?? 0;
+  const cats: any[] = Array.isArray(p.categorias_array) ? p.categorias_array : [];
+  const pctPagado = final > 0 ? (pagado / final) * 100 : 0;
+
+  return (
+    <div>
+      <Card>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+          <span style={{ color: 'var(--ep-muted,#6b7280)', fontSize: 13 }}>Presupuesto total</span>
+          <strong style={{ fontSize: 18 }}>{money(total, currency)}</strong>
+        </div>
+        <Bar color="#22c55e" pct={pctPagado} />
+        <div style={{ color: 'var(--ep-muted,#6b7280)', display: 'flex', fontSize: 12, gap: 12, marginTop: 8 }}>
+          <span>Pagado <strong style={{ color: '#22c55e' }}>{money(pagado, currency)}</strong></span>
+          <span>Estimado <strong>{money(estimado, currency)}</strong></span>
+          <span>Coste final <strong>{money(final, currency)}</strong></span>
+        </div>
+      </Card>
+
+      <div style={{ color: 'var(--ep-muted,#6b7280)', fontSize: 12, fontWeight: 600, margin: '14px 4px 8px' }}>
+        CATEGORÍAS ({cats.length})
+      </div>
+      {cats.length === 0 && <EmptyHint>Sin categorías de gasto.</EmptyHint>}
+      {cats.map((c, i) => {
+        const cFinal = c.coste_final ?? 0;
+        const cPag = c.pagado ?? 0;
+        const gastos = Array.isArray(c.gastos_array) ? c.gastos_array.length : 0;
+        return (
+          <Card key={c._id || i}>
+            <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+              <strong style={{ fontSize: 14, textTransform: 'capitalize' }}>{c.nombre || 'Categoría'}</strong>
+              <span style={{ fontSize: 13 }}>{money(cFinal, currency)}</span>
+            </div>
+            <Bar pct={cFinal > 0 ? (cPag / cFinal) * 100 : 0} />
+            <div style={{ color: 'var(--ep-muted,#9ca3af)', display: 'flex', fontSize: 11, gap: 10, marginTop: 6 }}>
+              <span>Pagado {money(cPag, currency)}</span>
+              <span>{gastos} gasto{gastos === 1 ? '' : 's'}</span>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/chat-ia/src/features/EventPanel/sections/ServiciosSection.tsx
+++ b/apps/chat-ia/src/features/EventPanel/sections/ServiciosSection.tsx
@@ -1,0 +1,54 @@
+import { EventoDetalle } from '@/services/mcpApi/eventos';
+
+import { Card, EmptyHint, StatusPill } from './shared';
+
+/**
+ * Servicios: itinerarios_array con tipo 'servicios' (verificado 3-ago — el evento real
+ * tenía 7 de tipo 'servicios' vs 6 'itinerario'). Cada task = un servicio/proveedor:
+ * descripcion (servicio) + responsable (proveedor) + estatus + fecha.
+ */
+export const ServiciosSection = ({ evento }: { evento: EventoDetalle }) => {
+  const all: any[] = Array.isArray(evento.itinerarios_array) ? evento.itinerarios_array : [];
+  const grupos = all.filter((i) => i?.tipo === 'servicios');
+
+  const totalServicios = grupos.reduce(
+    (acc, g) => acc + (Array.isArray(g.tasks) ? g.tasks.length : 0),
+    0,
+  );
+
+  if (totalServicios === 0) return <EmptyHint>Este evento no tiene servicios todavía.</EmptyHint>;
+
+  return (
+    <div>
+      <div style={{ color: 'var(--ep-muted,#6b7280)', fontSize: 12, fontWeight: 600, margin: '2px 4px 8px' }}>
+        {totalServicios} SERVICIO{totalServicios === 1 ? '' : 'S'}
+      </div>
+      {grupos.map((g, gi) => {
+        const tasks: any[] = Array.isArray(g.tasks) ? g.tasks : [];
+        if (tasks.length === 0) return null;
+        return (
+          <div key={g._id || gi} style={{ marginBottom: 6 }}>
+            {g.title && g.title !== 'sin nombre' && (
+              <div style={{ color: 'var(--ep-muted,#9ca3af)', fontSize: 11, fontWeight: 600, margin: '8px 4px 4px' }}>
+                {g.title}
+              </div>
+            )}
+            {tasks.slice(0, 60).map((t, j) => (
+              <Card key={t._id || j}>
+                <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
+                  <strong style={{ fontSize: 13 }}>{t.descripcion || 'Servicio'}</strong>
+                  <StatusPill value={t.estatus || t.estado} />
+                </div>
+                <div style={{ color: 'var(--ep-muted,#9ca3af)', display: 'flex', flexWrap: 'wrap', fontSize: 11, gap: 10, marginTop: 4 }}>
+                  {t.responsable && <span>👤 {t.responsable}</span>}
+                  {t.fecha && <span>📅 {String(t.fecha).slice(0, 16)}</span>}
+                  {t.duracion && <span>⏱ {t.duracion}</span>}
+                </div>
+              </Card>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/chat-ia/src/features/EventPanel/sections/shared.tsx
+++ b/apps/chat-ia/src/features/EventPanel/sections/shared.tsx
@@ -1,0 +1,66 @@
+import { ReactNode } from 'react';
+
+export const money = (n: number | undefined | null, currency = 'EUR'): string => {
+  const v = typeof n === 'number' && isFinite(n) ? n : 0;
+  try {
+    return new Intl.NumberFormat('es-ES', { currency, style: 'currency' }).format(v);
+  } catch {
+    return `${v.toLocaleString('es-ES')} ${currency}`;
+  }
+};
+
+const ESTATUS_COLOR: Record<string, string> = {
+  cancelado: '#ef4444',
+  completado: '#22c55e',
+  confirmado: '#22c55e',
+  en_progreso: '#f59e0b',
+  pagado: '#22c55e',
+  pendiente: '#f59e0b',
+};
+
+export const StatusPill = ({ value }: { value?: string }) => {
+  if (!value) return null;
+  const c = ESTATUS_COLOR[String(value).toLowerCase()] || '#9ca3af';
+  return (
+    <span
+      style={{
+        background: `${c}22`,
+        borderRadius: 999,
+        color: c,
+        fontSize: 11,
+        fontWeight: 600,
+        padding: '2px 8px',
+        textTransform: 'capitalize',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {String(value).replaceAll('_', ' ')}
+    </span>
+  );
+};
+
+export const Bar = ({ pct, color = '#6366f1' }: { color?: string; pct: number }) => (
+  <div style={{ background: 'var(--ep-bar-bg, #e5e7eb)', borderRadius: 999, height: 8, overflow: 'hidden', width: '100%' }}>
+    <div style={{ background: color, height: '100%', transition: 'width .3s', width: `${Math.max(0, Math.min(100, pct))}%` }} />
+  </div>
+);
+
+export const EmptyHint = ({ children }: { children: ReactNode }) => (
+  <div style={{ color: 'var(--ep-muted, #9ca3af)', fontSize: 13, padding: '24px 4px', textAlign: 'center' }}>
+    {children}
+  </div>
+);
+
+export const Card = ({ children }: { children: ReactNode }) => (
+  <div
+    style={{
+      background: 'var(--ep-card, #fff)',
+      border: '1px solid var(--ep-border, #ececef)',
+      borderRadius: 12,
+      marginBottom: 10,
+      padding: 12,
+    }}
+  >
+    {children}
+  </div>
+);

--- a/apps/chat-ia/src/features/EventPanel/store.ts
+++ b/apps/chat-ia/src/features/EventPanel/store.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+/**
+ * Store del PANEL CONTEXTUAL del chat (#7 informe integración api-ia).
+ * La IA (via filter_view) o el usuario abren el panel derecho en una sección del
+ * evento; el panel lee getEventoById DIRECTO de api-mcp (sin LLM, sin doble billing).
+ *
+ * Consumir con selectores de PRIMITIVAS (s => s.isOpen) para no romper con Zustand
+ * (React #185: selectores que devuelven objetos frescos). Ver [[reference_zustand5_useshallow_bandeja_185]].
+ */
+export type EventSection = 'presupuesto' | 'itinerario' | 'servicios';
+
+export const EVENT_SECTIONS: EventSection[] = ['presupuesto', 'itinerario', 'servicios'];
+
+// Entidades que la IA manda por filter_view → sección del panel.
+export const ENTITY_TO_SECTION: Record<string, EventSection> = {
+  budget: 'presupuesto',
+  itinerario: 'itinerario',
+  itinerary: 'itinerario',
+  presupuesto: 'presupuesto',
+  services: 'servicios',
+  servicio: 'servicios',
+  servicios: 'servicios',
+  timeline: 'itinerario',
+};
+
+interface EventPanelState {
+  close: () => void;
+  eventId: string | null;
+  isOpen: boolean;
+  open: (section: EventSection, eventId?: string | null) => void;
+  section: EventSection;
+  setSection: (section: EventSection) => void;
+}
+
+export const useEventPanelStore = create<EventPanelState>((set) => ({
+  close: () => set({ isOpen: false }),
+  eventId: null,
+  isOpen: false,
+  open: (section, eventId) =>
+    set((s) => ({ eventId: eventId ?? s.eventId, isOpen: true, section })),
+  section: 'presupuesto',
+  setSection: (section) => set({ section }),
+}));

--- a/apps/chat-ia/src/features/EventPanel/useEventoDetalle.ts
+++ b/apps/chat-ia/src/features/EventPanel/useEventoDetalle.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { EventoDetalle, getEventoById } from '@/services/mcpApi/eventos';
+
+/**
+ * Carga el evento rico (getEventoById) para el panel contextual.
+ * Estado de ERROR VISIBLE obligatorio: si api-mcp cae (BUG#5 `_eventsConnection` →
+ * DATABASE_CONNECTION_ERROR), NUNCA mostrar "no tienes presupuesto" en silencio →
+ * mostramos error + botón reintentar. Ver [[project_apimcp_db_connection_down_eventos_bug5_bug6]].
+ */
+export interface EventoDetalleState {
+  data: EventoDetalle | null;
+  error: string | null;
+  loading: boolean;
+  reload: () => void;
+}
+
+export function useEventoDetalle(eventId: string | null): EventoDetalleState {
+  const [data, setData] = useState<EventoDetalle | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  const reload = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    if (!eventId) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getEventoById(eventId)
+      .then((ev) => {
+        if (cancelled) return;
+        setData(ev);
+        if (!ev) setError('No se encontró el evento o no tienes acceso.');
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setData(null);
+        setError(
+          e?.message?.includes('CONNECTION')
+            ? 'No se pudo conectar con el servidor de eventos. Reintenta en unos segundos.'
+            : e?.message || 'Error cargando el evento.',
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId, nonce]);
+
+  return { data, error, loading, reload };
+}

--- a/apps/chat-ia/src/services/mcpApi/eventos.ts
+++ b/apps/chat-ia/src/services/mcpApi/eventos.ts
@@ -38,6 +38,22 @@ export interface GetEventosByUsuarioResponse {
   getEventosByUsuario: EventosResponse;
 }
 
+// Evento RICO para el panel contextual del chat (#7). Los *_array / *_objeto son
+// escalares JSON en api-mcp (sin subselección) → se tipan laxos y se parsean en el render.
+// Gate por dueño a nivel campo (backend, verificado): cross-tenant recibe solo el stub
+// público {_id,nombre,fecha,tipo} con los ricos en null.
+export interface EventoDetalle extends Evento {
+  invitados_array?: any[] | null;
+  itinerarios_array?: any[] | null;
+  menus_array?: any[] | null;
+  planSpace?: any[] | null;
+  presupuesto_objeto?: Record<string, any> | null;
+}
+
+export interface GetEventoByIdResponse {
+  getEventoById: EventoDetalle | null;
+}
+
 // ========================================
 // QUERIES
 // ========================================
@@ -54,6 +70,26 @@ const GET_EVENTOS_BY_USUARIO = `
         development
         usuario_id
       }
+    }
+  }
+`;
+
+// Panel contextual del chat (#7). Verificado EN VIVO 3-ago vs api-mcp:
+// getEventoById(id: ID!) — NO acepta `development`; `id` es ID! (no String).
+// Devuelve el evento rico (itinerarios_array/presupuesto_objeto/invitados_array).
+const GET_EVENTO_BY_ID = `
+  query GetEventoById($id: ID!) {
+    getEventoById(id: $id) {
+      _id
+      nombre
+      fecha
+      tipo
+      development
+      itinerarios_array
+      presupuesto_objeto
+      invitados_array
+      menus_array
+      planSpace
     }
   }
 `;
@@ -78,6 +114,19 @@ export const getEventosByUsuario = async (
     usuario_id: usuarioId,
   });
   return data.getEventosByUsuario?.eventos ?? [];
+};
+
+/**
+ * Obtiene UN evento con sus sub-objetos ricos (itinerario/presupuesto/servicios/invitados)
+ * para el panel contextual del chat (#7). Lectura DIRECTA a api-mcp (NO pasa por el LLM →
+ * sin coste IA, sin doble billing). El gate por dueño lo aplica api-mcp: si el usuario no
+ * es dueño, los *_array/*_objeto llegan en null (solo stub público).
+ * Devuelve null si no existe o no hay id.
+ */
+export const getEventoById = async (id: string): Promise<EventoDetalle | null> => {
+  if (!id) return null;
+  const data = await mcpClient.query<GetEventoByIdResponse>(GET_EVENTO_BY_ID, { id });
+  return data.getEventoById ?? null;
 };
 
 /**

--- a/apps/chat-ia/src/store/chat/slices/builtinTool/actions/filterAppView.ts
+++ b/apps/chat-ia/src/store/chat/slices/builtinTool/actions/filterAppView.ts
@@ -1,9 +1,7 @@
 import { StateCreator } from 'zustand/vanilla';
 
+import { ENTITY_TO_SECTION, useEventPanelStore } from '@/features/EventPanel/store';
 import { ChatStore } from '@/store/chat/store';
-import { setNamespace } from '@/utils/storeDebug';
-
-const n = setNamespace('tool');
 
 interface FilterViewData {
   entity: string;
@@ -21,7 +19,7 @@ export const filterAppViewSlice: StateCreator<
   [['zustand/devtools', never]],
   [],
   ChatFilterAppViewAction
-> = (set, get) => ({
+> = () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   filter_view: async (_id, data) => {
     if (typeof window === 'undefined') return;
@@ -29,6 +27,19 @@ export const filterAppViewSlice: StateCreator<
     const { entity, ids, query } = data;
 
     if (!entity) return;
+
+    // EMBEBIDO (chat-ia dentro del iframe de appEventos): avisar al parent para que
+    // filtre su vista nativa. En STANDALONE window.parent === window → ese postMessage
+    // no lo escucha nadie (audit F1). En ese caso, si la entidad es una sección de
+    // evento (presupuesto/itinerario/servicios), abrir el PANEL CONTEXTUAL local (#7).
+    const isEmbedded = window.parent !== window;
+    const section = ENTITY_TO_SECTION[String(entity).toLowerCase()];
+
+    if (!isEmbedded && section) {
+      // ids[0] puede venir como id de evento; si no, el panel resuelve el evento actual.
+      useEventPanelStore.getState().open(section, ids?.[0]);
+      return;
+    }
 
     window.parent.postMessage(
       {
@@ -39,6 +50,5 @@ export const filterAppViewSlice: StateCreator<
       },
       '*',
     );
-
   },
 });


### PR DESCRIPTION
Informe integración api-ia #7: panel derecho que lee getEventoById DIRECTO de api-mcp (sin LLM, sin doble billing). 3 secciones + trigger (arregla audit F1) + botón manual. Formas verificadas en vivo. Type-check limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)