### PR TITLE
🐛 fix(bandeja/A2): el detalle usa la fuente combinada del feed (no re-pide por canal)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
@@ -62,26 +62,40 @@ export function useConversations(channel: string | null) {
       const headers = buildHeaders();
       const dev = development || 'bodasdehoy';
 
-      const fetchUrl =
-        channel === 'whatsapp' || !channel
-          ? `${proxyBase}/whatsapp/conversations/${dev}`
-          : `${proxyBase}/conversations?development=${dev}&channel=${channel}`;
+      // A2 (QA 6-ago): el detalle debe usar la MISMA fuente COMBINADA que el feed
+      // (useRecentConversations: WhatsApp + otros canales), NO re-pedir
+      // /conversations?channel=X — ese endpoint solo indexa WhatsApp → devolvía vacío para
+      // web/IG/TG (vaciaba toda la lista) o desalineado con el feed para WhatsApp. Combinamos
+      // ambas fuentes + dedup por id + filtro de canal en cliente. dedupeFetch coalescE los
+      // GET concurrentes (el feed ya pide los mismos).
+      const [waRes, otherRes] = await Promise.all([
+        dedupeFetch(`${proxyBase}/whatsapp/conversations/${dev}`, { headers }),
+        dedupeFetch(`${proxyBase}/conversations?development=${dev}`, { headers }),
+      ]);
 
-      // H2: dedup de GET concurrentes idénticos (feed + detalle piden el mismo recurso).
-      const response = await dedupeFetch(fetchUrl, { headers });
+      const readRaw = async (res: Response, sourceKind: string): Promise<any[]> => {
+        if (!res.ok) return [];
+        try {
+          const data = await res.json();
+          const arr = Array.isArray(data) ? data : data.conversations || [];
+          return arr.map((c: any) => ({ ...c, __sourceKind: sourceKind }));
+        } catch {
+          return [];
+        }
+      };
 
-      if (response.ok) {
-        const data = await response.json();
-        const rawList = Array.isArray(data) ? data : data.conversations || [];
-        // N31 CERRADO 24-jun (api-ia commit 665097b normalizó lastMessage).
-        // Mantengo `|| ''` como cinturón-tirantes por canal legacy sin migrar.
-        // N33 activa: parseJid en api-ia sigue pendiente. Defensa vive en
-        // utils/jid.ts (friendlyContactName + classifyJidLike). Ver docs/AUTH-FLOW.md.
+      if (waRes.ok || otherRes.ok) {
+        // Mismo criterio de canal que useRecentConversations: WA→'whatsapp'; otros→'web' por defecto.
+        const rawList = [
+          ...(await readRaw(waRes, 'whatsapp')),
+          ...(await readRaw(otherRes, 'web')),
+        ];
+        // N31/N33: lastMessage/JID defensivos (utils/jid.ts). Ver docs/AUTH-FLOW.md.
         const normalized: Conversation[] = rawList.map((c: any) => {
           const rawName = c.displayName || c.contactInfo?.name || c.phoneNumber || '';
           return {
             assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
-            channel: (c.channel || c.platform || channel || 'whatsapp') as Conversation['channel'],
+            channel: (c.channel || c.platform || c.__sourceKind || 'whatsapp') as Conversation['channel'],
             contact: {
               name: friendlyContactName(rawName, c.phoneNumber, c.jidType ?? c.jid_type),
               phone: safePhoneOrEmpty(c.phoneNumber, c.jidType ?? c.jid_type),
@@ -110,15 +124,23 @@ export function useConversations(channel: string | null) {
             unreadCountForAgent: c.unreadCountForAgent ?? c.unread_count_for_agent ?? undefined,
           };
         });
-        const filtered = channel ? normalized.filter((c) => c.channel === channel) : normalized;
+        // Dedup por id (ambas fuentes pueden solapar en WhatsApp).
+        const seen = new Set<string>();
+        const deduped = normalized.filter((c) => {
+          const key = String(c.id ?? '');
+          if (!key || seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+        const filtered = channel ? deduped.filter((c) => c.channel === channel) : deduped;
         setConversations(filtered);
         setError(null);
-      } else if (response.status === 401 || response.status === 403) {
+      } else if ([waRes.status, otherRes.status].some((s) => s === 401 || s === 403)) {
         setConversations([]);
         setError(null);
       } else {
         setConversations([]);
-        setError(new Error(`Error ${response.status} al cargar conversaciones`));
+        setError(new Error('Error al cargar conversaciones'));
       }
     } catch (err) {
       setConversations([]);


### PR DESCRIPTION
## QA 6-ago (evidencia Network)
Al abrir una conversación, el detalle re-pedía `GET /api/messages/conversations?channel=X` — endpoint que **solo indexa WhatsApp**: para web/IG/TG devolvía `{conversations:[]}` → **vaciaba toda la lista** (grave); para WhatsApp, sin los filtros del feed (5→10).

## Fix (recomendación del QA: 'usar la misma fuente combinada')
`useConversations` ahora usa la **misma fuente combinada** que `useRecentConversations`/el feed: fetch de `/whatsapp/conversations` + `/conversations` (sin `channel`), **dedup por id**, mismo criterio de canal (WA→whatsapp, otros→web) y filtro de canal en cliente. Así el detalle no se vacía para no-WA y se alinea con el feed. `dedupeFetch` coalescE los GET (el feed ya los pide).

## Verificación
- eslint/tsc: sin errores nuevos (los sort-keys/any son preexistentes). **Requiere verificación visual de QA** en el próximo build (abrir conversación Web/IG/TG NO debe vaciar la lista; WhatsApp mantiene el filtro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)