### PR TITLE
🐛 fix(chat): /files en routesToSkip (nav #9/#1) + badge falsa-versión (#20)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/loading/Client/Redirect.tsx
+++ b/apps/chat-ia/src/app/[variants]/loading/Client/Redirect.tsx
@@ -45,6 +45,7 @@ const Redirect = memo<RedirectProps>(({ setActiveStage }) => {
         '/image',
         '/changelog',
         '/agentes',
+        '/files',
       ];
       
       // Si estamos en una de estas rutas, NO redirigir
@@ -90,6 +91,7 @@ const Redirect = memo<RedirectProps>(({ setActiveStage }) => {
         '/image',
         '/changelog',
         '/agentes',
+        '/files',
       ];
       
       // Si estamos en una de estas rutas, NO hacer NADA - salir inmediatamente

--- a/apps/chat-ia/src/features/User/UserPanel/useNewVersion.tsx
+++ b/apps/chat-ia/src/features/User/UserPanel/useNewVersion.tsx
@@ -1,5 +1,4 @@
 import { useGlobalStore } from '@/store/global';
-import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
 export const useNewVersion = () => {
   const [hasNewVersion, useCheckLatestVersion] = useGlobalStore((s) => [
@@ -7,8 +6,11 @@ export const useNewVersion = () => {
     s.useCheckLatestVersion,
   ]);
 
-  const { enableCheckUpdates } = useServerConfigStore(featureFlagsSelectors);
-  useCheckLatestVersion(enableCheckUpdates);
+  // Fork bodasdehoy (QA #20, 5-ago): el check compara CURRENT_VERSION (fork, p.ej. v1.0.1)
+  // contra el ÚLTIMO release de LobeChat upstream (p.ej. v1.143.3) → falsa alarma permanente
+  // "Nueva versión disponible". La comparación con upstream no tiene sentido en el fork.
+  // Desactivado hasta que exista una fuente de versión propia del fork.
+  useCheckLatestVersion(false);
 
   return hasNewVersion;
 };


### PR DESCRIPTION
## QA 5-ago

### #9 / #1 (parte /files) — el icono "Archivos" no navega
`Client/Redirect.tsx` redirige a `/asistente` **toda ruta que no esté en `routesToSkip`**, y `'/files'` **faltaba** en los 2 arrays (línea 30 y 75) → clic en Archivos / deep-link a `/files` rebotaba a `/asistente`. **Fix:** añadido `'/files'` a ambos arrays (mismo patrón que `/labs`, `/pendientes`, etc.).

### #20 — badge "Nueva versión disponible v1.143.3" con v1.0.1 instalada
`useNewVersion` llamaba `useCheckLatestVersion(enableCheckUpdates)`, que compara `CURRENT_VERSION` (fork) contra el **último release de LobeChat upstream** (`general.ts:143`) → falsa alarma permanente. **Fix:** desactivado (`useCheckLatestVersion(false)`) — la comparación con upstream no aplica al fork.

## Alcance
Solo `apps/chat-ia`: `loading/Client/Redirect.tsx` (+2 líneas) + `features/User/UserPanel/useNewVersion.tsx`. Sin cambios de API.

## Verificación
- eslint de `useNewVersion`: limpio; tsc limpio. (Los unused-vars de `Redirect.tsx` son **preexistentes**, no introducidos aquí.)
- Manual pendiente en chat-dev: clic en "Archivos" navega a `/files`; el badge de "nueva versión" no aparece.

## No incluido
`Server/Redirect.tsx` (lista más corta, no es el guard operativo de estas rutas) · el reset de estado tras el loop de #1 (parte no-/files) queda para el fix de estado runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)