### PR TITLE
🎨 fix(bandeja/A4): contraste tema oscuro (Conectar canal + Ver newsletters)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx
@@ -208,6 +208,9 @@ export default function MessagesPage() {
                     aria-pressed={showSpam}
                     className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600 hover:bg-gray-100"
                     onClick={toggleShowSpam}
+                    // A4 (QA 6-ago): color inline gana al override global del tema oscuro
+                    // (el repo no usa variantes dark:), evitando texto invisible sobre el bg blanco.
+                    style={{ color: '#4b5563' }}
                     type="button"
                   >
                     {showSpam ? '📢 Ocultar newsletters/estados' : '👁 Ver newsletters/estados'}
@@ -256,6 +259,8 @@ export default function MessagesPage() {
                     <button
                       className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-100"
                       onClick={() => router.push('/settings/integrations')}
+                      // A4 (QA 6-ago): color inline evita texto invisible en tema oscuro.
+                      style={{ color: '#374151' }}
                       type="button"
                     >
                       Conectar canal


### PR DESCRIPTION
## QA 6-ago (A4)
Ambos botones invisibles en tema oscuro (texto = color del fondo blanco): **"Conectar canal"** ([page.tsx:257](apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx)) y toggle **"Ver newsletters/estados"** ([page.tsx:213](apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx)).

## Causa
La Bandeja usa Tailwind claro hardcodeado (`bg-white text-gray-*`) y el repo **no usa variantes `dark:`**; el tema oscuro (antd-style) sobreescribe el color de texto → texto invisible sobre el bg blanco.

## Fix
Color de texto **inline** en los 2 botones (gana especificidad sobre el override global) → legible en oscuro, **sin regresión en claro** (mismo tono gris). Fix acotado a los 2 elementos confirmados por QA.

## Nota
A4 completo es sistémico (la Bandeja no es dark-theme-aware); esto cierra los 2 elementos reportados. Si QA detecta más, se hace un pase con tokens de tema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)