### PR TITLE
🐛 fix: A2-web (clasificación canal bandeja) + G-01 (/files React #418)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
@@ -75,7 +75,13 @@ interface MessageInputProps {
 
 /** Banner "canal desvinculado / solo lectura" (TICKET P1). Ámbar semántico fijo; el
  *  botón primario [Reconectar] usa el color de MARCA del whitelabel (no #EF5B94 fijo). */
-function ChannelInactiveBanner({ brandColor }: { brandColor: string }) {
+function ChannelInactiveBanner({ brandColor, channel }: { brandColor: string; channel?: string }) {
+  // A2-web: no rotular "WhatsApp anterior" en canales que NO son WhatsApp (el banner se
+  // colaba en conversaciones Web). Texto genérico salvo en el canal de WhatsApp.
+  const label =
+    channel === 'whatsapp' || !channel
+      ? 'Conexión de WhatsApp anterior — solo lectura'
+      : 'Este canal está en solo lectura';
   return (
     <div
       style={{
@@ -90,7 +96,7 @@ function ChannelInactiveBanner({ brandColor }: { brandColor: string }) {
     >
       <span aria-hidden style={{ color: '#B07E14', flexShrink: 0, fontSize: 16 }}>⚠</span>
       <span style={{ color: '#7A5A0E', flex: '1 1 130px', fontSize: 11.5, fontWeight: 700, minWidth: 0 }}>
-        Conexión de WhatsApp anterior — solo lectura
+        {label}
       </span>
       <a
         href="/settings/integrations"
@@ -396,7 +402,7 @@ export function MessageInput({ channel, conversationId, jidType, readOnly, requi
   // deshabilitado para que [Reconectar]/[Conexiones] sí sean clicables.
   return (
     <>
-      {readOnly && <ChannelInactiveBanner brandColor={composerBrand.brand} />}
+      {readOnly && <ChannelInactiveBanner brandColor={composerBrand.brand} channel={channel} />}
       <div
         aria-disabled={readOnly || undefined}
         className="space-y-1"

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
@@ -39,6 +39,10 @@ export interface Conversation {
   unreadCountForAgent?: number;
 }
 
+// A2-web: canales "otros" conocidos. Alineado 1:1 con useRecentConversations (feed).
+// Cualquier canal fuera de este set (o sin channel) se clasifica como "web" (cajón).
+const OTHER_CHANNELS = new Set(['instagram', 'telegram', 'email', 'web', 'facebook']);
+
 export function useConversations(channel: string | null) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -62,10 +66,17 @@ export function useConversations(channel: string | null) {
       const headers = buildHeaders();
       const dev = development || 'bodasdehoy';
 
-      const fetchUrl =
-        channel === 'whatsapp' || !channel
-          ? `${proxyBase}/whatsapp/conversations/${dev}`
-          : `${proxyBase}/conversations?development=${dev}&channel=${channel}`;
+      // A2-web (CAUSA RAÍZ): el feed (useRecentConversations) clasifica "web" como CAJÓN
+      // por defecto (channel||platform||'web', desconocido→'web') pegando a
+      // `/conversations?development=` SIN filtro. Aquí antes se pegaba con `&channel=web`
+      // + default 'whatsapp' → una conversación sin `channel` aparecía como "web" en el
+      // feed pero se PERDÍA al abrirla (lista vacía + banner WA colado). Fix: MISMO
+      // endpoint que el feed (dedupeFetch coalesce → sin fetch extra, sin el 429 de #286)
+      // + MISMA clasificación de canal (abajo).
+      const isWaView = channel === 'whatsapp' || !channel;
+      const fetchUrl = isWaView
+        ? `${proxyBase}/whatsapp/conversations/${dev}`
+        : `${proxyBase}/conversations?development=${dev}`;
 
       // H2: dedup de GET concurrentes idénticos (feed + detalle piden el mismo recurso).
       const response = await dedupeFetch(fetchUrl, { headers });
@@ -79,9 +90,18 @@ export function useConversations(channel: string | null) {
         // utils/jid.ts (friendlyContactName + classifyJidLike). Ver docs/AUTH-FLOW.md.
         const normalized: Conversation[] = rawList.map((c: any) => {
           const rawName = c.displayName || c.contactInfo?.name || c.phoneNumber || '';
+          // Clasificación IDÉNTICA al feed (useRecentConversations): en vista WA todo es
+          // 'whatsapp'; en vista "otros", desconocido/sin-channel → 'web' (cajón). Esto
+          // hace que la conv sobreviva al abrirla (el filtro de abajo ya cuadra).
+          const rawKind = c.channel || c.platform || (isWaView ? 'whatsapp' : 'web');
+          const kind = isWaView
+            ? 'whatsapp'
+            : OTHER_CHANNELS.has(rawKind)
+              ? rawKind
+              : 'web';
           return {
             assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
-            channel: (c.channel || c.platform || channel || 'whatsapp') as Conversation['channel'],
+            channel: kind as Conversation['channel'],
             contact: {
               name: friendlyContactName(rawName, c.phoneNumber, c.jidType ?? c.jid_type),
               phone: safePhoneOrEmpty(c.phoneNumber, c.jidType ?? c.jid_type),

--- a/apps/chat-ia/src/features/FileManager/FileList/FileListItem/index.tsx
+++ b/apps/chat-ia/src/features/FileManager/FileList/FileListItem/index.tsx
@@ -9,7 +9,6 @@ import { rgba } from 'polished';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Center, Flexbox } from 'react-layout-kit';
-import { useSearchParams } from 'react-router-dom';
 
 import FileIcon from '@/components/FileIcon';
 import { fileManagerSelectors, useFileStore } from '@/store/file';
@@ -79,6 +78,11 @@ const useStyles = createStyles(({ css, token, cx, isDarkMode }) => {
 interface FileRenderItemProps extends FileListItem {
   index: number;
   knowledgeBaseId?: string;
+  /** G-01 #418: abrir archivo por callback router-agnóstico (igual que el Masonry).
+   *  Antes se usaba useSearchParams de react-router-dom, que crashea en /files
+   *  (App Router de Next, SIN <Router>). Tanto /files como /knowledge pasan este
+   *  callback (onOpenFile=setFileModalId). */
+  onOpenFile: (id: string) => void;
   onSelectedChange: (id: string, selected: boolean, shiftKey: boolean, index: number) => void;
   selected?: boolean;
 }
@@ -99,12 +103,12 @@ const FileRenderItem = memo<FileRenderItemProps>(
     selected,
     chunkingStatus,
     onSelectedChange,
+    onOpenFile,
     knowledgeBaseId,
     index,
   }) => {
     const { t } = useTranslation('components');
     const { styles, cx } = useStyles();
-    const [, setSearchParams] = useSearchParams();
     const [isCreatingFileParseTask, parseFiles] = useFileStore((s) => [
       fileManagerSelectors.isCreatingFileParseTask(id)(s),
       s.parseFilesToChunks,
@@ -132,14 +136,7 @@ const FileRenderItem = memo<FileRenderItemProps>(
           flex={1}
           horizontal
           onClick={() => {
-            setSearchParams(
-              (prev) => {
-                const newParams = new URLSearchParams(prev);
-                newParams.set('file', id);
-                return newParams;
-              },
-              { replace: true },
-            );
+            onOpenFile(id);
           }}
         >
           <Flexbox align={'center'} horizontal>

--- a/apps/chat-ia/src/features/FileManager/FileList/index.tsx
+++ b/apps/chat-ia/src/features/FileManager/FileList/index.tsx
@@ -200,6 +200,7 @@ const FileList = memo<FileListProps>(({ knowledgeBaseId, category, onOpenFile })
               index={index}
               key={item.id}
               knowledgeBaseId={knowledgeBaseId}
+              onOpenFile={onOpenFile}
               onSelectedChange={(id, checked, shiftKey, clickedIndex) => {
                 if (shiftKey && lastSelectedIndex !== null && selectFileIds.length > 0 && data) {
                   // Range selection with shift key


### PR DESCRIPTION
## Qué

Dos bugs de QA front (independientes del incidente api-mcp):

### A2-web — la lista se vacía al abrir una conversación Web
**Causa raíz** (por fin): el feed (`useRecentConversations`) trata `web` como CAJÓN por defecto (`channel||platform||'web'`, desconocido→`web`) pegando a `/conversations` SIN filtro; pero `useConversations` pegaba con `&channel=web` + default `'whatsapp'` + filtro estricto `c.channel==='web'`. Una conversación sin `channel` salía como "web" en el feed pero se PERDÍA al abrirla (lista vacía + banner WA colado). Por eso #283/#286 no bastaron (tocaban el filtro, no la CLASIFICACIÓN).
**Fix**: `useConversations` usa el MISMO endpoint que el feed (`dedupeFetch` coalesce → sin fetch extra, sin el 429 que hundió #286) y la MISMA clasificación. Banner "solo lectura" ahora channel-aware.

### G-01 — crash React #418 en `/files`
`FileListItem` (vista Lista) usaba `useSearchParams` de `react-router-dom`, que exige `<Router>` (MemoryRouter en /knowledge, NO en /files=App Router) → crash al montar. El Masonry ya usaba `context.openFile` router-agnóstico.
**Fix**: `FileListItem` recibe `onOpenFile` (que /files y /knowledge ya pasan) y lo llama en el onClick.

## Test
- 8/8 tests unitarios de bandeja PASS.
- ESLint sin errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)