### PR TITLE
💄 feat(mesas/pdf): plano capturado como en la app (html2canvas) + quitar Guardar plantilla

### DIFF
--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -117,67 +117,29 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
                   <div className="bg-white flex flex-col absolute z-[10] top-[0px] right-0 rounded-b-md shadow-md min-w-[140px] md:min-w-[120px] items-center text-[10px] md:text-[12px] px-3 pt-1 pb-2 text-gray-800">
                     {/* Exportar PDF — movido aquí desde el icono suelto (plano más limpio) */}
                     <button
-                      onClick={() => {
+                      onClick={async () => {
                         setShowMiniMenu(false)
-                        const ok = exportPlanoPdf({ planSpaceActive, event, planoTitle: t(planSpaceActive?.title) })
+                        // Capturar el LIENZO tal cual se ve en la app (html2canvas) para que
+                        // el PDF del plano sea idéntico. Si falla, exportPlanoPdf cae al croquis.
+                        let planoImage: string | undefined
+                        try {
+                          const html2canvas = (await import('html2canvas')).default
+                          const el = document.getElementById('lienzo-drop')
+                          if (el) {
+                            const canvas = await html2canvas(el, { backgroundColor: '#F3F1EC', scale: 2, useCORS: true, logging: false } as any)
+                            planoImage = canvas.toDataURL('image/png')
+                          }
+                        } catch (e) {
+                          console.warn('[exportPDF] captura del plano falló; uso croquis vectorial:', e)
+                        }
+                        const ok = exportPlanoPdf({ planSpaceActive, event, planoTitle: t(planSpaceActive?.title), planoImage })
                         if (!ok) toast('error', t('pdferror') || 'No se pudo generar el PDF')
                       }}
                       className="w-full flex items-center gap-2 text-left font-semibold py-1.5 mb-1 border-b border-gray-100 hover:text-primary"
                     >
                       <mdIcons.MdPictureAsPdf className="w-4 h-4 text-primary" />{t('exportpdf') || 'Exportar PDF'}
                     </button>
-                    <span className="w-full text-left font-bold transform -ml-2">{t("savetemplate")}</span>
-                    <span className="flex flex-col text-[9px] md:text-[11px]">
-                      <span className="capitalize">{t("names")}</span>
-                      <input
-                        type="text"
-                        value={value}
-                        onChange={(e) => {
-                          setValue(e.target.value)
-                          const exists = psTemplates?.some(t => t.title === e.target.value)
-                          setident(!!exists)
-                        }}
-                        placeholder={t("templatename") || "Nombre del plano"}
-                        className="w-full border border-gray-300 rounded px-2 py-1 text-xs mt-1 focus:border-primary focus:outline-none"
-                      />
-                      <div className="relative">
-                        {!valir && <p className="w-[75%] font-display absolute rounded-xl text-xs left-0 bottom-0 transform translate-y-full text-red flex gap-1"><WarningIcon className="w-4 h-4" />{t("saveitreplaces")}</p>}
-                      </div>
-                      <div className="w-full flex justify-end mt-2 ">
-                        <button onClick={async () => {
-                          if (ident && valir) {
-                            setValir(!valir)
-                            return
-                          }
-                          if (value !== "") {
-                            setShowMiniMenu(false)
-                            setValir(true)
-                            if (!valir) {
-                              //aqui actualizo en vez de guarda
-                            } else {
-                              const resp = await fetchApiEventos({
-                                query: queries.createPsTemplate,
-                                variables: {
-                                  evento_id: event._id,
-                                  template: {
-                                    planSpaceID: planSpaceActive._id,
-                                    title: value,
-                                    uid: user?.uid
-                                  }
-                                }
-                              })
-                              setPsTemplates(old => {
-                                old.push(resp)
-                                return [...old]
-                              })
-                            }
-                          }
-                          setValue("")
-                          toast("success", t("savedtemplate"))
-                        }}
-                          className="bg-primary w-16 h-5 rounded-lg text-white capitalize">{t("save")}</button>
-                      </div>
-                    </span>
+                    {/* "Guardar como plantilla" eliminado del menú (petición): solo Exportar PDF. */}
                   </div>
                 </div>
               }

--- a/apps/appEventos/package.json
+++ b/apps/appEventos/package.json
@@ -51,6 +51,7 @@
     "googleapis": "^126.0.1",
     "graphql": "^16.11.0",
     "heic2any": "^0.0.4",
+    "html2canvas": "^1.4.1",
     "i18next": "^23.15.1",
     "i18next-browser-languagedetector": "^8.2.0",
     "interactjs": "^1.10.17",

--- a/apps/appEventos/utils/exportPlanoPdf.ts
+++ b/apps/appEventos/utils/exportPlanoPdf.ts
@@ -8,6 +8,9 @@ interface ExportArgs {
   planSpaceActive: any
   event: any
   planoTitle: string
+  // Captura del lienzo (html2canvas, dataURL PNG). Si viene, la página 1 muestra el
+  // plano TAL CUAL en la app. Si no, se dibuja el croquis vectorial.
+  planoImage?: string
 }
 
 // Colores de marca (RGB para jsPDF).
@@ -27,7 +30,7 @@ const stripHtml = (s: any): string =>
 
 const ROUND_TIPOS = ['redonda', 'oval', 'podio'];
 
-export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArgs): boolean => {
+export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle, planoImage }: ExportArgs): boolean => {
   try {
     const tables: any[] = planSpaceActive?.tables ?? [];
     const elements: any[] = planSpaceActive?.elements ?? [];
@@ -50,6 +53,21 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
     doc.setDrawColor(...C.border); doc.setLineWidth(1);
     doc.roundedRect(areaX, areaY, areaW, areaH, 8, 8, 'S');
 
+    // Si viene la CAPTURA del plano (html2canvas) → la pintamos = idéntico a la app.
+    let usedImage = false;
+    if (planoImage) {
+      try {
+        const props: any = doc.getImageProperties(planoImage);
+        const pad = 10;
+        const r = Math.min((areaW - pad * 2) / props.width, (areaH - pad * 2) / props.height);
+        const iw = props.width * r, ih = props.height * r;
+        doc.addImage(planoImage, 'PNG', areaX + (areaW - iw) / 2, areaY + (areaH - ih) / 2, iw, ih);
+        usedImage = true;
+      } catch { /* imagen inválida → se dibuja el croquis vectorial abajo */ }
+    }
+
+    // Croquis vectorial: SOLO si no se pudo usar la captura de la app.
+    if (!usedImage) {
     const W = planSpaceActive?.size?.width || 1400;
     const H = planSpaceActive?.size?.height || 1400;
     // pad para que las sillas del borde no se salgan del área
@@ -135,6 +153,7 @@ export const exportPlanoPdf = ({ planSpaceActive, event, planoTitle }: ExportArg
         doc.text(label, cx, cy, { align: 'center', baseline: 'middle', maxWidth: Math.max(20, w - 4) });
       }
     });
+    } // fin croquis vectorial (solo si no hubo captura de la app)
 
     // ---------- PÁGINAS 2+: invitados por mesa + sin mesa (2 columnas) ----------
     doc.addPage('letter', 'portrait');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       heic2any:
         specifier: ^0.0.4
         version: 0.0.4
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       i18next:
         specifier: ^23.15.1
         version: 23.16.8
@@ -19372,7 +19375,6 @@ packages:
     engines: {node: '>= 0.6.0'}
     requiresBuild: true
     dev: false
-    optional: true
 
   /base64-js@0.0.8:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
@@ -20887,7 +20889,6 @@ packages:
     dependencies:
       utrie: 1.0.2
     dev: false
-    optional: true
 
   /css-mediaquery@0.1.2:
     resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
@@ -25353,7 +25354,6 @@ packages:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
     dev: false
-    optional: true
 
   /http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
@@ -37240,7 +37240,6 @@ packages:
     dependencies:
       utrie: 1.0.2
     dev: false
-    optional: true
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -38428,7 +38427,6 @@ packages:
     dependencies:
       base64-arraybuffer: 1.0.2
     dev: false
-    optional: true
 
   /uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}


### PR DESCRIPTION
Feedback: (1) el PDF del plano debe verse como en la app → captura #lienzo-drop con html2canvas = página 1 idéntica; lista de invitados por mesa en páginas siguientes. (2) Quitado 'Guardar como plantilla' del menú. Verificado app-dev sq4MR7TmnGu9k85LQSi7h. +dep html2canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)