### PR TITLE
🎨 fix(mesas): selección con ring en vez de relleno gris que tapa la mesa

### DIFF
--- a/apps/appEventos/components/Mesas/DragableDefault.tsx
+++ b/apps/appEventos/components/Mesas/DragableDefault.tsx
@@ -125,7 +125,7 @@ export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWra
         })
         !disableDrag && setDisableWrapper(false)
       }}
-      className={`${!disableDrag ? prefijo === "table" || item?.tipo === "text" ? "js-drag" : "js-dragElement" : ""} ${editDefault?.clicked === item?._id ? "bg-gray-200 bg-opacity-50 border-gray-300 shadow-md" : ""} draggable-touch absolute hover:bg-gray-300 hover:bg-opacity-50 border border-transparent hover:border-gray-200 hover:shadow-md ${prefijo === "table" ? "p-10" : "p-3"} rounded-2xl ${editDefault?.clicked === item?._id ? "z-10" : ""}`} style={prefijo === "table" || item?.tipo === "text" ? { rotate: `${item?.rotation ?? 0}deg` } : {}} >
+      className={`${!disableDrag ? prefijo === "table" || item?.tipo === "text" ? "js-drag" : "js-dragElement" : ""} ${editDefault?.clicked === item?._id ? "ring-2 ring-primary shadow-md" : ""} draggable-touch absolute border border-transparent hover:ring-2 hover:ring-gray-300 hover:shadow-md ${prefijo === "table" ? "p-10" : "p-3"} rounded-2xl ${editDefault?.clicked === item?._id ? "z-10" : ""}`} style={prefijo === "table" || item?.tipo === "text" ? { rotate: `${item?.rotation ?? 0}deg` } : {}} >
       <div className="relative">
         {prefijo === "table"
           ? <MesaContent


### PR DESCRIPTION
## Bug QA
Al crear una mesa (queda auto-seleccionada) aparece cubierta por una **mancha gris translúcida** — parece "solo un círculo con el número", ocultando forma + sillas. El mismo overlay sale al seleccionar cualquier mesa existente y en hover.

## Causa raíz
[DragableDefault.tsx:128](apps/appEventos/components/Mesas/DragableDefault.tsx#L128): el estado seleccionado (`editDefault.clicked === item._id`) aplicaba `bg-gray-200 bg-opacity-50 border-gray-300 shadow-md` sobre el wrapper (con `p-10`), superponiéndose a la mesa. Igual en hover (`hover:bg-gray-300 hover:bg-opacity-50`). Más notorio al zoom por defecto (~40%), donde el borde fino no se ve.

## Fix (opción 2 del ticket)
- Seleccionado: **`ring-2 ring-primary`** (contorno rosa de marca) — sin relleno.
- Hover: **`ring-2 ring-gray-300`** — sin relleno.
- La mesa y sus sillas quedan visibles en ambos estados. `ring-` ya se usa en el repo; `primary` = `#ec4899`.

## Alcance / notas
- Cubre el caso de mesa nueva, la selección manual y el hover — **una sola causa**.
- No cambio la auto-selección al crear (el ring la hace correcta) ni datos. Sin errores de consola/red (era puro estado/estilo).
- Regresión visual (ticket #4): pendiente de QA visual en app-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)