### PR TITLE
🚑 fix(chat/agentes): proxy chat + getUserState al host canónico (502→200)

### DIFF
--- a/apps/chat-ia/src/app/(backend)/api/backend/[...path]/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/backend/[...path]/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
+
 export const runtime = 'nodejs';
 
-const getBackendUrl = (): string =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+// 502 chat (QA 7-ago): el proxy de chat (topics/messages/sessions) caía al fallback FLAKY
+// `api-ia.bodasdehoy.com` (526/502 intermitente CF↔origin) → el asistente no respondía.
+// api-ia origen está vivo (localhost:8030=200); el problema era el host. Uso el resolver
+// canónico (api-ia.eventosorganizador.com, no-flaky) como el resto de proxies.
+const getBackendUrl = (): string => resolveServerBackendOrigin();
 
 /**
  * Proxy catch-all: /api/backend/[...path] → api-ia/{path}

--- a/apps/chat-ia/src/services/user/apiIa.ts
+++ b/apps/chat-ia/src/services/user/apiIa.ts
@@ -1,5 +1,6 @@
 import type { PartialDeep } from 'type-fest';
 
+import { resolvePublicBackendOrigin } from '@/const/backendEndpoints';
 import { UserGuide, UserInitializationState, UserPreference } from '@/types/user';
 import { UserSettings } from '@/types/user/settings';
 
@@ -12,7 +13,10 @@ import { IUserService } from './type';
 // los stubs getUserSSOProviders/unlinkSSOProvider y la UI SSOProvidersList se
 // borraron por inútiles (siempre retornaban []).
 
-const API_IA_BASE = process.env.NEXT_PUBLIC_API_IA_URL || 'http://localhost:8080';
+// /agentes carga infinita (QA 7-ago): getUserState pegaba a NEXT_PUBLIC_API_IA_URL || localhost:8080
+// (inalcanzable desde el browser si el env no está seteado) → timeout 5s → pantalla colgada.
+// Resolver canónico (browser): api-ia.eventosorganizador.com (no-flaky).
+const API_IA_BASE = resolvePublicBackendOrigin();
 
 function getUserConfigContext(): { development: string; idToken?: string; userId?: string } {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
QA 7-ago: chat 100% caído (topics/messages/sessions/openai 502, asistente no responde) + /agentes carga infinita. Raíz: api-ia origen VIVO (localhost:8030=200) pero el **proxy de chat** `api/backend/[...path]` usaba el fallback FLAKY `api-ia.bodasdehoy.com` (el fix #293 migró messages+auth pero NO este), y **getUserState** (`services/user/apiIa.ts`) apuntaba a `localhost:8080` sin env → timeout → /agentes colgado. Ambos migrados al resolver canónico. Desbloquea B/C/E. Quedan ~13 ficheros más con el mismo fallback (sweep aparte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)