### PR TITLE
🐛 fix(chat): panel evento standalone (#7 · QA B-01/B-03) + composer (Bug#8)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/ChatInput/Desktop/ClassicChat.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/ChatInput/Desktop/ClassicChat.tsx
@@ -16,6 +16,7 @@ import LeadQualificationContext from '@/features/LeadQualificationContext';
 
 import MessageFromUrl from './MessageFromUrl';
 import ContextFromEmbed from '../../ContextFromEmbed';
+import StandaloneEventContext from '../../StandaloneEventContext';
 import { useSendMenuItems } from './useSendMenuItems';
 
 const leftActions: ActionKeys[] = [
@@ -78,6 +79,7 @@ const ClassicChatInput = memo(() => {
       <Suspense fallback={null}>
         <MessageFromUrl />
         <ContextFromEmbed />
+        <StandaloneEventContext />
         <LeadMonitor />
         <LeadQualificationContext />
       </Suspense>

--- a/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/StandaloneEventContext.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/StandaloneEventContext.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * StandaloneEventContext — inyecta el EVENTO ACTIVO en el systemRole del agente para
+ * que la IA tenga el `eventoId` y pueda invocar `show_event_section` (panel) también en
+ * STANDALONE (usuario que entra directo al chat, no desde appEventos).
+ *
+ * Complementa `ContextFromEmbed` (que solo cubre el caso EMBEBIDO vía sessionStorage
+ * `copilot_open_context`). Aquí leemos `current_event_id`/`current_event_name` (que fija
+ * el selector `ActiveEventChip` o el sync cross-app) y re-inyectamos en cada
+ * `chatia:activeEventChanged`. Mismos marcadores de bloque → idempotente (no acumula).
+ *
+ * Cierra el hueco QA B-01/B-03 · audit F4 (`no_context_at_all`).
+ */
+const MARK_START = '<!-- Contexto del evento (inyectado automáticamente) -->';
+const MARK_END = '<!-- fin contexto -->';
+const CLEAN_RE = /<!--\s*Contexto del evento[\S\s]*?<!--\s*fin contexto\s*-->\n*/g;
+
+const StandaloneEventContext = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let isMounted = true;
+
+    const inject = async () => {
+      try {
+        // Si hay contexto del embed pendiente, lo maneja ContextFromEmbed (más rico).
+        if (sessionStorage.getItem('copilot_open_context')) return;
+        const eventId = localStorage.getItem('current_event_id');
+        if (!eventId) return;
+        const eventName = localStorage.getItem('current_event_name') || '';
+
+        const lines = [MARK_START];
+        if (eventName) lines.push(`Evento: ${eventName}`);
+        lines.push(`ID de evento: ${eventId}`, 
+          'Cuando el usuario pida ver su presupuesto, itinerario o servicios, invoca show_event_section con este eventoId.', MARK_END
+        );
+        const contextBlock = lines.join('\n');
+
+        const [{ useAgentStore }, { agentSelectors }] = await Promise.all([
+          import('@/store/agent'),
+          import('@/store/agent/selectors'),
+        ]);
+        if (!isMounted) return;
+
+        const agentStore = useAgentStore.getState();
+        const current: string =
+          agentSelectors.currentAgentSystemRole(useAgentStore.getState()) || '';
+        const cleaned = current.replaceAll(CLEAN_RE, '').trimStart();
+        const next = cleaned ? `${contextBlock}\n\n${cleaned}` : contextBlock;
+        if (next === current) return;
+        await agentStore.updateAgentConfig({ systemRole: next });
+      } catch {
+        /* noop: sin evento activo o store no listo */
+      }
+    };
+
+    // Diferir para que el agent store inicialice (igual que ContextFromEmbed).
+    const timeout = setTimeout(inject, 900);
+    const onChange = () => inject();
+    window.addEventListener('chatia:activeEventChanged', onChange);
+    return () => {
+      isMounted = false;
+      clearTimeout(timeout);
+      window.removeEventListener('chatia:activeEventChanged', onChange);
+    };
+  }, []);
+
+  return null;
+};
+
+export default StandaloneEventContext;

--- a/apps/chat-ia/src/features/ChatInput/SendArea/SendButton.tsx
+++ b/apps/chat-ia/src/features/ChatInput/SendArea/SendButton.tsx
@@ -19,7 +19,10 @@ const SendButton = memo(() => {
       onStop={() => handleStop()}
       placement={'topRight'}
       shape={shape}
-      trigger={['hover']}
+      // QA Bug#8: 'hover' abría el menú de modo-de-envío al acercar el ratón (un clic
+      // ligeramente desviado abría el menú en vez de enviar). 'click' = solo al pulsar
+      // la flecha del split-button (UX estándar).
+      trigger={['click']}
     />
   );
 });

