### PR TITLE
🐛 fix(panel): habilitar lobe-event-panel en agente default (QA Bug #4)

### DIFF
--- a/apps/chat-ia/src/const/settings.ts
+++ b/apps/chat-ia/src/const/settings.ts
@@ -45,7 +45,11 @@ export const DEFAULT_AGENT_CONFIG: LobeAgentConfig = {
   },
 
   // 🛠️ Plugins (opcional)
-  plugins: [],
+  // lobe-event-panel: habilita el panel contextual del evento (show_event_section) por defecto.
+  // Sin esto, el modelo NO recibe la herramienta → nunca abre el panel (QA 4-ago, Bug #4:
+  // "muéstrame el presupuesto" → 0 llamadas, respuesta genérica). Las tools al modelo se filtran
+  // por agentConfig.plugins (tool.ts:23 / generateAIChat.ts:687).
+  plugins: ['lobe-event-panel'],
 
   // ✅ AUTO por defecto (como Cursor)
   provider: 'auto',


### PR DESCRIPTION
QA 4-ago Bug #4 (P0): el panel nunca se invoca (0 llamadas a api-mcp, respuesta genérica). Causa: las tools al modelo se filtran por `agentConfig.plugins` y el default estaba vacío → el modelo no recibía `show_event_section`. Fix: `lobe-event-panel` en DEFAULT_AGENT_CONFIG.plugins. Si aún no invoca tras desplegar → sospechar api-ia no reenvía tools (coordinar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)