### PR TITLE
⚡️ fix(bandeja): dedup del GET de ia-config (nota H2 de QA)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationHeader.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationHeader.tsx
@@ -7,6 +7,7 @@ import { useConversationActions } from '../hooks/useConversationActions';
 import { ConversationStatus, useConversationMeta } from '../hooks/useConversationMeta';
 import { ChannelBadge } from './ChannelBadge';
 import { useBandejaBrand } from '../utils/brand';
+import { dedupeFetch } from '../utils/dedupeFetch';
 import { IaLevelPicker, type IaLevel } from './IaLevelPicker';
 
 interface ConversationHeaderProps {
@@ -68,7 +69,8 @@ export function ConversationHeader({
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`/api/messages/workspace/${encodeURIComponent(development)}/ia-config`);
+        // H2 (QA 6-ago): dedup del GET de ia-config (el header se monta 2x al abrir).
+        const res = await dedupeFetch(`/api/messages/workspace/${encodeURIComponent(development)}/ia-config`);
         if (!res.ok) return;
         const json = await res.json();
         const lvl = json?.config?.ia_level;


### PR DESCRIPTION
QA 6-ago: FIX-H2 dejó conversations/messages en 1 GET, pero `ia-config` seguía 2x (ConversationHeader se monta 2x al abrir). Aplico `dedupeFetch` al GET de `/api/messages/workspace/{dev}/ia-config` (el POST intacto). Mismo patrón validado en #279/#282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)