### PR TITLE
⚡️ fix(bandeja/H2): dedup de GET concurrentes de /conversations

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 
 import { buildHeaders } from '../utils/auth';
+import { dedupeFetch } from '../utils/dedupeFetch';
 import { friendlyContactName, safePhoneOrEmpty } from '../utils/jid';
 import { useMessageStream } from './useMessageStream';
 
@@ -66,7 +67,8 @@ export function useConversations(channel: string | null) {
           ? `${proxyBase}/whatsapp/conversations/${dev}`
           : `${proxyBase}/conversations?development=${dev}&channel=${channel}`;
 
-      const response = await fetch(fetchUrl, { headers });
+      // H2: dedup de GET concurrentes idénticos (feed + detalle piden el mismo recurso).
+      const response = await dedupeFetch(fetchUrl, { headers });
 
       if (response.ok) {
         const data = await response.json();

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useRecentConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useRecentConversations.ts
@@ -7,6 +7,7 @@ import { getWhatsAppChannels, getWhatsAppConversationsGQL } from '@/services/mcp
 
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 import { buildHeaders } from '../utils/auth';
+import { dedupeFetch } from '../utils/dedupeFetch';
 import { friendlyContactName } from '../utils/jid';
 import { useMessageStream } from './useMessageStream';
 
@@ -92,7 +93,7 @@ export function useRecentConversations(max = 50, refreshKey = 0) {
 
         // Fetch WhatsApp conversations
         // Primary: REST via Baileys (live sessions). Fallback: GraphQL api2 store (works even if external WA service is down).
-        const waPromise = fetch(`/api/messages/whatsapp/conversations/${dev}`, {
+        const waPromise = dedupeFetch(`/api/messages/whatsapp/conversations/${dev}`, {
           headers: buildHeaders(),
         })
           .then(async (res) => {
@@ -153,7 +154,7 @@ export function useRecentConversations(max = 50, refreshKey = 0) {
 
         // Fetch other channels conversations (if backend supports them)
         const otherChannels: ChannelKind[] = ['instagram', 'telegram', 'email', 'web', 'facebook'];
-        const othersPromise = fetch(`/api/messages/conversations?development=${dev}`, {
+        const othersPromise = dedupeFetch(`/api/messages/conversations?development=${dev}`, {
           headers: buildHeaders(),
         })
           .then(async (res) => {

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/utils/dedupeFetch.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/utils/dedupeFetch.ts
@@ -1,0 +1,33 @@
+/**
+ * dedupeFetch — coalesce IN-FLIGHT identical GETs (H2, QA 5-ago).
+ *
+ * La Bandeja monta varias listas a la vez (feed `useRecentConversations` + detalle
+ * `useConversations`, y a veces `ConversationListWithFallback`→`ConversationListInner`),
+ * que piden EL MISMO recurso (`/whatsapp/conversations/{dev}`, `/conversations`) de forma
+ * simultánea → 2-3 GET idénticos por apertura ("Cargando mensajes…" lento).
+ *
+ * Este helper NO cachea en el tiempo: solo comparte la promesa mientras una petición
+ * idéntica está EN VUELO. En cuanto resuelve, se descarta del mapa → la siguiente petición
+ * (p.ej. el refetch del SSE) vuelve a la red y NO sirve datos viejos. Cada consumidor recibe
+ * un `clone()` de la Response, así puede leer status + body de forma independiente.
+ */
+const inflight = new Map<string, Promise<Response>>();
+
+type FetchInit = Parameters<typeof fetch>[1];
+
+export function dedupeFetch(url: string, init?: FetchInit): Promise<Response> {
+  // Solo deduplicamos GET (las escrituras nunca se coalescen).
+  const method = (init?.method || 'GET').toUpperCase();
+  if (method !== 'GET') return fetch(url, init);
+
+  const key = `${method} ${url}`;
+  let pending = inflight.get(key);
+  if (!pending) {
+    pending = fetch(url, init).finally(() => {
+      inflight.delete(key);
+    });
+    inflight.set(key, pending);
+  }
+  // clone(): la Response original nunca se lee directamente; cada llamante lee su copia.
+  return pending.then((res) => res.clone());
+}


### PR DESCRIPTION
## Qué (QA H2)
QA (5-ago) reportó **2-3 GET simultáneos idénticos** al abrir una conversación de Bandeja (`/conversations` x3), percibido como lentitud "Cargando mensajes…".

**Causa (verificada en código):** el feed (`useRecentConversations`) y la lista de detalle (`useConversations`), más la ruta fallback (`ConversationListWithFallback`→`ConversationListInner`), piden **el mismo recurso** (`/whatsapp/conversations/{dev}`, `/conversations`) a la vez, sin dedup compartido.

## Fix
`dedupeFetch()` — coalesce peticiones **GET idénticas EN VUELO** (comparte la promesa mientras la request está viva, la descarta al resolver). **No cachea en el tiempo** → el refetch del SSE sigue yendo a la red, sin riesgo de datos viejos. Cada consumidor recibe un `clone()` de la Response (status + body independientes).

Cableado en los 3 fetch de conversaciones. **Sin cambios de estructura de componentes ni de filtros.**

## Alcance
Solo `apps/chat-ia/.../bandeja`: nuevo `utils/dedupeFetch.ts` + `hooks/useConversations.ts` + `hooks/useRecentConversations.ts`.

## Verificación
- eslint del util + tsc: limpio. (Los sort-keys de los hooks son **preexistentes** en las interfaces/mappers, no introducidos aquí.)
- Manual pendiente en chat-dev: abrir una conversación → un solo GET de `/conversations` en Network.

## No incluido
**H1** (la ruta detalle no hereda el filtro del feed: 6 → 11) es arquitectural (feed y detalle son dos listas) y queda pendiente de un fix con verificación runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)