### PR TITLE
🚑 fix(bandeja/P0): brand is not defined — crash al abrir conversación WhatsApp

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationList.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ConversationList.tsx
@@ -60,6 +60,10 @@ type InboxView = 'all' | 'mine' | 'unassigned' | 'closed';
 
 function ConversationListInner({ channel, selectedId }: ConversationListProps) {
   const { conversations, loading, error } = useConversations(channel);
+  // P0 (QA 6-ago): ConversationListInner usaba `brand.brand` (líneas ~221/277) sin definir
+  // `brand` → ReferenceError que crasheaba toda la app al renderizar el contador "N sin leer"
+  // (solo se disparaba con no-leídos > 0). Definirlo aquí como en ConversationList/ChannelConversationList.
+  const brand = useBandejaBrand();
   const { isArchived } = useConversationActions();
   const metaState = useConversationMetaState();
   const { checkAuth } = useAuthCheck();


### PR DESCRIPTION
## P0 (QA 6-ago)
`ReferenceError: brand is not defined` rompe toda la app al abrir una conversación de **WhatsApp** en Bandeja. `ConversationListInner` usaba `brand.brand` (contador '{totalUnread} sin leer' + hover) **sin definir `brand`** en su scope. Landmine latente desde 24-jul; se dispara con no-leídos > 0.

## Fix
`const brand = useBandejaBrand()` en `ConversationListInner` (como en `ConversationList`/`ChannelConversationList`). tsc: "Cannot find name 'brand'" resuelto.

## Nota
El crash de **/agentes** (mismo error) NO pasa por ConversationListInner (AgentsCoworkView→MessagesRail, que define brand OK) → si persiste tras este deploy, necesito el stack trace de consola para pincharlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)