### PR TITLE
🐛 fix(chat-panel): fallback a evento activo cuando el LLM no pasa eventoId

### DIFF
--- a/apps/chat-ia/src/store/chat/slices/builtinTool/actions/eventPanel.ts
+++ b/apps/chat-ia/src/store/chat/slices/builtinTool/actions/eventPanel.ts
@@ -10,11 +10,26 @@ interface ShowEventSectionData {
 
 /** Estado que consume el Portal (event-panel/Portal). */
 export interface EventPanelState {
-  error?: 'not_found' | 'fetch_failed';
+  error?: 'not_found' | 'fetch_failed' | 'no_event';
   evento?: unknown;
   loading?: boolean;
   section?: string;
 }
+
+const OBJECT_ID_RE = /^[\da-f]{24}$/i;
+
+/**
+ * Resuelve el eventoId del panel. El LLM no siempre pasa un `eventoId` válido en
+ * `show_event_section`; en ese caso caemos al evento activo que fija el selector
+ * (`ActiveEventChip`) / el sync cross-app en `localStorage.current_event_id`.
+ * Devuelve '' si no hay ninguno válido (el caller marca `no_event`).
+ */
+const resolveEventoId = (fromLLM?: string): string => {
+  if (fromLLM && OBJECT_ID_RE.test(fromLLM)) return fromLLM;
+  if (typeof window === 'undefined') return '';
+  const active = window.localStorage.getItem('current_event_id') || '';
+  return OBJECT_ID_RE.test(active) ? active : '';
+};
 
 export interface ChatEventPanelAction {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -36,13 +51,15 @@ export const eventPanelSlice: StateCreator<
     openToolUI(id, 'lobe-event-panel');
     await updatePluginState(id, { loading: true, section } as EventPanelState);
 
-    if (!eventoId) {
-      await updatePluginState(id, { error: 'not_found', section } as EventPanelState);
+    // Fallback: si el LLM no pasó un eventoId válido, usar el evento activo del selector.
+    const resolvedId = resolveEventoId(eventoId);
+    if (!resolvedId) {
+      await updatePluginState(id, { error: 'no_event', section } as EventPanelState);
       return;
     }
 
     try {
-      const evento = await getEventoDetalle(eventoId);
+      const evento = await getEventoDetalle(resolvedId);
       // BUG#5 (api-mcp DB caída): distinguir "no encontrado" de "error de servidor"
       // no es posible aquí sin más señal → si no hay evento, marcarlo como not_found
       // (el consumer muestra estado honesto + reintento, no miente con datos vacíos).

--- a/apps/chat-ia/src/tools/event-panel/Portal/index.tsx
+++ b/apps/chat-ia/src/tools/event-panel/Portal/index.tsx
@@ -160,6 +160,16 @@ const EventPanelPortal = memo<BuiltinPortalProps<{ eventoId?: string; section?: 
         </div>
       );
     }
+    if (error === 'no_event') {
+      return (
+        <div style={wrap}>
+          <div style={{ fontWeight: 600 }}>¿De qué evento?</div>
+          <div style={{ color: '#6b7280', marginTop: 8 }}>
+            No tienes un evento activo. Elige uno en el selector del encabezado y vuelve a pedírmelo.
+          </div>
+        </div>
+      );
+    }
     if (error === 'not_found') {
       return (
         <div style={wrap}>


### PR DESCRIPTION
## Qué
`show_event_section` (tool del panel del evento) dependía de que el LLM pasara un `eventoId` válido; si no, el panel se quedaba en `not_found`. Ahora:
- Resuelve el `eventoId` con **fallback a `localStorage.current_event_id`** (el que fija el selector `ActiveEventChip` / el sync cross-app), validando forma ObjectId (24 hex).
- Nuevo estado honesto **`no_event`** ("¿De qué evento? — elige uno en el selector") en vez de `not_found` cuando no hay ninguno.

## Por qué
Robustez pendiente de la **sub-capacidad A (panel visual)** del plan "el asistente responde sobre MI evento". El lado texto (api-ia) ya auto-inyecta `activeEventId` en sus read-tools; el panel es client-side y no se beneficiaba de eso.

## Alcance
Solo `apps/chat-ia`: `eventPanel.ts` (acción store) + `event-panel/Portal` (render del estado). Sin cambios de API ni backend.

## Verificación
- eslint + tsc de los 2 ficheros: limpio.
- Manual pendiente en chat-dev: pedir "muéstrame el presupuesto" con evento en el chip y **sin** que el modelo pase eventoId → el panel abre igualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)