### PR TITLE
🐛 fix: wallet €0-falso (api-mcp down) + WA solo-lectura falso (channelParam) + 4 proxies env

### DIFF
--- a/apps/chat-ia/src/app/(backend)/webapi/models/[provider]/pull/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/models/[provider]/pull/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
+
 export const POST = async (req: Request, { params }: { params: Promise<{ provider: string }> }) => {
   const { provider } = await params;
-  const backendUrl = process.env.API_IA_URL || process.env.NEXT_PUBLIC_API_IA_URL;
+  const backendUrl = resolveServerBackendOrigin();
 
   if (!backendUrl) {
     return NextResponse.json(

--- a/apps/chat-ia/src/app/(backend)/webapi/models/[provider]/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/models/[provider]/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
+
 // SPRINT-AC: edge runtime — solo hace fetch a api-ia, sin Node APIs.
 // Cold start mucho más rápido + distributed en edge locations.
 export const runtime = 'edge';
 
 export const GET = async (req: Request, { params }: { params: Promise<{ provider: string }> }) => {
   const { provider } = await params;
-  const backendUrl = process.env.API_IA_URL || process.env.NEXT_PUBLIC_API_IA_URL;
+  const backendUrl = resolveServerBackendOrigin();
 
   if (!backendUrl) {
     return NextResponse.json(

--- a/apps/chat-ia/src/app/(backend)/webapi/plugin/gateway/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/plugin/gateway/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
+
 // SPRINT-AC: edge runtime — solo hace fetch a api-ia.
 export const runtime = 'edge';
 
 export const POST = async (req: Request) => {
-  const backendUrl = process.env.API_IA_URL || process.env.NEXT_PUBLIC_API_IA_URL;
+  const backendUrl = resolveServerBackendOrigin();
 
   if (!backendUrl) {
     return NextResponse.json(

--- a/apps/chat-ia/src/app/(backend)/webapi/text-to-image/[provider]/route.ts
+++ b/apps/chat-ia/src/app/(backend)/webapi/text-to-image/[provider]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+import { resolveServerBackendOrigin } from '@/const/backendEndpoints';
+
 // SPRINT-AC: edge runtime — solo hace fetch a api-ia.
 export const runtime = 'edge';
 
@@ -10,7 +12,7 @@ export const preferredRegion = [
 
 export const POST = async (req: Request, { params }: { params: Promise<{ provider: string }> }) => {
   const { provider } = await params;
-  const backendUrl = process.env.API_IA_URL || process.env.NEXT_PUBLIC_API_IA_URL;
+  const backendUrl = resolveServerBackendOrigin();
 
   if (!backendUrl) {
     return NextResponse.json(

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/MessageInput.tsx
@@ -78,10 +78,11 @@ interface MessageInputProps {
 function ChannelInactiveBanner({ brandColor, channel }: { brandColor: string; channel?: string }) {
   // A2-web: no rotular "WhatsApp anterior" en canales que NO son WhatsApp (el banner se
   // colaba en conversaciones Web). Texto genérico salvo en el canal de WhatsApp.
-  const label =
-    channel === 'whatsapp' || !channel
-      ? 'Conexión de WhatsApp anterior — solo lectura'
-      : 'Este canal está en solo lectura';
+  // WhatsApp llega como kind 'whatsapp' o como channelParam 'wa-{id}' (URL del detalle).
+  const isWhatsApp = channel === 'whatsapp' || channel?.startsWith('wa-') || !channel;
+  const label = isWhatsApp
+    ? 'Conexión de WhatsApp anterior — solo lectura'
+    : 'Este canal está en solo lectura';
   return (
     <div
       style={{

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
@@ -73,7 +73,12 @@ export function useConversations(channel: string | null) {
       // feed pero se PERDÍA al abrirla (lista vacía + banner WA colado). Fix: MISMO
       // endpoint que el feed (dedupeFetch coalesce → sin fetch extra, sin el 429 de #286)
       // + MISMA clasificación de canal (abajo).
-      const isWaView = channel === 'whatsapp' || !channel;
+      // isWaView: la vista WhatsApp llega como kind 'whatsapp', como null (feed) o como
+      // channelPARAM 'wa-{id}' (URL del detalle: /bandeja/wa-xxx/conv_yyy). Los tres deben
+      // pegar al endpoint WA y clasificarse como 'whatsapp'. Antes 'wa-xxx' caía al endpoint
+      // de "otros" y filtraba c.channel==='wa-xxx' → SIEMPRE vacío → toda conv WA abierta
+      // desde el detalle quedaba "solo lectura" falsamente (no solo las huérfanas).
+      const isWaView = channel === 'whatsapp' || channel?.startsWith('wa-') || !channel;
       const fetchUrl = isWaView
         ? `${proxyBase}/whatsapp/conversations/${dev}`
         : `${proxyBase}/conversations?development=${dev}`;
@@ -130,7 +135,14 @@ export function useConversations(channel: string | null) {
             unreadCountForAgent: c.unreadCountForAgent ?? c.unread_count_for_agent ?? undefined,
           };
         });
-        const filtered = channel ? normalized.filter((c) => c.channel === channel) : normalized;
+        // En vista WA devolvemos TODAS las conversaciones WA: el channelParam 'wa-{id}'
+        // identifica la CUENTA, no el canal de cada conv (que es 'whatsapp'); el detalle
+        // localiza la suya por id. En "otros" sí filtramos por el kind clasificado.
+        const filtered = isWaView
+          ? normalized
+          : channel
+            ? normalized.filter((c) => c.channel === channel)
+            : normalized;
         setConversations(filtered);
         setError(null);
       } else if (response.status === 401 || response.status === 403) {

--- a/apps/chat-ia/src/components/Wallet/WalletBadge.tsx
+++ b/apps/chat-ia/src/components/Wallet/WalletBadge.tsx
@@ -13,7 +13,7 @@ export interface WalletBadgeProps {
 }
 
 const WalletBadge = memo<WalletBadgeProps>(({ onClick, showDetails = false, size = 'medium' }) => {
-  const { totalBalance, currency, isLowBalance, isNegativeBalance, loading, status, formatBalance } = useWallet();
+  const { totalBalance, balanceLoaded, isLowBalance, isNegativeBalance, loading, status, formatBalance } = useWallet();
 
   const sizeStyles = {
     large: { fontSize: 16, iconSize: 20, padding: '10px 16px' },
@@ -91,10 +91,20 @@ const WalletBadge = memo<WalletBadgeProps>(({ onClick, showDetails = false, size
         padding,
         transition: 'all 0.2s ease',
       }}
-      title={isNegativeBalance ? 'Saldo negativo - Click para recargar' : isLowBalance ? 'Saldo bajo - Click para recargar' : 'Ver wallet'}
+      title={
+        !balanceLoaded
+          ? 'Saldo no disponible ahora — reintentando'
+          : isNegativeBalance
+            ? 'Saldo negativo - Click para recargar'
+            : isLowBalance
+              ? 'Saldo bajo - Click para recargar'
+              : 'Ver wallet'
+      }
     >
       <Wallet size={iconSize} />
-      <span>{formatBalance(totalBalance)}</span>
+      {/* €0/FREE falso (QA 7-ago): si el saldo NO se ha leído con éxito (fallo api-mcp),
+          mostrar "—" en vez de "€0.00" para no aparentar saldo agotado. */}
+      <span>{balanceLoaded ? formatBalance(totalBalance) : '—'}</span>
       {(isLowBalance || isNegativeBalance) && (
         <span
           style={{

--- a/apps/chat-ia/src/hooks/useWallet.ts
+++ b/apps/chat-ia/src/hooks/useWallet.ts
@@ -19,6 +19,10 @@ import {
 
 export interface UseWalletState {
   balance: number;
+  /** true solo cuando el saldo se leyó con ÉXITO al menos una vez. Mientras sea false
+   *  (carga inicial o fallo de api-mcp), el saldo es DESCONOCIDO → la UI debe mostrar
+   *  "—"/"no disponible", NO "€0.00" (evita el falso €0/"saldo insuficiente"). */
+  balanceLoaded: boolean;
   bonusBalance: number;
   creditLimit: number;
   currency: string;
@@ -165,7 +169,10 @@ export const useWallet = (): UseWalletReturn => {
 
   const canAfford = useCallback(async (amount: number): Promise<BalanceCheck> => {
     const check = await walletService.checkBalance(amount);
-    if (!check.allowed) {
+    // Solo abrir el modal de recarga ante una DENEGACIÓN REAL por saldo. Si la consulta a
+    // MCP falló (error_code API_ERROR → saldo DESCONOCIDO, no insuficiente), NO mostrar
+    // "saldo insuficiente": evita el falso B-12 durante caídas de api-mcp (QA 7-ago).
+    if (!check.allowed && check.error_code !== 'API_ERROR') {
       setLastBalanceCheck(check);
       setShowRechargeModal(true);
     }
@@ -341,6 +348,7 @@ export const useWallet = (): UseWalletReturn => {
 
   return {
     balance,
+    balanceLoaded,
     bonusBalance,
     canAfford,
     consumeService,


### PR DESCRIPTION
Punto 3 (front independiente del backend) + hallazgo del audit WhatsApp.

## 1) Wallet: no mostrar €0/"saldo insuficiente" falso cuando api-mcp cae
`canAfford` ya no abre el modal de recarga si `error_code === 'API_ERROR'` (saldo DESCONOCIDO ≠ insuficiente). `useWallet` expone `balanceLoaded`; `WalletBadge` muestra "—" en vez de "€0.00" mientras el saldo no se haya leído con éxito. **53 tests wallet PASS.**

## 2) WhatsApp: conv del detalle no queda "solo lectura" falsamente (audit finding #4)
La URL `/bandeja/wa-{id}/conv_yyy` pasaba el channelParam `wa-{id}` a `useConversations`, que filtraba `c.channel==='wa-{id}'` → siempre vacío → conv no encontrada → `isChannelInactive` → **toda conv WA abierta desde el detalle salía solo-lectura**. Ahora `isWaView` reconoce `wa-{id}` y la vista WA devuelve todas las conv WA (el detalle localiza la suya; las huérfanas siguen sin aparecer = correcto). El envío sigue gateado por `useConversationCapabilities` (backend). Banner vuelve a rotular "WhatsApp". **8/8 tests bandeja PASS. Necesita validación QA.**

## 3) 4 proxies webapi → resolveServerBackendOrigin
plugin/gateway, text-to-image, models, models/pull leían el env sin fallback (undefined si no seteado). Ahora usan el resolver canónico. config/* se quedan (localhost:8030 dev local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)