### PR TITLE
🐛 fix(files): heredar evento activo + selector propio (#9) y no flashear muro guest (#10)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/files/(content)/FileGuestGate.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/files/(content)/FileGuestGate.tsx
@@ -6,7 +6,10 @@ import { FolderLock, Sparkles } from 'lucide-react';
 import { memo, type ReactNode } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
+import CircleLoading from '@/components/Loading/CircleLoading';
 import { useDomainGuestUser } from '@/hooks/useDomainGuestUser';
+import { useUserStore } from '@/store/user';
+import { preferenceSelectors } from '@/store/user/selectors';
 
 // BUG QA 30-jul: el gate mandaba a app*.bodasdehoy.com/login (la app de eventos) →
 // desde chat-dev saltaba a PRODUCCIÓN (app.bodasdehoy.com) y sacaba al usuario de
@@ -65,6 +68,20 @@ const FileGuestGate = memo<{ children: ReactNode }>(({ children }) => {
   // useDomainGuestUser (requiere !isSignedIn Y confirmación del chat store), consistente
   // con el fix raíz de auth (PR #207). Evita la caída silenciosa a visitante.
   const isGuest = useDomainGuestUser();
+  // #10 (QA 5-ago): no decidir "invitado" hasta que el estado de usuario esté
+  // inicializado. Antes, durante el arranque de auth (recarga forzada), el gate caía
+  // a guest=true por defecto y mostraba el muro de "Crear cuenta" pese a haber sesión
+  // válida (falso-negativo). Mientras inicializa, mostramos loader (no cambiamos la
+  // lógica de determinación de guest → cero impacto de seguridad).
+  const isUserStateInit = useUserStore(preferenceSelectors.isPreferenceInit);
+
+  if (!isUserStateInit) {
+    return (
+      <Flexbox className={styles.container} gap={16}>
+        <CircleLoading />
+      </Flexbox>
+    );
+  }
 
   if (isGuest) {
     return (

--- a/apps/chat-ia/src/features/Portal/Home/Body/Files/StorageFileList/index.tsx
+++ b/apps/chat-ia/src/features/Portal/Home/Body/Files/StorageFileList/index.tsx
@@ -18,6 +18,7 @@ import { Center, Flexbox } from 'react-layout-kit';
 import { Input, Select, Button, Segmented, Tooltip, message, Alert } from 'antd';
 import Balancer from 'react-wrap-balancer';
 
+import EventSelector from '@/components/EventSelector';
 import Loading from '@/components/Loading/CircleLoading';
 import { useWallet } from '@/hooks/useWallet';
 import { listEventFiles, getCurrentEventId, type StorageFile, deleteFile } from '@/services/storage-r2';
@@ -44,7 +45,39 @@ const StorageFileList = () => {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [refreshing, setRefreshing] = useState(false);
 
-  const eventId = useMemo(() => getCurrentEventId(), []);
+  // #9 (QA 5-ago): antes era useMemo(..., []) → se leía UNA vez y /files no
+  // reaccionaba al evento activo elegido en el header (ActiveEventChip) ni al
+  // contexto standalone (#266). Ahora es estado reactivo y se re-sincroniza con
+  // `chatia:activeEventChanged` (mismo canal que usa todo lo demás) y con `storage`.
+  const [eventId, setEventId] = useState<string | null>(() => getCurrentEventId());
+  useEffect(() => {
+    const sync = () => setEventId(getCurrentEventId());
+    window.addEventListener('chatia:activeEventChanged', sync);
+    window.addEventListener('storage', sync);
+    return () => {
+      window.removeEventListener('chatia:activeEventChanged', sync);
+      window.removeEventListener('storage', sync);
+    };
+  }, []);
+
+  // #9: tenant activo para el selector de eventos (mismo criterio que el resto de la app).
+  const development =
+    (typeof window !== 'undefined' && localStorage.getItem('current_development')) || 'bodasdehoy';
+
+  // #9: al elegir evento en /files persistimos el key canónico + disparamos el evento
+  // global (idéntico a ActiveEventChip) para que el resto de la app quede en sync.
+  const handleSelectEvent = useCallback((id: string, evento: any) => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('current_event_id', id);
+    const name = evento?.nombre || evento?.name;
+    if (name) localStorage.setItem('current_event_name', name);
+    window.dispatchEvent(
+      new CustomEvent('chatia:activeEventChanged', {
+        detail: { eventId: id, source: 'files-picker' },
+      }),
+    );
+    setEventId(id);
+  }, []);
 
   const loadFiles = useCallback(async (eventIdToUse: string, showLoading = true) => {
     if (showLoading) {
@@ -193,6 +226,16 @@ const StorageFileList = () => {
             Selecciona un evento para ver sus archivos
           </Text>
         </Balancer>
+        {/* #9 (QA 5-ago): antes NO había forma de elegir evento en /files. Ahora el
+            usuario que entra directo puede seleccionarlo aquí mismo. */}
+        <div style={{ marginTop: 8, minWidth: 260 }}>
+          <EventSelector
+            development={development}
+            onChange={handleSelectEvent}
+            placeholder="Selecciona un evento"
+            value={eventId ?? undefined}
+          />
+        </div>
       </Center>
     );
   }

--- a/apps/chat-ia/src/services/storage-r2.ts
+++ b/apps/chat-ia/src/services/storage-r2.ts
@@ -221,8 +221,14 @@ export async function deleteFile(fileId: string, eventId?: string): Promise<{ er
  */
 export function getCurrentEventId(): string | null {
   if (typeof window === 'undefined') return null;
-  
+
   try {
+    // Clave canónica top-level: la que fijan el header (ActiveEventChip) y el
+    // contexto standalone (#266) al seleccionar evento. /files debe heredar de ahí
+    // (antes solo miraba dev-user-config → no heredaba el evento de /asistente). QA #9.
+    const topLevel = localStorage.getItem('current_event_id');
+    if (topLevel) return topLevel;
+
     const devConfig = localStorage.getItem('dev-user-config');
     if (devConfig) {
       const config = JSON.parse(devConfig);


### PR DESCRIPTION
## Contexto
QA CODIFICADOR (5-ago). Dos fallos de la ruta `/files`.

## #9 — /files no heredaba el evento y no tenía selector
**Root cause:** `getCurrentEventId()` solo miraba `dev-user-config.current_event_id`, pero el header (`ActiveEventChip`) y el contexto standalone (#266) fijan el key canónico **top-level** `current_event_id` → desajuste de claves → /files nunca veía el evento de /asistente.

**Fix:**
- `getCurrentEventId()` lee primero el key canónico top-level.
- `StorageFileList`: `eventId` pasa de `useMemo(once)` a **estado reactivo** que escucha `chatia:activeEventChanged` + `storage` → hereda en vivo.
- Se añade `<EventSelector>` en el estado vacío → quien entra directo a /files puede elegir evento (persiste el key canónico + dispara el evento global, idéntico a `ActiveEventChip`).

## #10 — muro "usuario no registrado" al recargar con sesión válida
**Root cause:** `FileGuestGate` decidía guest **antes** de que el estado de usuario inicializara (durante el arranque de auth, `useDomainGuestUser` cae a guest=true por defecto).

**Fix:** esperar a `isUserStateInit` (`preferenceSelectors`) y mostrar loader mientras tanto. **NO cambia la lógica de `useDomainGuestUser`** → cero impacto de seguridad (un guest real sigue bloqueado tras init).

## Verificación
- `eslint`: 0 errores (solo warnings `any` preexistentes del estilo del repo).
- Typecheck autoritativo en el `next build` del deploy.
- Re-QA: en /files sin evento → aparece selector; elegir evento → carga archivos; recargar con sesión → NO muro guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)