### PR TITLE
🐛 fix(chat/P0): metadata.pageContext.activeEventId — asistente ya no pide elegir evento

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/StandaloneEventContext.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/StandaloneEventContext.tsx
@@ -28,14 +28,24 @@ const StandaloneEventContext = () => {
         // Si hay contexto del embed pendiente, lo maneja ContextFromEmbed (más rico).
         if (sessionStorage.getItem('copilot_open_context')) return;
         const eventId = localStorage.getItem('current_event_id');
-        if (!eventId) return;
         const eventName = localStorage.getItem('current_event_name') || '';
 
         const lines = [MARK_START];
-        if (eventName) lines.push(`Evento: ${eventName}`);
-        lines.push(`ID de evento: ${eventId}`, 
-          'Cuando el usuario pida ver su presupuesto, itinerario o servicios, invoca show_event_section con este eventoId.', MARK_END
-        );
+        if (eventId) {
+          if (eventName) lines.push(`Evento: ${eventName}`);
+          lines.push(
+            `ID de evento: ${eventId}`,
+            'Cuando el usuario pida ver su presupuesto, itinerario o servicios, invoca show_event_section con este eventoId.',
+            MARK_END,
+          );
+        } else {
+          // [P1] Sin evento activo: que el asistente PREGUNTE de qué evento, no responda a ciegas.
+          lines.push(
+            'El usuario NO tiene un evento activo seleccionado.',
+            'Si pregunta sobre presupuesto, itinerario, servicios o invitados de un evento, NO respondas sin evento: pregúntale "¿De qué evento hablamos?" o pídele que lo elija en el selector del encabezado.',
+            MARK_END,
+          );
+        }
         const contextBlock = lines.join('\n');
 
         const [{ useAgentStore }, { agentSelectors }] = await Promise.all([

--- a/apps/chat-ia/src/services/chat/index.ts
+++ b/apps/chat-ia/src/services/chat/index.ts
@@ -487,6 +487,17 @@ class ChatService {
         ...(finalPayload as any).metadata,
         development: development || undefined,
         eventId: eventId || undefined,
+        // [P0] api-ia lee el evento activo en metadata.pageContext.activeEventId (ANIDADO),
+        // no en metadata.eventId (plano). Sin esto el asistente pedía "selecciona un evento"
+        // aunque hubiera evento activo (desajuste de shape). eventId plano queda de fallback.
+        pageContext: {
+          ...((finalPayload as any).metadata?.pageContext),
+          activeEventId: eventId || undefined,
+          availableEvents: (userEvents || [])
+            .map((e: any) => ({ id: e._id || e.id || e.id_evento, name: e.nombre || e.titulo || e.name }))
+            .filter((e: any) => e.id),
+          eventScope: eventId ? 'active' : 'all',
+        },
         userId: currentUserId || undefined,
       };
     }


### PR DESCRIPTION
Causa raíz (shape mismatch): front mandaba metadata.eventId (plano), api-ia lee metadata.pageContext.activeEventId (anidado). getChatCompletion añade metadata.pageContext {activeEventId, eventScope, availableEvents} (aditivo, eventId fallback). [P1] StandaloneEventContext: sin evento activo, instruye al asistente a PREGUNTAR de qué evento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)