### PR TITLE
chore(appEventos): bind de pnpm dev a 0.0.0.0 y ignorar analisis/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ resultados-bateria-api2-*.json
 test-results/
 .agent-browser/
 node_modules
+
+# Análisis local (no versionar)
+analisis/

--- a/apps/appEventos/package.json
+++ b/apps/appEventos/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "scripts": {
-    "dev": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 127.0.0.1 -p 3220",
+    "dev": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 0.0.0.0 -p 3220",
     "dev:local": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 0.0.0.0 -p 3220",
     "dev:hmr": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 127.0.0.1 -p 3225",
     "dev:3001": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 0.0.0.0 -p 3001",


### PR DESCRIPTION
Permite acceso al servidor de desarrollo desde VPN/túnel (no solo loopback) e ignora la carpeta local de análisis.