### PR TITLE
💄 feat(mesas): texto (Escribe aquí+controles+tamaño) + Exportar PDF descarga + Resumen por-espacio

### DIFF
--- a/apps/appEventos/components/Mesas/BlockResumen.tsx
+++ b/apps/appEventos/components/Mesas/BlockResumen.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react"
-import { EventContextProvider } from "../../context"
+import { AuthContextProvider, EventContextProvider } from "../../context"
 import { guests } from '../../utils/Interfaces';
+import { fetchApiEventos, queries } from '../../utils/Fetching';
 import { useTranslation } from 'react-i18next';
 
 // Rediseño fiel al prototipo (MESAS.dc.html): tarjeta de resumen (% ocupado + 3 stats)
@@ -11,7 +12,27 @@ interface propsBlockResumen {
 }
 const BlockResumen: FC<propsBlockResumen> = ({ InvitadoSentados }) => {
     const { t } = useTranslation();
-    const { event, planSpaceSelect } = EventContextProvider()
+    const { event, planSpaceSelect, setPlanSpaceSelect } = EventContextProvider()
+    const { user } = AuthContextProvider()
+
+    // Al clicar un espacio en "Por espacio", cambiar el plano activo a ese espacio.
+    // setPlanSpaceSelect dispara el efecto del context que actualiza planSpaceActive
+    // (mismo patrón que BlockPlanos.handleClick). Persiste la selección en backend.
+    const handleSelectSpace = (id?: string) => {
+        if (!id || planSpaceSelect === id) return
+        try {
+            setPlanSpaceSelect(id)
+            fetchApiEventos({
+                query: queries.setPlanSpaceSelect,
+                variables: {
+                    evento_id: event?._id,
+                    planSpaceSelect: id,
+                    isOwner: user?.uid === event?.usuario_id,
+                },
+            })
+        } catch {
+        }
+    }
 
     const totalInvitados = event?.invitados_array?.length || 0
     const perSpace = (event?.planSpace || []).map((ps) => {
@@ -53,7 +74,7 @@ const BlockResumen: FC<propsBlockResumen> = ({ InvitadoSentados }) => {
             {perSpace.map((r, idx) => {
                 const active = planSpaceSelect === r._id
                 return (
-                    <div key={idx} className={`rounded-[11px] px-3 py-[11px] border ${active ? "bg-[#FCF2F6] border-[#f7c2da]" : "bg-white border-[#f0f0f2]"}`}>
+                    <div key={idx} onClick={() => handleSelectSpace(r._id)} title={t("showthisplan") || "Mostrar este plano"} className={`cursor-pointer rounded-[11px] px-3 py-[11px] border transition-colors ${active ? "bg-[#FCF2F6] border-[#f7c2da]" : "bg-white border-[#f0f0f2] hover:border-[#f7c2da] hover:bg-[#fdf7fa]"}`}>
                         <div className="flex items-center justify-between mb-2">
                             <div className="flex items-center gap-2">
                                 <span className="w-2 h-2 rounded-full bg-[#EF5B94]" />

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -120,7 +120,7 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
                       onClick={() => {
                         setShowMiniMenu(false)
                         const ok = exportPlanoPdf({ planSpaceActive, event, planoTitle: t(planSpaceActive?.title) })
-                        if (!ok) toast('error', t('popupblocked') || 'Permite las ventanas emergentes para exportar el PDF')
+                        if (!ok) toast('error', t('pdferror') || 'No se pudo generar el PDF')
                       }}
                       className="w-full flex items-center gap-2 text-left font-semibold py-1.5 mb-1 border-b border-gray-100 hover:text-primary"
                     >

--- a/apps/appEventos/components/Mesas/DragableDefault.tsx
+++ b/apps/appEventos/components/Mesas/DragableDefault.tsx
@@ -24,6 +24,7 @@ export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWra
   // Mobiliario (no mesa, no texto): controles SOBRE el elemento fieles al HTML
   // (papelera arriba-izq + pastilla −/＋ debajo). Misma lógica que EditDefault, persistida.
   const isFurniture = prefijo !== "table" && item?.tipo !== "text"
+  const isText = item?.tipo === "text"
   const selected = editDefault?.clicked === item?._id
 
   const handleDeleteEl = async () => {
@@ -49,6 +50,20 @@ export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWra
       planSpace: prev.planSpace.map((ps: any) => ps._id !== planSpaceActive._id ? ps : nps),
     }))
     await fetchApiBodas({ query: queries.editElement, variables: { evento_id: event._id, element_id: item._id, datos: { size: newSize } } })
+  }
+
+  // Tamaño de LETRA del texto (px). Mismo patrón que la escala del mobiliario, pero
+  // sobre item.fontSize. planSpace es JSON → persiste el campo.
+  const handleFontSize = async (delta: number) => {
+    const cur = typeof (item as any)?.fontSize === 'number' ? (item as any).fontSize : 14
+    const newFontSize = Math.max(10, Math.min(72, Math.round(cur + delta)))
+    const nps = { ...planSpaceActive, elements: (planSpaceActive?.elements || []).map((el: any) => el._id !== item._id ? el : { ...el, fontSize: newFontSize }) }
+    setPlanSpaceActive(nps)
+    setEvent((prev: any) => ({
+      ...prev,
+      planSpace: prev.planSpace.map((ps: any) => ps._id !== planSpaceActive._id ? ps : nps),
+    }))
+    await fetchApiBodas({ query: queries.editElement, variables: { evento_id: event._id, element_id: item._id, datos: { fontSize: newFontSize } } })
   }
 
   useEffect(() => {
@@ -143,6 +158,38 @@ export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWra
           >
             <button onClick={(e) => { e.stopPropagation(); handleScaleEl(1 / 1.2) }} title="Achicar" className="w-[22px] h-[22px] rounded-[7px] text-[#6b6b72] text-[15px] leading-none flex items-center justify-center">−</button>
             <button onClick={(e) => { e.stopPropagation(); handleScaleEl(1.2) }} title="Agrandar" className="w-[22px] h-[22px] rounded-[7px] text-[#EF5B94] text-[15px] leading-none flex items-center justify-center">＋</button>
+          </div>
+        </>
+      )}
+      {/* Controles del TEXTO (fiel al prototipo): papelera izq + lápiz der (circulares)
+          + pastilla −/＋ de tamaño de letra. stopPropagation para no arrastrar/deseleccionar. */}
+      {isText && selected && (
+        <>
+          <button
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            onClick={(e) => { e.stopPropagation(); handleDeleteEl() }}
+            title="Borrar"
+            className="absolute -top-3 -left-3 w-[26px] h-[26px] rounded-full bg-white border border-[#f2c9d9] shadow-[0_3px_8px_rgba(0,0,0,.18)] flex items-center justify-center z-20"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
+          </button>
+          <button
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            onClick={(e) => { e.stopPropagation(); window.dispatchEvent(new CustomEvent('mesas-text-edit', { detail: { id: item._id } })) }}
+            title="Editar texto"
+            className="absolute -top-3 -right-3 w-[26px] h-[26px] rounded-full bg-white border border-[#f2c9d9] shadow-[0_3px_8px_rgba(0,0,0,.18)] flex items-center justify-center z-20"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" /></svg>
+          </button>
+          <div
+            onMouseDown={(e) => e.stopPropagation()}
+            onTouchStart={(e) => e.stopPropagation()}
+            className="absolute -bottom-4 left-1/2 -translate-x-1/2 flex gap-0.5 bg-white border border-[#eee] rounded-[10px] shadow-[0_3px_8px_rgba(0,0,0,.15)] p-0.5 z-20"
+          >
+            <button onClick={(e) => { e.stopPropagation(); handleFontSize(-2) }} title="Letra más pequeña" className="w-[22px] h-[22px] rounded-[7px] text-[#6b6b72] text-[15px] leading-none flex items-center justify-center">−</button>
+            <button onClick={(e) => { e.stopPropagation(); handleFontSize(+2) }} title="Letra más grande" className="w-[22px] h-[22px] rounded-[7px] text-[#EF5B94] text-[15px] leading-none flex items-center justify-center">＋</button>
           </div>
         </>
       )}

--- a/apps/appEventos/components/Mesas/ElementContent.tsx
+++ b/apps/appEventos/components/Mesas/ElementContent.tsx
@@ -227,7 +227,9 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
           border: ${isEditing ? "1.5px solid #EF5B94" : "none"} !important;
           border-radius: ${isEditing ? "9999px" : "0"};
           padding: ${isEditing ? "4px 16px" : "0"};
-          background: white;
+          /* Sin fondo blanco en display: el texto se ve limpio sobre la cuadrícula.
+             Solo pinta blanco dentro del pill rosa al editar. */
+          background: ${isEditing ? "white" : "transparent"};
           transition: border-color .15s ease, padding .15s ease;
         }
         .textTable-editor_${item._id} .ql-container.ql-snow {

--- a/apps/appEventos/components/Mesas/ElementContent.tsx
+++ b/apps/appEventos/components/Mesas/ElementContent.tsx
@@ -21,7 +21,8 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
   const { editDefault } = EventContextProvider()
   const [reactElement, setReactElement] = useState<React.ReactElement>();
   const { event, planSpaceActive, setPlanSpaceActive, setEvent } = EventContextProvider()
-  const [customEditor, setCustomEditor] = useState<string>(item?.title || `<p class="ql-align-center">texto</p>`)
+  // Vacío por defecto → se muestra el placeholder "Escribe aquí" (fiel al prototipo).
+  const [customEditor, setCustomEditor] = useState<string>(item?.title || "")
   const [editDefaultOld, setEditDefaultOld] = useState<any>()
   const [isMounted, setIsMounted] = useState(false)
   const [isClickEditor, setIsClickEditor] = useState(false)
@@ -69,13 +70,12 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
       const handleClickOutside = (e: MouseEvent) => {
         const elem = document.getElementById(`editor-textTable_${item._id}`)
         const editor = elem?.querySelector('.ql-editor') as HTMLElement
-        const toolbar = elem?.querySelector('.ql-toolbar') as HTMLElement
-        if (editor && toolbar) {
+        if (editor) {
           const target = e.target as Node
-          const isClickInsideEditor = editor.contains(target)
-          const isClickInsideToolbar = toolbar.contains(target)
-          if (!isClickInsideEditor && !isClickInsideToolbar) {
+          // Los botones lápiz/+/- hacen stopPropagation → no llegan aquí.
+          if (!editor.contains(target)) {
             setTriggerClickOutside(new Date())
+            setIsClickEditor(false)
           }
         }
       }
@@ -96,17 +96,25 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
       setIsMounted(false)
     }
   }, [])
-  // Configuración del editor Quill
-  const quillModules = {
-    toolbar: [
-      [{ 'size': ['small', false, 'large', 'huge'] }], // Selector de tamaño de fuente
-      ['bold', 'italic', 'underline', 'strike'],
-      ['clean'],
-      [{ 'align': [] }],
-      [{ 'color': [] }, { 'background': [] }],
 
-    ],
-  };
+  // El botón LÁPIZ (en DragableDefault) dispara la edición del texto vía evento,
+  // para mostrar el input tipo píldora con borde rosa (fiel al prototipo).
+  useEffect(() => {
+    const onEdit = (e: any) => {
+      if (e?.detail?.id === item._id) {
+        setIsClickEditor(true)
+        setTimeout(() => {
+          const editor = document.getElementById(`editor-textTable_${item._id}`)?.querySelector('.ql-editor') as HTMLElement | null
+          editor?.focus()
+        }, 0)
+      }
+    }
+    window.addEventListener('mesas-text-edit', onEdit as any)
+    return () => window.removeEventListener('mesas-text-edit', onEdit as any)
+  }, [item?._id])
+  // Sin toolbar Quill: el diseño (prototipo) usa lápiz para editar y +/- para el
+  // tamaño de letra (como mobiliario). Texto plano centrado.
+  const quillModules = { toolbar: false };
 
   useEffect(() => {
     if (isMounted && item?.tipo === "text") {
@@ -161,6 +169,7 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
           modules={quillModules}
           formats={quillFormats}
           theme="snow"
+          placeholder="Escribe aquí"
           className={`bg-white border-none textTable-editor_${item._id}`}
         />
       </div>
@@ -185,6 +194,11 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
     }
   }, [item, event?.galerySvgs]);
 
+  // Modo edición del texto: seleccionado + click-editor activo (lápiz o clic en el texto).
+  // El pill con borde rosa aparece solo aquí. (isClickEditor se resetea al soltar el drag.)
+  const isEditing = editDefault?.clicked === item?._id && isClickEditor
+  const fontSize = item?.fontSize ?? 14
+
   return (
     <>
       {reactElement
@@ -206,24 +220,32 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
           height: auto !important;
           overflow: hidden;
           font-family: inherit;
-          font-size: 0.875rem;
-          line-height: 1.5rem;
-          border: none !important;
+          font-size: ${fontSize}px;
+          line-height: 1.4;
           position: static !important;
+          /* Input tipo píldora con borde rosa SOLO al editar (fiel al prototipo). */
+          border: ${isEditing ? "1.5px solid #EF5B94" : "none"} !important;
+          border-radius: ${isEditing ? "9999px" : "0"};
+          padding: ${isEditing ? "4px 16px" : "0"};
+          background: white;
+          transition: border-color .15s ease, padding .15s ease;
         }
         .textTable-editor_${item._id} .ql-container.ql-snow {
           border: none !important;
           position: static !important;
         }
         .textTable-editor_${item._id} .ql-editor {
-          background-color: white;
-          min-width: 50px;
-          //min-height: 200px;
+          background-color: transparent;
+          min-width: 60px;
           padding: 0;
-          font-size: 12px;
+          font-size: ${fontSize}px;
+          font-weight: 600;
+          text-align: center;
+          color: #1f2937;
           height: 100%;
           overflow-y: auto;
           position: static !important;
+          cursor: ${isEditing ? "text" : "pointer"};
         }
         .textTable-editor_${item._id} .ql-toolbar {
           ${editDefault?.clicked === item._id && !disableDrag && isClickEditor ? "visibility: visible" : "display: none"};
@@ -301,9 +323,13 @@ export const ElementContent: FC<propsElement> = ({ item, scale, disableDrag }) =
           fill: currentColor;
         }
         .textTable-editor_${item._id} .ql-editor.ql-blank::before {
-          color: #9ca3af;
+          color: ${isEditing ? "#c4c4cc" : "#1f2937"};
           font-style: normal;
-          font-size: 12px;
+          font-weight: 600;
+          font-size: ${fontSize}px;
+          left: 0;
+          right: 0;
+          text-align: center;
         }
       `}</style>
     </>

--- a/apps/appEventos/components/Mesas/prueba.tsx
+++ b/apps/appEventos/components/Mesas/prueba.tsx
@@ -54,9 +54,9 @@ const Prueba: FC<propsPrueba> = ({ setShowFormEditar, fullScreen, setFullScreen 
         {/* BUG-6 (informe QA 21-jun): bg-blue-200 era debug hardcoded. Cambiamos a
             bg-base (token de tema) para que respete el diseño del whitelabel. */}
         <div id="rootElementTables" ref={refDiv} className="bg-base flex w-[100%] h-[calc(100%-32px)] relative">
-          {/* Barra lateral izquierda: solo para mesas y texto. El mobiliario usa los
-              controles SOBRE el elemento (papelera + −/＋), fieles al HTML (DragableDefault). */}
-          {editDefault?.clicked && !(editDefault?.itemTipo === "element" && editDefault?.item?.tipo !== "text") &&
+          {/* Barra lateral izquierda: SOLO para mesas. El mobiliario Y el texto usan los
+              controles SOBRE el elemento (papelera/lápiz + −/＋), fieles al HTML (DragableDefault). */}
+          {editDefault?.clicked && editDefault?.itemTipo === "table" &&
             <ClickAwayListener
               onClickAway={() => {
                 if (editDefault.activeButtons) {

--- a/apps/appEventos/package.json
+++ b/apps/appEventos/package.json
@@ -57,6 +57,7 @@
     "interweave": "^13.1.0",
     "interweave-autolink": "^5.1.1",
     "js-cookie": "^3.0.1",
+    "jspdf": "^4.2.1",
     "lucide-react": "^0.514.0",
     "mongoose": "^8.9.4",
     "nanoid": "^4.0.2",

--- a/apps/appEventos/utils/Interfaces.ts
+++ b/apps/appEventos/utils/Interfaces.ts
@@ -410,6 +410,7 @@ interface propsBase {
 }
 export interface element extends propsBase {
     tipo: string
+    fontSize?: number // px del texto (elementos tipo "text"). planSpace es JSON → persiste.
 }
 
 export interface guest {

--- a/apps/appEventos/utils/exportPlanoPdf.ts
+++ b/apps/appEventos/utils/exportPlanoPdf.ts
@@ -1,13 +1,8 @@
-// Rediseño Fase D (fiel a MESAS.dc.html): exportar el plano a PDF.
-// Sin dependencias: genera un HTML con croquis SVG (mesas posicionadas) + lista de
-// invitados por mesa, lo abre en una ventana nueva y lanza print() → el usuario elige
-// "Guardar como PDF". Usa datos reales (planSpaceActive.tables, table.guests,
-// event.invitados_array). El _buildPDF del prototipo es solo referencia de layout.
-
-const escapeHtml = (s: any): string =>
-  String(s ?? '').replace(/[&<>"']/g, (c) => (
-    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' } as Record<string, string>
-  )[c]);
+// Exportar el plano a PDF con DESCARGA real (jsPDF, sin popup ni servicios externos).
+// Página 1: croquis del plano (mesas posicionadas a escala + nombre).
+// Páginas siguientes: lista de invitados por mesa (asiento + nombre).
+// Datos reales: planSpaceActive.tables, table.guests, event.invitados_array.
+import { jsPDF } from 'jspdf';
 
 interface ExportArgs {
   planSpaceActive: any
@@ -15,66 +10,136 @@ interface ExportArgs {
   planoTitle: string
 }
 
+// Colores de marca (RGB para jsPDF).
+const C = {
+  bg: [240, 240, 242] as [number, number, number],
+  border: [231, 231, 234] as [number, number, number],
+  ink: [58, 58, 66] as [number, number, number],
+  muted: [138, 138, 144] as [number, number, number],
+  pink: [239, 91, 148] as [number, number, number],
+  line: [242, 242, 244] as [number, number, number],
+};
+
 export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArgs): boolean => {
-  const tables: any[] = planSpaceActive?.tables ?? [];
-  const W = planSpaceActive?.size?.width || 1400;
-  const H = planSpaceActive?.size?.height || 1400;
+  try {
+    const tables: any[] = planSpaceActive?.tables ?? [];
+    const guestsById: Record<string, any> = {};
+    (event?.invitados_array ?? []).forEach((g: any) => { if (g?._id) guestsById[g._id] = g; });
 
-  const guestsById: Record<string, any> = {};
-  (event?.invitados_array ?? []).forEach((g: any) => { if (g?._id) guestsById[g._id] = g; });
+    const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'letter' });
+    const pw = doc.internal.pageSize.getWidth();
+    const ph = doc.internal.pageSize.getHeight();
+    const M = 40;
 
-  const svgTables = tables.map((tb: any) => {
-    const x = tb?.position?.x ?? 0;
-    const y = tb?.position?.y ?? 0;
-    const w = tb?.size?.width ?? 100;
-    const h = tb?.size?.height ?? 100;
-    const round = ['redonda', 'oval', 'podio'].includes(tb?.tipo);
-    const shape = round
-      ? `<ellipse cx="${x + w / 2}" cy="${y + h / 2}" rx="${w / 2}" ry="${h / 2}" fill="#F0F0F2" stroke="#3A3A42" stroke-width="2"/>`
-      : `<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="10" fill="#F0F0F2" stroke="#3A3A42" stroke-width="2"/>`;
-    const label = `<text x="${x + w / 2}" y="${y + h / 2}" text-anchor="middle" dominant-baseline="central" font-size="24" font-weight="700" fill="#3A3A42" font-family="Poppins,Arial">${escapeHtml(tb?.title || tb?.nombre_mesa || '')}</text>`;
-    return shape + label;
-  }).join('');
+    // ---------- PÁGINA 1: croquis del plano ----------
+    doc.setFont('helvetica', 'bold'); doc.setFontSize(18); doc.setTextColor(...C.ink);
+    doc.text(String(planoTitle || 'Plano'), M, M + 4);
+    doc.setFont('helvetica', 'normal'); doc.setFontSize(10); doc.setTextColor(...C.muted);
+    doc.text(`${tables.length} mesa${tables.length === 1 ? '' : 's'}${event?.nombre ? '  ·  ' + event.nombre : ''}`, M, M + 20);
 
-  const svg = `<svg viewBox="0 0 ${W} ${H}" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:auto;max-height:58vh;border:1px solid #E7E7EA;border-radius:12px;background:#fff">${svgTables}</svg>`;
+    const areaX = M, areaY = M + 34;
+    const areaW = pw - M * 2, areaH = ph - areaY - M;
+    doc.setDrawColor(...C.border); doc.setLineWidth(1);
+    doc.roundedRect(areaX, areaY, areaW, areaH, 8, 8, 'S');
 
-  const lists = tables.map((tb: any) => {
-    const rows = (tb?.guests ?? [])
-      .slice()
-      .sort((a: any, b: any) => (a?.chair ?? 0) - (b?.chair ?? 0))
-      .map((gg: any) => {
-        const guest = guestsById[gg?._id];
-        return `<li><span class="seat">A${(gg?.chair ?? 0) + 1}</span> ${escapeHtml(guest?.nombre || '—')}</li>`;
-      }).join('');
-    const cap = tb?.numberChair ? ` / ${tb.numberChair}` : '';
-    return `<div class="tbl"><h3>${escapeHtml(tb?.title || tb?.nombre_mesa || '')} <small>${tb?.guests?.length ?? 0}${cap}</small></h3><ul>${rows || '<li class="empty">Sin invitados</li>'}</ul></div>`;
-  }).join('');
+    const W = planSpaceActive?.size?.width || 1400;
+    const H = planSpaceActive?.size?.height || 1400;
+    const scale = Math.min(areaW / W, areaH / H);
+    const offX = areaX + (areaW - W * scale) / 2;
+    const offY = areaY + (areaH - H * scale) / 2;
 
-  const html = `<!doctype html><html lang="es"><head><meta charset="utf-8"><title>${escapeHtml(planoTitle)}</title>
-<style>
-  *{box-sizing:border-box} body{font-family:Poppins,Arial,sans-serif;color:#3A3A42;margin:28px}
-  h1{font-size:22px;margin:0 0 4px} .sub{color:#8a8a90;font-size:12px;margin-bottom:18px}
-  h2{font-size:15px;margin:22px 0 12px;color:#EF5B94}
-  .lists{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:14px}
-  .tbl{border:1px solid #E7E7EA;border-radius:10px;padding:10px 12px;break-inside:avoid}
-  .tbl h3{font-size:13px;margin:0 0 6px} .tbl small{color:#a0a0a8;font-weight:500}
-  .tbl ul{list-style:none;padding:0;margin:0} .tbl li{font-size:12px;padding:3px 0;border-top:1px solid #f2f2f4;display:flex;gap:8px;align-items:center}
-  .tbl li:first-child{border-top:none} .seat{color:#EF5B94;font-weight:700;font-size:10px;min-width:26px}
-  .empty{color:#c8c8ce}
-  @media print{ body{margin:12mm} }
-</style></head><body>
-  <h1>${escapeHtml(planoTitle)}</h1>
-  <div class="sub">${tables.length} mesas${event?.nombre ? ' · ' + escapeHtml(event.nombre) : ''}</div>
-  <div class="croquis">${svg}</div>
-  <h2>Invitados por mesa</h2>
-  <div class="lists">${lists || '<div class="empty">Sin mesas</div>'}</div>
-  <script>window.onload=function(){setTimeout(function(){window.print()},300)}</script>
-</body></html>`;
+    if (tables.length === 0) {
+      doc.setFontSize(12); doc.setTextColor(...C.muted);
+      doc.text('Este plano no tiene mesas todavía.', pw / 2, areaY + areaH / 2, { align: 'center', baseline: 'middle' });
+    }
 
-  const win = window.open('', '_blank');
-  if (!win) return false;
-  win.document.open();
-  win.document.write(html);
-  win.document.close();
-  return true;
+    tables.forEach((tb: any) => {
+      const x = offX + (tb?.position?.x ?? 0) * scale;
+      const y = offY + (tb?.position?.y ?? 0) * scale;
+      const w = (tb?.size?.width ?? 100) * scale;
+      const h = (tb?.size?.height ?? 100) * scale;
+      doc.setFillColor(...C.bg); doc.setDrawColor(...C.ink); doc.setLineWidth(1);
+      const round = ['redonda', 'oval', 'podio'].includes(tb?.tipo);
+      if (round) doc.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 'FD');
+      else doc.roundedRect(x, y, w, h, 3, 3, 'FD');
+      const label = String(tb?.title || tb?.nombre_mesa || '');
+      if (label) {
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(Math.max(5, Math.min(9, w / 7)));
+        doc.setTextColor(...C.ink);
+        doc.text(label, x + w / 2, y + h / 2, { align: 'center', baseline: 'middle', maxWidth: Math.max(20, w - 4) });
+      }
+    });
+
+    // ---------- PÁGINAS 2+: invitados por mesa (2 columnas, con salto de página) ----------
+    doc.addPage('letter', 'portrait');
+    const pw2 = doc.internal.pageSize.getWidth();
+    const ph2 = doc.internal.pageSize.getHeight();
+    doc.setFont('helvetica', 'bold'); doc.setFontSize(15); doc.setTextColor(...C.pink);
+    doc.text('Invitados por mesa', M, M + 2);
+
+    const colGap = 18;
+    const colW = (pw2 - M * 2 - colGap) / 2;
+    const colX = [M, M + colW + colGap];
+    const topY = M + 22;
+    const bottomY = ph2 - M;
+    let col = 0;
+    let y = topY;
+
+    const newColumnOrPage = (blockH: number) => {
+      if (y + blockH <= bottomY) return;
+      if (col === 0) { col = 1; y = topY; }
+      else { doc.addPage('letter', 'portrait'); col = 0; y = topY; }
+    };
+
+    if (tables.length === 0) {
+      doc.setFont('helvetica', 'normal'); doc.setFontSize(11); doc.setTextColor(...C.muted);
+      doc.text('Sin mesas.', M, topY + 6);
+    }
+
+    tables.forEach((tb: any) => {
+      const guests = (tb?.guests ?? [])
+        .slice()
+        .sort((a: any, b: any) => (a?.chair ?? 0) - (b?.chair ?? 0));
+      const rowH = 13;
+      const headH = 20;
+      const blockH = headH + Math.max(1, guests.length) * rowH + 8;
+      newColumnOrPage(blockH);
+      const x = colX[col];
+
+      // header de la mesa
+      doc.setFont('helvetica', 'bold'); doc.setFontSize(11); doc.setTextColor(...C.ink);
+      const cap = tb?.numberChair ? ` / ${tb.numberChair}` : '';
+      doc.text(String(tb?.title || tb?.nombre_mesa || 'Mesa'), x, y + 8, { maxWidth: colW - 40 });
+      doc.setFont('helvetica', 'normal'); doc.setFontSize(9); doc.setTextColor(...C.muted);
+      doc.text(`${guests.length}${cap}`, x + colW, y + 8, { align: 'right' });
+      y += headH;
+
+      if (guests.length === 0) {
+        doc.setFont('helvetica', 'italic'); doc.setFontSize(9); doc.setTextColor(...C.muted);
+        doc.text('Sin invitados', x + 4, y + 2);
+        y += rowH;
+      } else {
+        guests.forEach((gg: any) => {
+          const guest = guestsById[gg?._id];
+          doc.setDrawColor(...C.line); doc.setLineWidth(0.5);
+          doc.line(x, y - 3, x + colW, y - 3);
+          doc.setFont('helvetica', 'bold'); doc.setFontSize(8); doc.setTextColor(...C.pink);
+          doc.text(`A${(gg?.chair ?? 0) + 1}`, x + 2, y + 5);
+          doc.setFont('helvetica', 'normal'); doc.setFontSize(9); doc.setTextColor(...C.ink);
+          doc.text(String(guest?.nombre || '—'), x + 26, y + 5, { maxWidth: colW - 30 });
+          y += rowH;
+        });
+      }
+      y += 10;
+    });
+
+    const fname = `${event?.nombre || 'evento'} ${planoTitle || 'plano'}`
+      .replace(/[^a-zA-Z0-9\s]/g, '').replace(/\s+/g, '_') + '.pdf';
+    doc.save(fname);
+    return true;
+  } catch (e) {
+    console.error('[exportPlanoPdf]', e);
+    return false;
+  }
 };

--- a/apps/appEventos/utils/exportPlanoPdf.ts
+++ b/apps/appEventos/utils/exportPlanoPdf.ts
@@ -1,7 +1,7 @@
 // Exportar el plano a PDF con DESCARGA real (jsPDF, sin popup ni servicios externos).
-// Página 1: croquis del plano (mesas posicionadas a escala + nombre).
-// Páginas siguientes: lista de invitados por mesa (asiento + nombre).
-// Datos reales: planSpaceActive.tables, table.guests, event.invitados_array.
+// Página 1: croquis del plano (mesas + SILLAS ocupadas/libres + textos + muebles, a escala).
+// Páginas siguientes: invitados por mesa (asiento + nombre) + invitados SIN mesa.
+// Datos reales: planSpaceActive.tables, table.guests, planSpaceActive.elements, event.invitados_array.
 import { jsPDF } from 'jspdf';
 
 interface ExportArgs {
@@ -18,11 +18,19 @@ const C = {
   muted: [138, 138, 144] as [number, number, number],
   pink: [239, 91, 148] as [number, number, number],
   line: [242, 242, 244] as [number, number, number],
+  chairEmpty: [200, 200, 208] as [number, number, number],
+  furniture: [230, 230, 234] as [number, number, number],
 };
+
+const stripHtml = (s: any): string =>
+  String(s ?? '').replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/\s+/g, ' ').trim();
+
+const ROUND_TIPOS = ['redonda', 'oval', 'podio'];
 
 export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArgs): boolean => {
   try {
     const tables: any[] = planSpaceActive?.tables ?? [];
+    const elements: any[] = planSpaceActive?.elements ?? [];
     const guestsById: Record<string, any> = {};
     (event?.invitados_array ?? []).forEach((g: any) => { if (g?._id) guestsById[g._id] = g; });
 
@@ -44,34 +52,91 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
 
     const W = planSpaceActive?.size?.width || 1400;
     const H = planSpaceActive?.size?.height || 1400;
-    const scale = Math.min(areaW / W, areaH / H);
+    // pad para que las sillas del borde no se salgan del área
+    const scale = Math.min(areaW / (W * 1.06), areaH / (H * 1.06));
     const offX = areaX + (areaW - W * scale) / 2;
     const offY = areaY + (areaH - H * scale) / 2;
+    const sx = (v: number) => offX + v * scale;
+    const sy = (v: number) => offY + v * scale;
 
-    if (tables.length === 0) {
+    if (tables.length === 0 && elements.length === 0) {
       doc.setFontSize(12); doc.setTextColor(...C.muted);
       doc.text('Este plano no tiene mesas todavía.', pw / 2, areaY + areaH / 2, { align: 'center', baseline: 'middle' });
     }
 
+    // Muebles (elements no-texto): caja gris clara con etiqueta (fiel: gris claro).
+    elements.filter((el) => el?.tipo !== 'text').forEach((el: any) => {
+      const x = sx(el?.position?.x ?? 0), y = sy(el?.position?.y ?? 0);
+      const w = (el?.size?.width ?? 60) * scale, h = (el?.size?.height ?? 60) * scale;
+      doc.setFillColor(...C.furniture); doc.setDrawColor(...C.chairEmpty); doc.setLineWidth(0.6);
+      doc.roundedRect(x, y, w, h, 3, 3, 'FD');
+      const lbl = String(el?.tipo || '');
+      if (lbl && w > 24) {
+        doc.setFont('helvetica', 'normal'); doc.setFontSize(Math.max(5, Math.min(7, w / 8))); doc.setTextColor(...C.muted);
+        doc.text(lbl, x + w / 2, y + h / 2, { align: 'center', baseline: 'middle', maxWidth: w - 4 });
+      }
+    });
+
+    // Textos: contenido plano en su posición (con su fontSize).
+    elements.filter((el) => el?.tipo === 'text').forEach((el: any) => {
+      const txt = stripHtml(el?.title) || 'Escribe aquí';
+      const x = sx((el?.position?.x ?? 0) + (el?.size?.width ?? 80) / 2);
+      const y = sy((el?.position?.y ?? 0) + (el?.size?.height ?? 30) / 2);
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(Math.max(6, Math.min(14, (el?.fontSize ?? 14) * scale * 1.4)));
+      doc.setTextColor(...C.ink);
+      doc.text(txt, x, y, { align: 'center', baseline: 'middle', maxWidth: Math.max(40, (el?.size?.width ?? 120) * scale) });
+    });
+
+    // Mesas + sillas.
     tables.forEach((tb: any) => {
-      const x = offX + (tb?.position?.x ?? 0) * scale;
-      const y = offY + (tb?.position?.y ?? 0) * scale;
+      const x = sx(tb?.position?.x ?? 0);
+      const y = sy(tb?.position?.y ?? 0);
       const w = (tb?.size?.width ?? 100) * scale;
       const h = (tb?.size?.height ?? 100) * scale;
+      const cx = x + w / 2, cy = y + h / 2;
+      const round = ROUND_TIPOS.includes(tb?.tipo);
+
+      // sillas alrededor del perímetro
+      const N = tb?.numberChair ?? (tb?.guests?.length ?? 0);
+      const occupied = new Set((tb?.guests ?? []).map((g: any) => g?.chair));
+      const chairR = Math.max(2.2, Math.min(w, h) * 0.09);
+      const gap = chairR * 1.35;
+      for (let i = 0; i < N; i++) {
+        let px: number, py: number;
+        if (round) {
+          const th = (i / N) * Math.PI * 2 - Math.PI / 2;
+          px = cx + (w / 2 + gap + chairR) * Math.cos(th);
+          py = cy + (h / 2 + gap + chairR) * Math.sin(th);
+        } else {
+          // recorrido del perímetro del rectángulo
+          const perim = 2 * (w + h);
+          const d = ((i + 0.5) / N) * perim;
+          const off = gap + chairR;
+          if (d < w) { px = x + d; py = y - off; }
+          else if (d < w + h) { px = x + w + off; py = y + (d - w); }
+          else if (d < 2 * w + h) { px = x + w - (d - w - h); py = y + h + off; }
+          else { px = x - off; py = y + h - (d - 2 * w - h); }
+        }
+        if (occupied.has(i)) doc.setFillColor(...C.pink);
+        else doc.setFillColor(...C.chairEmpty);
+        doc.circle(px, py, chairR, 'F');
+      }
+
+      // mesa
       doc.setFillColor(...C.bg); doc.setDrawColor(...C.ink); doc.setLineWidth(1);
-      const round = ['redonda', 'oval', 'podio'].includes(tb?.tipo);
-      if (round) doc.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 'FD');
+      if (round) doc.ellipse(cx, cy, w / 2, h / 2, 'FD');
       else doc.roundedRect(x, y, w, h, 3, 3, 'FD');
       const label = String(tb?.title || tb?.nombre_mesa || '');
       if (label) {
         doc.setFont('helvetica', 'bold');
         doc.setFontSize(Math.max(5, Math.min(9, w / 7)));
         doc.setTextColor(...C.ink);
-        doc.text(label, x + w / 2, y + h / 2, { align: 'center', baseline: 'middle', maxWidth: Math.max(20, w - 4) });
+        doc.text(label, cx, cy, { align: 'center', baseline: 'middle', maxWidth: Math.max(20, w - 4) });
       }
     });
 
-    // ---------- PÁGINAS 2+: invitados por mesa (2 columnas, con salto de página) ----------
+    // ---------- PÁGINAS 2+: invitados por mesa + sin mesa (2 columnas) ----------
     doc.addPage('letter', 'portrait');
     const pw2 = doc.internal.pageSize.getWidth();
     const ph2 = doc.internal.pageSize.getHeight();
@@ -92,6 +157,8 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
       else { doc.addPage('letter', 'portrait'); col = 0; y = topY; }
     };
 
+    const seatedIds = new Set<string>();
+
     if (tables.length === 0) {
       doc.setFont('helvetica', 'normal'); doc.setFontSize(11); doc.setTextColor(...C.muted);
       doc.text('Sin mesas.', M, topY + 6);
@@ -101,13 +168,12 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
       const guests = (tb?.guests ?? [])
         .slice()
         .sort((a: any, b: any) => (a?.chair ?? 0) - (b?.chair ?? 0));
-      const rowH = 13;
-      const headH = 20;
+      guests.forEach((g: any) => { if (g?._id) seatedIds.add(g._id); });
+      const rowH = 13, headH = 20;
       const blockH = headH + Math.max(1, guests.length) * rowH + 8;
       newColumnOrPage(blockH);
       const x = colX[col];
 
-      // header de la mesa
       doc.setFont('helvetica', 'bold'); doc.setFontSize(11); doc.setTextColor(...C.ink);
       const cap = tb?.numberChair ? ` / ${tb.numberChair}` : '';
       doc.text(String(tb?.title || tb?.nombre_mesa || 'Mesa'), x, y + 8, { maxWidth: colW - 40 });
@@ -117,8 +183,7 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
 
       if (guests.length === 0) {
         doc.setFont('helvetica', 'italic'); doc.setFontSize(9); doc.setTextColor(...C.muted);
-        doc.text('Sin invitados', x + 4, y + 2);
-        y += rowH;
+        doc.text('Sin invitados', x + 4, y + 2); y += rowH;
       } else {
         guests.forEach((gg: any) => {
           const guest = guestsById[gg?._id];
@@ -133,6 +198,23 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
       }
       y += 10;
     });
+
+    // Invitados SIN mesa (por sentar).
+    const sinMesa = (event?.invitados_array ?? []).filter((g: any) => g?._id && !seatedIds.has(g._id));
+    if (sinMesa.length > 0) {
+      const rowH = 13;
+      newColumnOrPage(20 + sinMesa.length * rowH + 8);
+      const x = colX[col];
+      doc.setFont('helvetica', 'bold'); doc.setFontSize(11); doc.setTextColor(...C.pink);
+      doc.text(`Sin mesa (${sinMesa.length})`, x, y + 8); y += 20;
+      sinMesa.forEach((g: any) => {
+        doc.setDrawColor(...C.line); doc.setLineWidth(0.5);
+        doc.line(x, y - 3, x + colW, y - 3);
+        doc.setFont('helvetica', 'normal'); doc.setFontSize(9); doc.setTextColor(...C.ink);
+        doc.text(String(g?.nombre || '—'), x + 4, y + 5, { maxWidth: colW - 8 });
+        y += rowH;
+      });
+    }
 
     const fname = `${event?.nombre || 'evento'} ${planoTitle || 'plano'}`
       .replace(/[^a-zA-Z0-9\s]/g, '').replace(/\s+/g, '_') + '.pdf';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       js-cookie:
         specifier: ^3.0.1
         version: 3.0.5
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       lucide-react:
         specifier: ^0.514.0
         version: 0.514.0(react@19.2.4)
@@ -409,9 +412,6 @@ importers:
       '@formkit/auto-animate':
         specifier: ^0.9.0
         version: 0.9.0
-      '@google/genai':
-        specifier: ^1.24.0
-        version: 1.52.0(@modelcontextprotocol/sdk@1.25.2)
       '@icons-pack/react-simple-icons':
         specifier: ^13.8.0
         version: 13.8.0(react@19.2.4)
@@ -430,9 +430,6 @@ importers:
       '@lobechat/electron-client-ipc':
         specifier: workspace:*
         version: link:packages/electron-client-ipc
-      '@lobechat/model-runtime':
-        specifier: workspace:*
-        version: link:packages/model-runtime
       '@lobechat/prompts':
         specifier: workspace:*
         version: link:packages/prompts
@@ -643,12 +640,6 @@ importers:
       oidc-provider:
         specifier: ^9.5.1
         version: 9.6.0
-      ollama:
-        specifier: ^0.6.3
-        version: 0.6.3
-      openai:
-        specifier: ^4.104.0
-        version: 4.104.0(ws@8.19.0)(zod@3.25.76)
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -1787,7 +1778,7 @@ packages:
       '@ant-design/icons': 5.6.1(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       classnames: 2.5.1
       rc-resize-observer: 1.4.3(react-dom@19.2.4)(react@19.2.4)
@@ -1833,7 +1824,7 @@ packages:
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-skeleton': 2.2.1(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       rc-resize-observer: 0.2.6(react-dom@19.2.4)(react@19.2.4)
       rc-util: 5.44.4(react-dom@19.2.4)(react@19.2.4)
@@ -1852,7 +1843,7 @@ packages:
       '@ant-design/icons': 5.6.1(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@chenshuai2144/sketch-color': 1.0.9(react@19.2.4)
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       classnames: 2.5.1
@@ -1878,7 +1869,7 @@ packages:
       '@ant-design/pro-field': 3.1.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@chenshuai2144/sketch-color': 1.0.9(react@19.2.4)
       '@umijs/use-params': 1.0.9(react@19.2.4)
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
@@ -1904,7 +1895,7 @@ packages:
       '@ant-design/icons': 5.6.1(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@umijs/route-utils': 4.0.3
       '@umijs/use-params': 1.0.9(react@19.2.4)
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
@@ -1933,7 +1924,7 @@ packages:
       '@ant-design/pro-field': 3.1.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-table': 3.21.0(antd@5.29.3)(rc-field-form@2.7.1)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       classnames: 2.5.1
       dayjs: 1.11.19
@@ -1953,7 +1944,7 @@ packages:
       react-dom: 19.2.4
     dependencies:
       '@ant-design/cssinjs': 1.24.0(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@ctrl/tinycolor': 3.6.1
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       dayjs: 1.11.19
@@ -1970,7 +1961,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -1991,7 +1982,7 @@ packages:
       '@ant-design/pro-form': 2.32.0(antd@5.29.3)(rc-field-form@2.7.1)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-utils': 2.18.0(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@dnd-kit/core': 6.3.1(react-dom@19.2.4)(react@19.2.4)
       '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.3.1)(react@19.2.4)
       '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.3.1)(react@19.2.4)
@@ -2017,7 +2008,7 @@ packages:
     dependencies:
       '@ant-design/icons': 5.6.1(react-dom@19.2.4)(react@19.2.4)
       '@ant-design/pro-provider': 2.16.2(antd@5.29.3)(react-dom@19.2.4)(react@19.2.4)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       antd: 5.29.3(date-fns@3.6.0)(react-dom@19.2.4)(react@19.2.4)
       classnames: 2.5.1
       dayjs: 1.11.19
@@ -5790,7 +5781,6 @@ packages:
   /@babel/runtime@7.29.7:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/template@7.28.6:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -6649,7 +6639,7 @@ packages:
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
     dependencies:
       '@babel/helper-module-imports': 7.28.6
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -13330,7 +13320,7 @@ packages:
     resolution: {integrity: sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==}
     engines: {node: '>=14.x'}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   /@rc-component/color-picker@2.0.1(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==}
@@ -13351,7 +13341,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       rc-util: 5.44.4(react-dom@19.2.4)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -13360,7 +13350,7 @@ packages:
     resolution: {integrity: sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==}
     engines: {node: '>=8.x'}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   /@rc-component/mutate-observer@1.1.0(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==}
@@ -13382,7 +13372,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.2.4)(react@19.2.4)
       react: 19.2.4
@@ -13509,7 +13499,7 @@ packages:
   /@react-pdf/pdfkit@4.1.0:
     resolution: {integrity: sha512-Wm/IOAv0h/U5Ra94c/PltFJGcpTUd/fwVMVeFD6X9tTTPCttIwg0teRG1Lqq617J8K4W7jpL/B0HTH0mjp3QpQ==}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@react-pdf/png-js': 3.0.0
       browserify-zlib: 0.2.0
       crypto-js: 4.2.0
@@ -13542,7 +13532,7 @@ packages:
   /@react-pdf/render@4.3.2:
     resolution: {integrity: sha512-el5KYM1sH/PKcO4tRCIm8/AIEmhtraaONbwCrBhFdehoGv6JtgnXiMxHGAvZbI5kEg051GbyP+XIU6f6YbOu6Q==}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@react-pdf/fns': 3.1.2
       '@react-pdf/primitives': 4.1.1
       '@react-pdf/textkit': 6.1.0
@@ -14383,7 +14373,7 @@ packages:
       webpack: '>=5.0.0'
     dependencies:
       '@sentry/bundler-plugin-core': 5.2.0
-      webpack: 5.106.0(esbuild@0.25.12)
+      webpack: 5.106.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -16927,6 +16917,10 @@ packages:
       '@types/node': 22.19.6
     dev: true
 
+  /@types/pako@2.0.4:
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+    dev: false
+
   /@types/papaparse@5.5.2:
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
     dependencies:
@@ -16993,6 +16987,12 @@ packages:
     dependencies:
       parchment: 1.1.4
     dev: false
+
+  /@types/raf@3.4.3:
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@types/ramda@0.30.2:
     resolution: {integrity: sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==}
@@ -19214,7 +19214,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       cosmiconfig: 7.1.0
       resolve: 1.22.11
     dev: false
@@ -19365,6 +19365,13 @@ packages:
     requiresBuild: true
     dependencies:
       bare-path: 3.0.0
+    optional: true
+
+  /base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+    requiresBuild: true
+    dev: false
     optional: true
 
   /base64-js@0.0.8:
@@ -19797,6 +19804,22 @@ packages:
     dependencies:
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
+    dev: false
+    optional: true
+
+  /canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/raf': 3.4.3
+      core-js: 3.47.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
     dev: false
     optional: true
 
@@ -20858,6 +20881,14 @@ packages:
     engines: {node: '>=12 || >=16'}
     dev: true
 
+  /css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+    requiresBuild: true
+    dependencies:
+      utrie: 1.0.2
+    dev: false
+    optional: true
+
   /css-mediaquery@0.1.2:
     resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
     dev: false
@@ -21735,7 +21766,7 @@ packages:
   /dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       csstype: 3.2.3
     dev: false
 
@@ -23592,6 +23623,14 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
+  /fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.2.0
+    dev: false
+
   /fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
@@ -25306,6 +25345,16 @@ packages:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
     dev: false
 
+  /html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+    requiresBuild: true
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    dev: false
+    optional: true
+
   /http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
     engines: {node: '>= 0.8'}
@@ -25814,6 +25863,10 @@ packages:
     dependencies:
       loose-envify: 1.4.0
     dev: true
+
+  /iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
+    dev: false
 
   /ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -27139,7 +27192,7 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   /json-schema-traverse@0.4.1:
@@ -27255,6 +27308,19 @@ packages:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.3
+
+  /jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
+    dependencies:
+      '@babel/runtime': 7.29.7
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.47.0
+      dompurify: 3.3.1
+      html2canvas: 1.4.1
+    dev: false
 
   /jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -28241,7 +28307,7 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       complex.js: 2.4.3
       decimal.js: 10.6.0
       escape-latex: 1.2.0
@@ -30298,12 +30364,6 @@ packages:
       - supports-color
     dev: false
 
-  /ollama@0.6.3:
-    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
-    dependencies:
-      whatwg-fetch: 3.6.20
-    dev: false
-
   /on-change@4.0.2:
     resolution: {integrity: sha512-cMtCyuJmTx/bg2HCpHo3ZLeF7FZnBOapLqZHr2AlLeJ5Ul0Zu2mUJJz051Fdwu/Et2YW04ZD+TtU+gVy0ACNCA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -30750,6 +30810,10 @@ packages:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
     dev: false
 
+  /pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+    dev: false
+
   /pangu@4.0.7:
     resolution: {integrity: sha512-weZKJIwwy5gjt4STGVUH9bix3BGk7wZ2ahtIypwe3e/mllsrIZIvtfLx1dPX56GcpZFOCFKmeqI1qVuB9enRzA==}
     hasBin: true
@@ -31016,6 +31080,12 @@ packages:
 
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  /performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -32204,6 +32274,14 @@ packages:
     resolution: {integrity: sha512-yEc24TEgCFLXx7D4JHJJkK4JFVtatO8fziwUxY4nB/Jbea9o9CVS3gt22mA0W7rPYAGW2fWzYDSOtD94PwOyqA==}
     dev: true
 
+  /raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+    requiresBuild: true
+    dependencies:
+      performance-now: 2.1.0
+    dev: false
+    optional: true
+
   /ramda-adjunct@5.1.0(ramda@0.30.1):
     resolution: {integrity: sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==}
     engines: {node: '>=0.10.3'}
@@ -32468,7 +32546,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-resize-observer: 1.4.3(react-dom@19.2.4)(react@19.2.4)
       rc-util: 5.44.4(react-dom@19.2.4)(react@19.2.4)
@@ -32549,7 +32627,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.2.4)(react@19.2.4)
       react: 19.2.4
@@ -32755,7 +32833,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-is: 18.3.1
@@ -32767,7 +32845,7 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-resize-observer: 1.4.3(react-dom@19.2.4)(react@19.2.4)
       rc-util: 5.44.4(react-dom@19.2.4)(react@19.2.4)
@@ -32800,7 +32878,7 @@ packages:
       react-dom: 19.2.4
     dependencies:
       '@babel/plugin-transform-runtime': 7.28.5(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       prop-types: 15.8.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -32951,7 +33029,7 @@ packages:
       react: 19.2.4
     dependencies:
       react: 19.2.4
-      unlayer-types: 1.441.0
+      unlayer-types: 1.464.0
     dev: false
 
   /react-error-boundary@5.0.0(react@19.2.4):
@@ -32959,7 +33037,7 @@ packages:
     peerDependencies:
       react: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       react: 19.2.4
     dev: false
 
@@ -33143,7 +33221,7 @@ packages:
     peerDependencies:
       react: 19.2.4
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/css': 11.13.5
       react: 19.2.4
     transitivePeerDependencies:
@@ -33813,7 +33891,7 @@ packages:
   /redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
     dev: true
 
   /redux@5.0.1:
@@ -33851,6 +33929,12 @@ packages:
   /regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
     dev: true
+
+  /regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -35167,6 +35251,13 @@ packages:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
     dev: true
 
+  /rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -36203,6 +36294,13 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
@@ -36780,6 +36878,13 @@ packages:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
     dev: true
 
+  /svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
     dev: true
@@ -37061,6 +37166,29 @@ packages:
       webpack: 5.106.0(esbuild@0.25.12)
     dev: false
 
+  /terser-webpack-plugin@5.4.0(webpack@5.106.0):
+    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.1
+      webpack: 5.106.0
+    dev: false
+
   /terser@5.46.1:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
     engines: {node: '>=10'}
@@ -37105,6 +37233,14 @@ packages:
   /text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
     dev: true
+
+  /text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+    requiresBuild: true
+    dependencies:
+      utrie: 1.0.2
+    dev: false
+    optional: true
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -38111,8 +38247,8 @@ packages:
       normalize-path: 2.1.1
     dev: true
 
-  /unlayer-types@1.441.0:
-    resolution: {integrity: sha512-kv517UseH1plEpm11xANkIS4jx7rwpvT/7KPHepEnVn3JQitZ0te+XkznG37+1bfXcFJcyKlpI0wznlU4aPJTw==}
+  /unlayer-types@1.464.0:
+    resolution: {integrity: sha512-z4Bi5gkA1BOpl0YLpbJZwVI1L3vj4I5T71cbeYVdC3qHeoeMHqiM8g4j5tmJNoRczAMYdrjBQRDA1DeDzg4XWg==}
     dev: false
 
   /unpipe@1.0.0:
@@ -38285,6 +38421,14 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  /utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+    requiresBuild: true
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    dev: false
+    optional: true
 
   /uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
@@ -38801,6 +38945,47 @@ packages:
     dev: false
     optional: true
 
+  /webpack@5.106.0:
+    resolution: {integrity: sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.20.1
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.4.0(webpack@5.106.0)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: false
+
   /webpack@5.106.0(esbuild@0.25.12):
     resolution: {integrity: sha512-Pkx5joZ9RrdgO5LBkyX1L2ZAJeK/Taz3vqZ9CbcP0wS5LEMx5QkKsEwLl29QJfihZ+DKRBFldzy1O30pJ1MDpA==}
     engines: {node: '>=10.13.0'}
@@ -38871,10 +39056,6 @@ packages:
     dependencies:
       iconv-lite: 0.6.3
     dev: true
-
-  /whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
-    dev: false
 
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}


### PR DESCRIPTION
Verificado en app-dev. 4 commits:
- Texto: 'Escribe aquí' + papelera/lápiz circulares + pill rosa + tamaño de letra (+/-); sin barra lateral izq; sin fondo blanco en display.
- Exportar PDF: descarga real (jsPDF) — croquis del plano (mesas+sillas+textos+muebles) + invitados por mesa + sin mesa.
- Resumen 'por espacio': clic en un espacio cambia el plano.
Type-check + lint limpios. +dep jspdf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)