### PR TITLE
🐛 fix(agentes): guard de hidratación — corta React #418 (QA Bug #5)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
@@ -148,6 +148,12 @@ export default function AgentesPage() {
     }
   }, [selectedId, agentSessions]);
 
+  // Guard de hidratación (React #418, QA 4-ago): los selectores de Zustand pueden diferir
+  // entre SSR (estado inicial) y el primer render del cliente (store ya hidratado) → mismatch.
+  // Renderizamos el placeholder hasta `mounted` para garantizar HTML SSR == 1er render cliente.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   // Estado local (disabled + channels) por agente — memoria hasta backend.
   const [localStates, setLocalStates] = useState<Record<string, LocalAgentState>>({});
   useEffect(() => {
@@ -340,7 +346,7 @@ export default function AgentesPage() {
   // Sessions aún no hidratadas — Redirect.tsx ya evita el fullscreen loader
   // en /agentes (ROUTES_TO_SKIP). Aquí ponemos placeholder discreto para
   // evitar mostrar "no tienes agentes" mientras cargan.
-  if (!isSessionListInit) {
+  if (!mounted || !isSessionListInit) {
     return (
       <div className="flex h-full" style={{ backgroundColor: '#FFFFFF' }}>
         <MessagesRail />


### PR DESCRIPTION
QA Bug #5 (P1): /agentes lanza React #418 (hydration mismatch). Causa: render depende de selector Zustand (isSessionListInit) que difiere SSR vs 1er render cliente. Fix: guard `mounted` → SSR y 1er render cliente muestran el placeholder por igual. Sin cambio funcional. (El 'stuck loading' depende de la init de sesiones/backend, se re-evalúa aparte.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)