### PR TITLE
✨ feat(chat-ia/panel): sección Servicios en el panel del evento

### DIFF
--- a/apps/chat-ia/src/tools/event-panel/Portal/index.tsx
+++ b/apps/chat-ia/src/tools/event-panel/Portal/index.tsx
@@ -85,7 +85,8 @@ const Presupuesto = ({ evento }: { evento: any }) => {
 
 const Itinerario = ({ evento }: { evento: any }) => {
   const arr = asObj<any[]>(evento?.itinerarios_array);
-  const items: any[] = Array.isArray(arr) ? arr : [];
+  // Los itinerarios con tipo 'servicios' van en la sección Servicios (abajo).
+  const items: any[] = Array.isArray(arr) ? arr.filter((it) => it?.tipo !== 'servicios') : [];
   return (
     <div style={wrap}>
       <div style={h}>📅 Itinerario — {evento?.nombre ?? 'Evento'}</div>
@@ -105,6 +106,39 @@ const Itinerario = ({ evento }: { evento: any }) => {
             </div>
           );
         })
+      )}
+      <div style={{ color: '#9ca3af', fontSize: 11, marginTop: 16 }}>Solo lectura</div>
+    </div>
+  );
+};
+
+// Servicios: itinerarios_array con tipo 'servicios' (verificado en vivo 3-ago: el
+// evento real tenía 7 de tipo 'servicios'). Cada task = un servicio/proveedor.
+const Servicios = ({ evento }: { evento: any }) => {
+  const arr = asObj<any[]>(evento?.itinerarios_array);
+  const grupos: any[] = Array.isArray(arr) ? arr.filter((it) => it?.tipo === 'servicios') : [];
+  const tareas = grupos.flatMap((g) => (Array.isArray(g?.tasks) ? g.tasks : []));
+  return (
+    <div style={wrap}>
+      <div style={h}>🛎️ Servicios — {evento?.nombre ?? 'Evento'}</div>
+      {tareas.length === 0 ? (
+        <div style={{ color: '#9ca3af' }}>Sin servicios registrados.</div>
+      ) : (
+        tareas.map((t, i) => (
+          <div key={t?._id ?? i} style={{ ...row, alignItems: 'baseline' }}>
+            <span style={{ flex: 1, minWidth: 0 }}>
+              {t?.descripcion ?? t?.title ?? `Servicio ${i + 1}`}
+              {t?.responsable && (
+                <span style={{ color: '#6b7280', fontSize: 11 }}> · {t.responsable}</span>
+              )}
+            </span>
+            {(t?.estatus || t?.estado) && (
+              <b style={{ fontSize: 11, textTransform: 'capitalize' }}>
+                {String(t?.estatus ?? t?.estado).replace(/_/g, ' ')}
+              </b>
+            )}
+          </div>
+        ))
       )}
       <div style={{ color: '#9ca3af', fontSize: 11, marginTop: 16 }}>Solo lectura</div>
     </div>
@@ -137,7 +171,9 @@ const EventPanelPortal = memo<BuiltinPortalProps<{ eventoId?: string; section?: 
       return <div style={wrap}><div style={{ color: '#9ca3af' }}>Cargando…</div></div>;
     }
 
-    return section === 'itinerario' ? <Itinerario evento={evento} /> : <Presupuesto evento={evento} />;
+    if (section === 'itinerario') return <Itinerario evento={evento} />;
+    if (section === 'servicios') return <Servicios evento={evento} />;
+    return <Presupuesto evento={evento} />;
   },
 );
 

--- a/apps/chat-ia/src/tools/event-panel/Render/index.tsx
+++ b/apps/chat-ia/src/tools/event-panel/Render/index.tsx
@@ -9,6 +9,7 @@ interface ShowEventSectionContent {
 const LABEL: Record<string, string> = {
   itinerario: 'itinerario',
   presupuesto: 'presupuesto',
+  servicios: 'servicios',
 };
 
 /** Resumen inline en el cuerpo del chat; el detalle vive en el Portal (panel lateral). */

--- a/apps/chat-ia/src/tools/event-panel/index.ts
+++ b/apps/chat-ia/src/tools/event-panel/index.ts
@@ -11,7 +11,7 @@ export const EventPanelManifest: BuiltinToolManifest = {
   api: [
     {
       description:
-        'Abre el panel lateral del chat mostrando una sección del evento actual (presupuesto o itinerario) con sus datos reales. Úsalo cuando el usuario hable de su presupuesto/gastos/pagos o de su itinerario/agenda y quiera verlo.',
+        'Abre el panel lateral del chat mostrando una sección del evento actual (presupuesto, itinerario o servicios) con sus datos reales. Úsalo cuando el usuario hable de su presupuesto/gastos/pagos, de su itinerario/agenda, o de sus servicios/proveedores y quiera verlo.',
       name: 'show_event_section',
       parameters: {
         properties: {
@@ -22,7 +22,7 @@ export const EventPanelManifest: BuiltinToolManifest = {
           },
           section: {
             description: 'Sección del evento a mostrar en el panel.',
-            enum: ['presupuesto', 'itinerario'],
+            enum: ['presupuesto', 'itinerario', 'servicios'],
             type: 'string',
           },
         },
@@ -36,7 +36,7 @@ export const EventPanelManifest: BuiltinToolManifest = {
     avatar: '📊',
     title: 'Panel del evento',
   },
-  systemRole: `Cuando el usuario hable del PRESUPUESTO (gastos, coste, pagos, cuánto llevo) o del ITINERARIO (agenda, tareas, timing) de su evento y quiera verlo, invoca show_event_section con { section, eventoId }.
+  systemRole: `Cuando el usuario hable del PRESUPUESTO (gastos, coste, pagos, cuánto llevo), del ITINERARIO (agenda, tareas, timing) o de los SERVICIOS (proveedores, contrataciones) de su evento y quiera verlo, invoca show_event_section con { section, eventoId }.
 - El eventoId está en el contexto de página (screenData) del evento actual.
 - Tras invocarlo, el panel lateral del chat muestra la sección con los datos REALES (solo lectura por ahora).
 - En tu respuesta menciónalo brevemente: "Te muestro el presupuesto en el panel derecho."


### PR DESCRIPTION
Aditivo sobre el tool lobe-event-panel (PRs #258/#259/#260 del panel contextual). Añade la 3ª sección: **Servicios** = itinerarios_array tipo 'servicios' (verificado en vivo: 7 de tipo servicios en evento real). Enum += servicios, render Servicios en el Portal, Itinerario excluye 'servicios' para no duplicar. Type-check limpio en event-panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)