### PR TITLE
🚑 fix(auth): rutas login/refresh al host canónico (arregla 503 de /agentes)

### DIFF
--- a/apps/chat-ia/src/app/(backend)/api/auth/firebase-login/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/auth/firebase-login/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
+
 export const runtime = 'nodejs';
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_IA_URL || process.env.API_IA_URL || 'https://api-ia.bodasdehoy.com';
+// 503 firebase-login (QA 7-ago): la ruta de auth caía al fallback FLAKY `api-ia.bodasdehoy.com`
+// (zona con 526/503 intermitente CF↔origin). Uso el resolver canónico, que cae a
+// DEFAULT_API_IA_ORIGIN (eventosorganizador, no-flaky) cuando el env no está seteado — igual
+// que el proxy de messages.
+const BACKEND_URL = resolveServerBackendOrigin();
 
 /**
  * Proxy server-side para POST /api/auth/firebase-login

--- a/apps/chat-ia/src/hooks/useTokenRefresh.ts
+++ b/apps/chat-ia/src/hooks/useTokenRefresh.ts
@@ -12,6 +12,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { message } from 'antd';
 import { onAuthStateChanged, type User } from 'firebase/auth';
 
+import { resolvePublicBackendOrigin } from '@/const/backendEndpoints';
+
 // Importar auth de forma lazy para evitar errores en SSR
 let auth: any = null;
 const getAuth = async () => {
@@ -29,7 +31,10 @@ interface TokenRefreshStatus {
   nextRefresh: Date | null;
 }
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_API_IA_URL || 'http://localhost:8030';
+// 503 firebase-login (QA 7-ago): usaba NEXT_PUBLIC_API_IA_URL (zona FLAKY bodasdehoy) con
+// fallback a localhost. El resolver canónico cae a DEFAULT_API_IA_ORIGIN (eventosorganizador,
+// no-flaky) — alinea la renovación de JWT con el proxy de messages y quita el 503 de /agentes.
+const BACKEND_URL = resolvePublicBackendOrigin();
 
 // Configuración
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // Verificar cada 5 minutos


### PR DESCRIPTION
## QA 7-ago
/agentes cuelga por `POST /api/auth/firebase-login → 503`. Raíz (verificada en código): las rutas de AUTH caían a la zona **FLAKY** `api-ia.bodasdehoy.com` (526/503 intermitente CF↔origin) — usaban `NEXT_PUBLIC_API_IA_URL` con fallback viejo (bodasdehoy/localhost), mientras el proxy de messages ya usa el resolver canónico.

## Fix
- `firebase-login/route.ts` → `resolveServerBackendOrigin()`
- `useTokenRefresh.ts` → `resolvePublicBackendOrigin()`

Ambos caen a `DEFAULT_API_IA_ORIGIN` (`api-ia.eventosorganizador.com`, no-flaky) cuando el env no está seteado. Cierra las 2 rutas de auth que no cubrió el fix #4. tsc limpio (los sort-keys/any son preexistentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)