### PR TITLE
⚡️ fix(bandeja/H2-resto): dedup del GET de /messages al abrir conversación

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useMessages.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useMessages.ts
@@ -6,6 +6,7 @@ import { useAuthCheck } from '@/hooks/useAuthCheck';
 
 import { getWhatsAppMessagesGQL } from '@/services/mcpApi/whatsapp';
 import { buildHeaders, parseWhatsAppConversationId } from '../utils/auth';
+import { dedupeFetch } from '../utils/dedupeFetch';
 import { useMessageStream } from './useMessageStream';
 import type { StreamMessage } from './useMessageStream';
 
@@ -122,7 +123,8 @@ export function useMessages(channel: string, conversationId: string) {
 
     try {
       setLoading(true);
-      const response = await fetch(url, { headers: buildHeaders() });
+      // H2-resto: dedup de GET concurrentes idénticos (el detalle monta useMessages 2x al abrir).
+      const response = await dedupeFetch(url, { headers: buildHeaders() });
 
       if (!response.ok) {
         if (response.status === 404) {


### PR DESCRIPTION
## QA 6-ago (HML)
FIX-H2 (#279) bajó de 3 a 2 los GET al abrir una conversación, pero quedaban **2 GET duplicados a `/api/messages/conversations/{id}/messages`** (el detalle monta `useMessages` 2× al abrir).

## Fix
Aplico el mismo `dedupeFetch` al fetch de mensajes (`useMessages.ts:126`): coalesce GET concurrentes idénticos **en vuelo**, sin cache en el tiempo → el polling/SSE-refresh siguen yendo a la red. Completa #279.

## Verificación
- eslint limpio.
- Manual pendiente: abrir conversación → **1 solo** GET a `/messages` en Network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)