### PR TITLE
🧹 fix(backend-proxies): barrido — 12 rutas al host api-ia canónico (cierra clase 502)

### DIFF
--- a/apps/chat-ia/src/app/(backend)/api/auth/identify-user/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/auth/identify-user/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 // Forzar uso del runtime de Node.js para poder hacer peticiones HTTP
 export const runtime = 'nodejs';
 
 const getBackendUrl = (): string =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 /**
  * API Route: Identificar Usuario

--- a/apps/chat-ia/src/app/(backend)/api/auth/save-user-config/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/auth/save-user-config/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 export const runtime = 'nodejs';
 
 const getBackendUrl = (): string =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 /**
  * Proxy: POST /api/auth/save-user-config → backend api-ia

--- a/apps/chat-ia/src/app/(backend)/api/memories/[...path]/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/memories/[...path]/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 export const runtime = 'nodejs';
 
 const getBackendUrl = (): string =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 /**
  * Proxy catch-all: /api/memories/[...path] → api-ia/api/memories/[...path]

--- a/apps/chat-ia/src/app/(backend)/api/storage/files/[fileId]/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/storage/files/[fileId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 /**
  * API Route para obtener URL de archivo desde Storage R2
  * 
@@ -20,9 +21,7 @@ export async function GET(
     const development = request.headers.get('X-Development') || 'bodasdehoy';
     const userId = request.headers.get('X-User-ID') || request.headers.get('X-User-Email') || 'anonymous';
 
-    const backendUrl = process.env.API_IA_URL || 
-                       process.env.NEXT_PUBLIC_API_IA_URL || 
-                       'https://api-ia.bodasdehoy.com';
+    const backendUrl = resolveServerBackendOrigin();
 
     const url = `${backendUrl}/api/storage/files/${fileId}?version=${version}${eventId ? `&event_id=${eventId}` : ''}`;
 
@@ -68,9 +67,7 @@ export async function DELETE(
     const development = request.headers.get('X-Development') || 'bodasdehoy';
     const userId = request.headers.get('X-User-ID') || request.headers.get('X-User-Email') || 'anonymous';
 
-    const backendUrl = process.env.API_IA_URL || 
-                       process.env.NEXT_PUBLIC_API_IA_URL || 
-                       'https://api-ia.bodasdehoy.com';
+    const backendUrl = resolveServerBackendOrigin();
 
     const url = `${backendUrl}/api/storage/files/${fileId}${eventId ? `?event_id=${eventId}` : ''}`;
 

--- a/apps/chat-ia/src/app/(backend)/api/storage/proxy-image/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/storage/proxy-image/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 const BACKEND_URL =
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 /**
  * GET /api/storage/proxy-image?url=<encoded-image-url>

--- a/apps/chat-ia/src/app/(backend)/api/storage/upload/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/storage/upload/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 const BACKEND_URL =
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 const PROXY_TIMEOUT_MS = 30_000;
 

--- a/apps/chat-ia/src/app/(backend)/api/widget-chat/route.ts
+++ b/apps/chat-ia/src/app/(backend)/api/widget-chat/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 export const runtime = 'nodejs';
 export const maxDuration = 300;
 
 const WIDGET_MSG_LIMIT = 10;
 
 const getApiIaUrl = (): string =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 /**
  * POST /api/widget-chat

--- a/apps/chat-ia/src/app/(backend)/webapi/create-image/comfyui/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/create-image/comfyui/route.ts
@@ -9,13 +9,12 @@
 
 import { NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 export const runtime = 'nodejs';
 export const maxDuration = 300;
 
 const getBackendUrl = () =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 export const POST = async (req: Request) => {
   const backendUrl = getBackendUrl();

--- a/apps/chat-ia/src/app/(backend)/webapi/stt/openai/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/stt/openai/route.ts
@@ -1,3 +1,4 @@
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 /**
  * STT proxy → api-ia backend
  * No llama a OpenAI directamente. El audio pasa por api-ia para
@@ -9,9 +10,7 @@
 export const runtime = 'edge';
 
 const getBackendUrl = () =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 export const POST = async (req: Request) => {
   const backendUrl = getBackendUrl();

--- a/apps/chat-ia/src/app/(backend)/webapi/tts/edge/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/tts/edge/route.ts
@@ -1,3 +1,4 @@
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 /**
  * Edge Speech TTS proxy → api-ia backend
  * Migrado 2026-05-20 LOTE 5. Antes usaba @lobehub/tts EdgeSpeechTTS local
@@ -8,9 +9,7 @@
 export const runtime = 'edge';
 
 const getBackendUrl = () =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 export const POST = async (req: Request) => {
   const backendUrl = getBackendUrl();

--- a/apps/chat-ia/src/app/(backend)/webapi/tts/microsoft/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/tts/microsoft/route.ts
@@ -1,3 +1,4 @@
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 /**
  * Microsoft Speech TTS proxy → api-ia backend
  * Migrado 2026-05-20 LOTE 5. Antes usaba @lobehub/tts MicrosoftSpeechTTS local.
@@ -7,9 +8,7 @@
 export const runtime = 'edge';
 
 const getBackendUrl = () =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 export const POST = async (req: Request) => {
   const backendUrl = getBackendUrl();

--- a/apps/chat-ia/src/app/(backend)/webapi/tts/openai/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/tts/openai/route.ts
@@ -1,3 +1,4 @@
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
 /**
  * TTS proxy → api-ia backend
  * No llama a OpenAI directamente. Todo el audio pasa por api-ia para
@@ -9,9 +10,7 @@
 export const runtime = 'edge';
 
 const getBackendUrl = () =>
-  process.env.API_IA_URL ||
-  process.env.NEXT_PUBLIC_API_IA_URL ||
-  'https://api-ia.bodasdehoy.com';
+  resolveServerBackendOrigin();
 
 export const POST = async (req: Request) => {
   const backendUrl = getBackendUrl();


### PR DESCRIPTION
Tras los parches puntuales (#293 auth+messages, #294 chat+getUserState), quedaban **12 rutas (backend)** con el mismo fallback FLAKY `api-ia.bodasdehoy.com`: auth (save-user-config, identify-user), storage (proxy-image, upload, files), widget-chat, memories, webapi (tts×3, stt, create-image). Migradas todas a `resolveServerBackendOrigin()` (canónico, no-flaky) por script + dry-run (13 reemplazos, tsc limpio). Cierra la clase de 502 por rutas sueltas.

**Follow-up menor:** config/route, config/[developer], plugin/gateway, text-to-image, models usan `API_IA_URL || NEXT_PUBLIC_API_IA_URL` sin fallback (→ undefined si env vacío) — migrar aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)