### PR TITLE
💄 fix(mesas): PDF captura #lienzo-drop (iconos+cuadrícula) + ocupación 0–100%

### DIFF
--- a/apps/appEventos/components/Mesas/BlockResumen.tsx
+++ b/apps/appEventos/components/Mesas/BlockResumen.tsx
@@ -39,11 +39,20 @@ const BlockResumen: FC<propsBlockResumen> = ({ InvitadoSentados }) => {
         const sentados = ps?.tables?.length
             ? ps.tables.map((tb) => tb.guests).flat().filter(Boolean).length
             : 0
-        return { _id: ps?._id, title: ps?.title, sentados, pct: totalInvitados ? Math.round((sentados / totalInvitados) * 100) : 0 }
+        return { _id: ps?._id, title: ps?.title, sentados, pct: totalInvitados ? Math.min(100, Math.round((sentados / totalInvitados) * 100)) : 0 }
     })
-    const totalSentados = perSpace.reduce((a, p) => a + p.sentados, 0)
+    // Sentados TOTALES = invitados ÚNICOS sentados en cualquier plano (un invitado sentado
+    // en Recepción Y Ceremonia cuenta 1, no 2). Antes se sumaban los per-space → daba >100%.
+    const seatedIds = new Set<string>()
+    ;(event?.planSpace || []).forEach((ps: any) =>
+        (ps?.tables || []).forEach((tb: any) =>
+            (tb?.guests || []).forEach((g: any) => { if (g?._id) seatedIds.add(g._id) })
+        )
+    )
+    const totalSentados = seatedIds.size
     const totalMesas = event?.mesas_array?.length || 0
-    const overallPct = totalInvitados ? Math.round((totalSentados / totalInvitados) * 100) : 0
+    // Ocupación acotada a 0–100% (no puede haber más sentados únicos que invitados).
+    const overallPct = totalInvitados ? Math.min(100, Math.round((totalSentados / totalInvitados) * 100)) : 0
 
     const stats = [
         { n: totalMesas, l: t("tables") || "Mesas" },

--- a/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
+++ b/apps/appEventos/components/Mesas/ComponenteTransformWrapper.tsx
@@ -124,28 +124,32 @@ export const ComponenteTransformWrapper: FC<propsComponenteTransformWrapper> = (
                         // no en #lienzo-drop; por eso capturamos el wrapper (cuadrícula + mesas
                         // + muebles + textos, exactamente como se ve). Si falla → croquis vectorial.
                         let planoImage: string | undefined
-                        // Guardar el encuadre actual para restaurarlo tras la foto.
-                        const prevT = { x: state?.positionX ?? 0, y: state?.positionY ?? 0, s: state?.scale ?? scaleIni }
                         try {
                           const html2canvas = (await import('html2canvas')).default
-                          // Encuadrar el plano ENTERO (mismo fit que al abrir) para que salgan
-                          // TODAS las mesas, muebles y textos — no solo lo visible al zoom actual.
-                          try { centerView(scaleIni) } catch { /* noop */ }
-                          await new Promise((r) => setTimeout(r, 500))
-                          const el =
-                            (document.querySelector('.react-transform-wrapper') as HTMLElement | null) ||
-                            document.getElementById('lienzo-drop')
+                          // Capturar el CONTENIDO del plano (#lienzo-drop) a tamaño natural = el
+                          // plano ENTERO con mesas, sillas, ICONOS de mobiliario y TEXTOS. NO se
+                          // captura el wrapper del zoom (.react-transform-wrapper): su transform
+                          // rompe html2canvas (por eso salía el croquis de fallback). Se añade la
+                          // cuadrícula temporal por CSS para que la foto salga como en la web.
+                          const el = document.getElementById('lienzo-drop')
                           if (el) {
-                            const canvas = await html2canvas(el, { allowTaint: true, backgroundColor: '#F3F1EC', logging: false, scale: 2, useCORS: true } as any)
-                            planoImage = canvas.toDataURL('image/png')
+                            const prev = { background: el.style.background, backgroundImage: el.style.backgroundImage, backgroundSize: el.style.backgroundSize }
+                            el.style.background = '#F3F1EC'
+                            el.style.backgroundImage = 'linear-gradient(#E4E1D8 1px, transparent 1px), linear-gradient(90deg, #E4E1D8 1px, transparent 1px)'
+                            el.style.backgroundSize = '44px 44px'
+                            const w = el.scrollWidth || (lienzo?.width ?? 0)
+                            const h = el.scrollHeight || (lienzo?.height ?? 0)
+                            try {
+                              const canvas = await html2canvas(el, { backgroundColor: '#F3F1EC', height: h, logging: false, scale: 2, useCORS: true, width: w, windowHeight: h, windowWidth: w } as any)
+                              planoImage = canvas.toDataURL('image/png')
+                            } finally {
+                              el.style.background = prev.background
+                              el.style.backgroundImage = prev.backgroundImage
+                              el.style.backgroundSize = prev.backgroundSize
+                            }
                           }
                         } catch (e) {
                           console.warn('[exportPDF] captura del plano falló; uso croquis vectorial:', e)
-                        } finally {
-                          // Restaurar el encuadre que tenía el usuario.
-                          const st = (params as any)?.setTransform
-                          if (typeof st === 'function') st(prevT.x, prevT.y, prevT.s, 0)
-                          else try { centerView(prevT.s) } catch { /* noop */ }
                         }
                         const ok = exportPlanoPdf({ planSpaceActive, event, planoTitle: t(planSpaceActive?.title), planoImage })
                         if (!ok) toast('error', t('pdferror') || 'No se pudo generar el PDF')


### PR DESCRIPTION
PDF: capturar #lienzo-drop (el transform de .react-transform-wrapper rompía html2canvas → croquis sin iconos) + cuadrícula temporal CSS → foto con iconos/textos/cuadrícula. Ocupación: invitados únicos sentados + cap 0-100% (era 191% por doble conteo). app-dev nZCbQhLSGDW00QTj8Kkut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)