### PR TITLE
🎨 fix(mesas): ring de selección pegado a la forma (no al wrapper p-10)

### DIFF
--- a/apps/appEventos/components/Mesas/DragableDefault.tsx
+++ b/apps/appEventos/components/Mesas/DragableDefault.tsx
@@ -125,8 +125,10 @@ export const DragableDefault: FC<propsTable> = forwardRef(({ item, setDisableWra
         })
         !disableDrag && setDisableWrapper(false)
       }}
-      className={`${!disableDrag ? prefijo === "table" || item?.tipo === "text" ? "js-drag" : "js-dragElement" : ""} ${editDefault?.clicked === item?._id ? "ring-2 ring-primary shadow-md" : ""} draggable-touch absolute border border-transparent hover:ring-2 hover:ring-gray-300 hover:shadow-md ${prefijo === "table" ? "p-10" : "p-3"} rounded-2xl ${editDefault?.clicked === item?._id ? "z-10" : ""}`} style={prefijo === "table" || item?.tipo === "text" ? { rotate: `${item?.rotation ?? 0}deg` } : {}} >
-      <div className="relative">
+      className={`${!disableDrag ? prefijo === "table" || item?.tipo === "text" ? "js-drag" : "js-dragElement" : ""} ${editDefault?.clicked === item?._id ? "shadow-md" : ""} group draggable-touch absolute border border-transparent hover:shadow-md ${prefijo === "table" ? "p-10" : "p-3"} rounded-2xl ${editDefault?.clicked === item?._id ? "z-10" : ""}`} style={prefijo === "table" || item?.tipo === "text" ? { rotate: `${item?.rotation ?? 0}deg` } : {}} >
+      {/* Ring de selección/hover pegado a la FORMA (no al wrapper con p-10, que dejaba el ring
+          40px fuera del círculo → QA no lo veía). Seleccionada = ring rosa; hover = ring gris. */}
+      <div className={`relative rounded-2xl ${editDefault?.clicked === item?._id ? "ring-2 ring-primary" : "group-hover:ring-2 group-hover:ring-gray-300"}`}>
         {prefijo === "table"
           ? <MesaContent
             table={item as table}


### PR DESCRIPTION
QA (7-ago): el ring de #285 no se veía — estaba en el wrapper con `p-10` (40px fuera del círculo). Lo muevo al div interno (envuelve la forma) → ring rosa (seleccionada) / gris (hover) pegados a la mesa, patrón `group`. Solo className. **Requiere verificación visual de QA.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)