--- a/apps/chat-ia/src/features/ChatInput/store/action.ts
+++ b/apps/chat-ia/src/features/ChatInput/store/action.ts
@@ -46,6 +46,12 @@ export const store: CreateStore = (publicState) => (set, get) => ({
     // siguiente keystroke del user. clearContent del callback queda
     // no-op porque ya se limpió.
     const snapshot = String(editor?.getDocument('markdown') || '').trimEnd();
+
+    // QA Bug#8: si el snapshot sale VACÍO (carrera de serialización del editor / clic
+    // sin contenido), NO limpiar ni enviar — evita el síntoma "el texto se borra pero
+    // el mensaje nunca se envía". Con contenido no vacío se procede normal.
+    if (!snapshot) return;
+
     editor?.cleanDocument();
 
     get().onSend?.({

--- a/apps/chat-ia/src/hooks/useAvailableEventsFromCookie.ts
+++ b/apps/chat-ia/src/hooks/useAvailableEventsFromCookie.ts
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react';
 
+import { getEventosByUsuario } from '@/services/mcpApi/eventos';
+
 const COOKIE_NAME = 'bodas_available_events';
 
 export interface AvailableEvent {
@@ -11,7 +13,7 @@ export interface AvailableEvent {
 
 const readCookie = (name: string): string | null => {
   if (typeof document === 'undefined') return null;
-  const escaped = name.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+  const escaped = name.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
   const match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
   return match ? decodeURIComponent(match[1]) : null;
 };
@@ -48,7 +50,13 @@ export const useAvailableEventsFromCookie = (): AvailableEvent[] => {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const refresh = () => setEvents(parse(readCookie(COOKIE_NAME)));
+    // La cookie es la fuente primaria (appEventos la publica). Solo sobreescribimos
+    // cuando trae eventos, para NO pisar el fallback fetch de abajo con [] cuando la
+    // cookie está vacía (standalone: el usuario NO viene de appEventos).
+    const refresh = () => {
+      const fromCookie = parse(readCookie(COOKIE_NAME));
+      if (fromCookie.length) setEvents(fromCookie);
+    };
     const onVisibility = () => {
       if (document.visibilityState === 'visible') refresh();
     };
@@ -61,6 +69,36 @@ export const useAvailableEventsFromCookie = (): AvailableEvent[] => {
       window.removeEventListener('storage', refresh);
     };
   }, []);
+
+  // Fallback STANDALONE (audit F4 / QA B-01): si la cookie no trae eventos (el usuario
+  // entró directo al chat, no desde appEventos), buscar los eventos del usuario vía
+  // api-mcp para poblar el selector. Sin esto, el chip no aparece y la IA no tiene
+  // eventoId → nunca invoca show_event_section (no_context_at_all).
+  useEffect(() => {
+    if (typeof window === 'undefined' || events.length > 0) return;
+    let cancelled = false;
+    try {
+      const raw = localStorage.getItem('dev-user-config');
+      const cfg = raw ? JSON.parse(raw) : {};
+      const usuarioId = cfg.user_id ?? cfg.userId ?? cfg.user_email ?? cfg.email;
+      const development =
+        cfg.development ?? cfg.developer ?? localStorage.getItem('current_development') ?? 'bodasdehoy';
+      if (!usuarioId) return;
+      getEventosByUsuario(development, String(usuarioId))
+        .then((list) => {
+          if (cancelled || !Array.isArray(list) || list.length === 0) return;
+          setEvents(list.map((e) => ({ id: e._id, name: e.nombre || '' })));
+        })
+        .catch(() => {
+          /* sin eventos o backend caído: el chip simplemente no se puebla */
+        });
+    } catch {
+      /* dev-user-config ausente/roto */
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [events.length]);
 
   return events;
 };


### PR DESCRIPTION
QA chat-dev. Front-actionable:
- **#7** panel usable en STANDALONE: fetch de eventos del usuario cuando no vienes de appEventos (puebla ActiveEventChip) + StandaloneEventContext inyecta el evento activo en el systemRole → la IA obtiene eventoId → invoca show_event_section. Cierra B-01/B-03 / audit F4.
- **Bug#8** composer: menú modo-envío solo en clic (era hover) + guard de snapshot vacío (no perder texto).
- D-03 (React #418) ya cubierto por #265.

⚠️ Additivo sobre el contexto de evento del actor (CTX-C). No toca el flujo embebido. Type-check + lint limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)