### PR TITLE
fix(appEventos): itinerario con crearTarea/actualizarTarea, proxy en …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 build/
 out/
 
+# Node.js V8 module compile cache (cwd del proceso; no versionar)
+node-compile-cache/
+
 # Lock files (pnpm generates these)
 # pnpm-lock.yaml is tracked
 

--- a/apps/appEventos/components/DefaultLayout/Navigation.tsx
+++ b/apps/appEventos/components/DefaultLayout/Navigation.tsx
@@ -234,7 +234,7 @@ const Navigation: FC = () => {
               </span>
             )}
           </span>
-          <NavbarDirectory />
+          {/* <NavbarDirectory /> */}
           <div className="flex items-center gap-3">
             {canSeeCopilot && <ChatToggleButton />}
             <Profile
@@ -248,13 +248,13 @@ const Navigation: FC = () => {
         {/* segundo menu superior con las redirecciones funcionales de la app */}
         <div className={`${(urls.includes(url)) ? "hidden" : "block"}`}>
           <div className={`w-full h-20 hidden md:flex bg-base justify-center items-start`}>
-              <div style={{ width, height }} className={`absolute top-16 z-10 px-16 flex justify-center transition-opacity duration-200 ${width > 0 ? 'opacity-100' : 'opacity-0'}`}>
-                <Tooltip
-                  label={navNoEventHint}
-                  icon={<IconLightBulb16 className="w-6 h-6" />}
-                  disabled={!!event?._id}
-                  className="w-full h-full"
-                >
+            <div style={{ width, height }} className={`absolute top-16 z-10 px-16 flex justify-center transition-opacity duration-200 ${width > 0 ? 'opacity-100' : 'opacity-0'}`}>
+              <Tooltip
+                label={navNoEventHint}
+                icon={<IconLightBulb16 className="w-6 h-6" />}
+                disabled={!!event?._id}
+                className="w-full h-full"
+              >
                 <div className="flex w-full h-full justify-center items-center">
                   <ul className="flex w-full h-max justify-between">
                     {Navbar.filter(item => !(item.hideForGuest && user?.displayName === 'guest')).map((item, idx) => (
@@ -297,8 +297,8 @@ const Navigation: FC = () => {
                     ))}
                   </ul>
                 </div>
-                </Tooltip>
-              </div>
+              </Tooltip>
+            </div>
             <div ref={refBanner} className="flex max-w-[1020px] flex-1 items-start">
               <Banner
                 className={`${pathname === "/" ? "text-primary" : "text-white"} transition`}

--- a/apps/appEventos/components/DefaultLayout/SocketControlator.tsx
+++ b/apps/appEventos/components/DefaultLayout/SocketControlator.tsx
@@ -19,6 +19,7 @@ export const SocketControlator = () => {
   const [received, setReceived] = useState({ channel: "", msg: null, d: null })
   const router = useRouter()
   const senderPlanSpaceActiveRef = useRef(false)
+  const setEventEmitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [countEvent, setCountEvent] = useState(0)
   const [countPlanSpaceActive, setCountPlanSpaceActive] = useState(0)
 
@@ -329,17 +330,25 @@ export const SocketControlator = () => {
 
   useEffect(() => {
     if (!valirRemoteEvent && !valirRemotePlanSpaceActive && !senderPlanSpaceActiveRef.current) {
-      // console.log(100010, "EMIT event")
-      socket?.emit(`app:message`, {
-        event: event?._id,
-        emit: user?.uid,
-        receiver: event?._id,
-        type: "event",
-        payload: {
-          action: "setEvent",
-          value: event?._id
-        }
-      })
+      const eventId = event?._id
+      if (!eventId || !socket) {
+        countEvent < 5 && setCountEvent(countEvent + 1)
+        return
+      }
+      // Debounce: ráfagas de setEvent (p. ej. init itinerario) colapsan a 1 emit.
+      if (setEventEmitTimerRef.current) clearTimeout(setEventEmitTimerRef.current)
+      setEventEmitTimerRef.current = setTimeout(() => {
+        socket.emit(`app:message`, {
+          event: eventId,
+          emit: user?.uid,
+          receiver: eventId,
+          type: "event",
+          payload: {
+            action: "setEvent",
+            value: eventId
+          }
+        })
+      }, 400)
     } else {
       if (senderPlanSpaceActiveRef.current) {
         senderPlanSpaceActiveRef.current = false
@@ -348,6 +357,12 @@ export const SocketControlator = () => {
       setValirRemotePlanSpaceActive(false)
     }
     countEvent < 5 && setCountEvent(countEvent + 1)
+    return () => {
+      if (setEventEmitTimerRef.current) {
+        clearTimeout(setEventEmitTimerRef.current)
+        setEventEmitTimerRef.current = null
+      }
+    }
   }, [event])
 
 

--- a/apps/appEventos/components/Forms/Login/Forms/FormRegister.tsx
+++ b/apps/appEventos/components/Forms/Login/Forms/FormRegister.tsx
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { publicKey } from './../../../../publicKey.js'
+import { publicKey } from './../../../../publicKey'
 import { Formik, Form, ErrorMessage } from "formik";
 import { Dispatch, FC, SetStateAction, useState } from "react";
 import { EmailIcon, Eye, EyeSlash, LockClosed, PhoneMobile, UserForm } from "../../../icons";

--- a/apps/appEventos/components/GoogleAnalitytcs/index.tsx
+++ b/apps/appEventos/components/GoogleAnalitytcs/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Script from "next/script"
-import * as gtag from "../../gtas.js"
+import * as gtag from "../../gtas"
 
 const GoogleAnalytics = () => {
   return (

--- a/apps/appEventos/components/Itinerario/MicroComponente/ItineraryPanel.tsx
+++ b/apps/appEventos/components/Itinerario/MicroComponente/ItineraryPanel.tsx
@@ -168,6 +168,7 @@ export const ItineraryPanel: FC<props> = ({ itinerario, editTitle, setEditTitle,
           query: queries.editTask,
           variables: {
             evento_id: event._id,
+            itinerario_id: itinerario._id,
             task_id: task._id,
             development: config.development || "bodasdehoy",
             updates: { [fieldName]: apiValue },
@@ -368,6 +369,7 @@ export const ItineraryPanel: FC<props> = ({ itinerario, editTitle, setEditTitle,
         query: queries.editTask,
         variables: {
           evento_id: event._id,
+          itinerario_id: itinerario._id,
           task_id: values._id,
           development: config.development || "bodasdehoy",
           updates: { spectatorView: newSpectatorViewValue }

--- a/apps/appEventos/components/Itinerario/MicroComponente/ItineraryTabs.tsx
+++ b/apps/appEventos/components/Itinerario/MicroComponente/ItineraryTabs.tsx
@@ -74,8 +74,8 @@ export const ItineraryTabs: FC<props> = ({ setModalDuplicate, itinerario, setIti
             // Guard: usar fecha del evento si es válida, si no fallback a hoy.
             const fechaParsed = event?.fecha ? parseInt(String(event.fecha)) : NaN
             const f = !isNaN(fechaParsed) && fechaParsed > 0
-              ? new Date(fechaParsed)
-              : new Date()
+                ? new Date(fechaParsed)
+                : new Date()
             const baseDate = isNaN(f.getTime()) ? new Date() : f
             const fy = baseDate.getUTCFullYear()
             const fm = baseDate.getUTCMonth()
@@ -116,6 +116,7 @@ export const ItineraryTabs: FC<props> = ({ setModalDuplicate, itinerario, setIti
                     query: queries.editTask,
                     variables: {
                         evento_id: event._id,
+                        itinerario_id: itinerario._id,
                         task_id: addNewTask._id,
                         development: config.development || "bodasdehoy",
                         updates: { estatus: true }
@@ -192,33 +193,41 @@ export const ItineraryTabs: FC<props> = ({ setModalDuplicate, itinerario, setIti
                     start_Id: itineraries[0]?._id,
                     end_Id: itineraries[itineraries.length - 1]?._id
                 }
-                // Reconstruir el array de listIdentifiers de forma segura.
-                const newListIdentifiers = [...safeListIdentifiers, listIdentifier]
-                fetchApiEventos({
-                    query: queries.eventUpdate,
-                    variables: {
-                        idEvento: event._id,
-                        variable: "listIdentifiers",
-                        value: JSON.stringify(newListIdentifiers)
-                    }
-                })
+                // Sustituir entrada existente (p. ej. start_Id null) o añadir.
+                // Antes siempre hacía push + setEvent({...prev}) sin meter listIdentifiers
+                // → el guard seguía true → bucle infinito de setEvent + hydrate socket.
+                const newListIdentifiers = fListIdentifiers >= 0
+                    ? safeListIdentifiers.map((el, i) => i === fListIdentifiers ? listIdentifier : el)
+                    : [...safeListIdentifiers, listIdentifier]
+                const nextById = new Map<string, string | null>()
                 if (itineraries.length > 1) {
-                    const itinerariesSlice = itineraries.slice(0, itineraries.length - 1)
-                    itinerariesSlice.map((elem, idx) => {
-                        if (elem) elem.next_id = itineraries[idx + 1]?._id
-                    })
-                }
-                fetchApiEventos({
-                    query: queries.eventUpdate,
-                    variables: {
-                        idEvento: event._id,
-                        variable: "itinerarios_array",
-                        value: JSON.stringify(event.itinerarios_array)
+                    for (let idx = 0; idx < itineraries.length - 1; idx++) {
+                        const cur = itineraries[idx]
+                        if (cur?._id) nextById.set(cur._id, itineraries[idx + 1]?._id ?? null)
                     }
-                })
-                // Trigger re-render con copia top-level del estado actual.
-                setEvent((prev) => ({ ...prev }))
-                setItineraries([...itineraries])
+                }
+                const baseItinerarios = Array.isArray(event?.itinerarios_array) ? event.itinerarios_array : []
+                const nextItinerarios = nextById.size
+                    ? baseItinerarios.map((it) =>
+                        nextById.has(it._id) ? { ...it, next_id: nextById.get(it._id) } : it
+                    )
+                    : baseItinerarios
+                const orderedForTabs = nextById.size
+                    ? itineraries.map((it) =>
+                        nextById.has(it._id) ? { ...it, next_id: nextById.get(it._id) } : it
+                    )
+                    : [...itineraries]
+                if (!event?._id) return
+                // EventoUpdateInput.listIdentifiers es [String!] en api-v2 (bug vs Event: JSON).
+                // Enviar objetos → 400 "String cannot represent a non string value".
+                // Solo estado local; la persistencia real de orden/tabs sigue por flujos
+                // que API2 alinee el SDL (JSON) o por editItinerario de next_id.
+                setEvent((prev) => ({
+                    ...prev,
+                    listIdentifiers: newListIdentifiers,
+                    itinerarios_array: nextItinerarios,
+                }))
+                setItineraries(orderedForTabs)
             } else {
                 let newItineraries: any[] = []
                 const itinerariesCopy = [...itineraries] // Copia para no modificar el original mientras iteramos
@@ -269,8 +278,8 @@ export const ItineraryTabs: FC<props> = ({ setModalDuplicate, itinerario, setIti
         // Usar la fecha del evento si es válida, si no fallback a "hoy".
         const fechaParsed = event?.fecha ? parseInt(String(event.fecha)) : NaN
         const f = !isNaN(fechaParsed) && fechaParsed > 0
-          ? new Date(fechaParsed)
-          : new Date()
+            ? new Date(fechaParsed)
+            : new Date()
         const baseDate = isNaN(f.getTime()) ? new Date() : f
         const y = baseDate.getUTCFullYear()
         const m = baseDate.getUTCMonth()
@@ -295,56 +304,55 @@ export const ItineraryTabs: FC<props> = ({ setModalDuplicate, itinerario, setIti
                 console.warn("[ItineraryTabs] createItinerario devolvió result null/sin _id", r)
                 return
             }
-            const fListIdentifiers = event?.listIdentifiers?.findIndex(elem => elem.table === window?.location?.pathname.slice(1))
-            if (event.itinerarios_array?.filter(elem => elem.tipo === window?.location?.pathname.slice(1)).length) {
-                const lastListIdentifiers = { ...event.listIdentifiers[fListIdentifiers] }
-                const f1 = event.itinerarios_array.findIndex(elem => elem._id === lastListIdentifiers.end_Id)
-                if (f1 > -1) {
-                    event.itinerarios_array[f1].next_id = result._id
-                    updatedNextId(event.itinerarios_array[f1])
-                    event.listIdentifiers[fListIdentifiers].end_Id = result._id
-                    updatedListIdentifiers(event)
+            const pathSlice = window?.location?.pathname.slice(1)
+            const safeList = Array.isArray(event?.listIdentifiers) ? [...event.listIdentifiers] : []
+            const fListIdentifiers = safeList.findIndex(elem => elem?.table === pathSlice)
+            const sameTipo = Array.isArray(event?.itinerarios_array)
+                ? event.itinerarios_array.filter(elem => elem?.tipo === pathSlice)
+                : []
+
+            let nextList = safeList
+            let nextItinerarios = Array.isArray(event?.itinerarios_array) ? [...event.itinerarios_array] : []
+
+            if (sameTipo.length) {
+                const lastListIdentifiers = fListIdentifiers >= 0 ? { ...safeList[fListIdentifiers] } : null
+                const f1 = lastListIdentifiers?.end_Id
+                    ? nextItinerarios.findIndex(elem => elem._id === lastListIdentifiers.end_Id)
+                    : -1
+                if (f1 > -1 && lastListIdentifiers) {
+                    nextItinerarios[f1] = { ...nextItinerarios[f1], next_id: result._id }
+                    updatedNextId(nextItinerarios[f1])
+                    nextList = safeList.map((li, i) =>
+                        i === fListIdentifiers ? { ...li, end_Id: result._id } : li
+                    )
+                    updatedListIdentifiers({ ...event, listIdentifiers: nextList })
                 } else {
-                    event.listIdentifiers.push({
+                    nextList = [...safeList, {
                         end_Id: result._id,
                         start_Id: result._id,
-                        table: window?.location?.pathname.slice(1)
-                    })
-                    fetchApiEventos({
-                        query: queries.eventUpdate,
-                        variables: {
-                            idEvento: event._id,
-                            variable: "listIdentifiers",
-                            value: JSON.stringify(event.listIdentifiers)
-                        }
-                    })
+                        table: pathSlice,
+                    }]
                 }
+            } else if (fListIdentifiers < 0) {
+                nextList = [...safeList, {
+                    start_Id: result._id,
+                    end_Id: result._id,
+                    table: pathSlice,
+                }]
             } else {
-                if (fListIdentifiers === -1) {
-                    event.listIdentifiers.push({
-                        start_Id: result._id,
-                        end_Id: result._id,
-                        table: window?.location?.pathname.slice(1)
-                    })
-                } else {
-                    event.listIdentifiers[fListIdentifiers].start_Id = result._id
-                    event.listIdentifiers[fListIdentifiers].end_Id = result._id
-                }
-                fetchApiEventos({
-                    query: queries.eventUpdate,
-                    variables: {
-                        idEvento: event._id,
-                        variable: "listIdentifiers",
-                        value: JSON.stringify(event.listIdentifiers)
-                    }
-                })
+                nextList = safeList.map((li, i) =>
+                    i === fListIdentifiers ? { ...li, start_Id: result._id, end_Id: result._id } : li
+                )
             }
-            const newItinerario = { ...result, viewers: [] as any[] }
+
+            const newItinerario = { ...result, tasks: result.tasks ?? [], viewers: result.viewers ?? [] }
+            nextItinerarios = [...nextItinerarios, newItinerario]
             setEvent((prev) => ({
                 ...prev,
-                itinerarios_array: [...prev.itinerarios_array, newItinerario],
+                listIdentifiers: nextList,
+                itinerarios_array: nextItinerarios,
             }))
-            setItinerario({ ...result })
+            setItinerario({ ...newItinerario })
             /*  setEditTitle(true) */
         })
     }
@@ -585,7 +593,7 @@ export const ItineraryTabs: FC<props> = ({ setModalDuplicate, itinerario, setIti
     }
 
     return (
-        <div className="flex w-full max-w-[1050px] h-10 items-center justify-center border-b md:px-4 md:py-2 shadow-md">
+        <div className="flex w-full max-w-[1050px] h-10 items-center justify-center border-primary border-b md:px-4 md:py-2 shadow-md">
             <div id="content" className="flex-1 h-full flex justify-between">
                 {/* Vista Desktop */}
                 {!isMobile && (

--- a/apps/appEventos/components/Utils/BlockTitle.tsx
+++ b/apps/appEventos/components/Utils/BlockTitle.tsx
@@ -44,7 +44,7 @@ export const BlockTitle = ({ title }) => {
             overflow-hidden en el wrapper aseguran banner SIEMPRE 56px. */}
         <img
           src={event?.imgEvento?.i320 ? `/api/proxy-image?url=${encodeURIComponent(`https://api-mcp.eventosorganizador.com/${event.imgEvento.i320}`)}` : defaultImagenes[event?.tipo?.toLowerCase()]}
-          className="h-[90%] max-h-[50px] object-cover object-top rounded-md border-1 border-gray-600 hidden md:block shrink-0"
+          className="h-[90%] max-h-[50px] object-cover object-top rounded-md border-1 border-gray-300 hidden md:block shrink-0"
           alt={event?.nombre}
           onError={(e) => { (e.target as HTMLImageElement).src = defaultImagenes[event?.tipo?.toLowerCase()] || defaultImagenes['otro']; }}
         />

--- a/apps/appEventos/package.json
+++ b/apps/appEventos/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 0.0.0.0 -p 3220",
+    "dev:turbo": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev --turbopack -H 0.0.0.0 -p 3220",
     "dev:local": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 0.0.0.0 -p 3220",
     "dev:hmr": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 127.0.0.1 -p 3225",
     "dev:3001": "node -r ./scripts/dns-dev-preflight.cjs node_modules/next/dist/bin/next dev -H 0.0.0.0 -p 3001",

--- a/apps/appEventos/utils/Fetching.ts
+++ b/apps/appEventos/utils/Fetching.ts
@@ -321,6 +321,27 @@ export const fetchApiEventos = async ({
       maybeInvalidateOnMutation(query);
       return __adapter.mapResponse(canonical, variables || {});
     }
+    // crearTarea/actualizarTarea: la query ya es canónica; sin map no hay fallback CRM válido.
+    if (__field === 'crearTarea' || __field === 'actualizarTarea') {
+      throw new Error(
+        `[fetchApiEventos] ${__field}: adapter no pudo mapear (falta evento_id, itinerario_id o task_id)`
+      );
+    }
+    if (__field === 'createTask' || __field === 'editTask') {
+      const vars = (variables || {}) as Record<string, any>;
+      const task = vars.task ?? vars.tarea ?? {};
+      const hasItin = !!(
+        vars.itinerario_id ||
+        vars.itinerarioID ||
+        task?.itinerario_id ||
+        task?.itinerarioID
+      );
+      if (hasItin) {
+        throw new Error(
+          `[fetchApiEventos] ${__field}: adapter no pudo mapear (falta evento_id, itinerario_id o task_id)`
+        );
+      }
+    }
   }
   try {
     const axiosRes = await api.ApiApp({ query, variables }, token);
@@ -704,44 +725,52 @@ export const queries = {
     }
   }`,
 
-  editTask: `mutation ($evento_id:ID!, $task_id:ID!, $development:String!, $updates:TaskUpdateInput!){
-    editTask(evento_id:$evento_id, task_id:$task_id, development:$development, updates:$updates){
+  editTask: `mutation ($evento_id:ID!, $itinerario_id:ID!, $tarea_id:ID!, $updates:TareaUpdateInput!){
+    actualizarTarea(evento_id:$evento_id, itinerario_id:$itinerario_id, tarea_id:$tarea_id, updates:$updates){
       success
       errors{ field message code }
-      task{ _id }
+      itinerario {
+        _id
+        tasks {
+          _id
+          descripcion
+          fecha
+          responsable
+          duracion
+          tags
+          icon
+          completada
+          attachments
+          comments
+          commentsViewers
+          fecha_creacion
+          updatedAt
+        }
+      }
     }
   }`,
 
-  createTask: `mutation ($evento_id:ID!, $development:String!, $task:TaskInput!){
-    createTask(evento_id:$evento_id, development:$development, task:$task){
+  createTask: `mutation ($evento_id:ID!, $itinerario_id:ID!, $tarea:TareaInput!){
+    crearTarea(evento_id:$evento_id, itinerario_id:$itinerario_id, tarea:$tarea){
       success
       errors{ field message code }
-      task{
+      itinerario {
         _id
-        fecha
-        hora
-        horaActiva
-        icon
-        descripcion
-        responsable
-        duracion
-        tags
-        tips
-        estatus
-        attachments{ _id name url size createdAt updatedAt }
-        spectatorView
-        comments{
+        tasks {
           _id
-          comment
-          uid
-          createdAt
-          nicknameUnregistered
-          attachments{ _id name size }
+          descripcion
+          fecha
+          responsable
+          duracion
+          tags
+          icon
+          completada
+          attachments
+          comments
+          commentsViewers
+          fecha_creacion
+          updatedAt
         }
-        commentsViewers
-        estado
-        prioridad
-        fecha_creacion
       }
     }
   }`,
@@ -771,53 +800,21 @@ export const queries = {
   mutation  ( $eventID:String, $itinerarioID:String, $taskID:String, $commentID:String  ) {
     deleteComment ( eventID:$eventID  itinerarioID:$itinerarioID  taskID:$taskID, commentID:$commentID)
   }`,
-  createItinerario: `mutation ($evento_id:ID!, $itinerario:JSON!){
-    createItinerario(evento_id:$evento_id, itinerario:$itinerario){
+  createItinerario: `mutation ($evento_id:ID!, $itinerario:ItinerarioInput!){
+    crearItinerario(evento_id:$evento_id, itinerario:$itinerario){
       success
       errors{ field message code }
       itinerario{
         _id
-      next_id
-      title
-      tasks{
-        _id
-        fecha
-        hora
-        horaActiva
-        icon
-        descripcion
-        responsable
-        duracion
-        tags
-        tips
-        estatus
-        attachments{
-          _id
-          name
-          url
-          size
-          createdAt
-          updatedAt
-        }
-        spectatorView
-        comments{
-          _id
-          comment
-          uid
-          createdAt
-          nicknameUnregistered
-          attachments{
-            _id
-            name
-            size
-          }
-        }
-        commentsViewers
-        estado
-        prioridad
-      }
-      tipo
-      fecha_creacion
+        title
+        tipo
+        tasks{ _id descripcion fecha responsable duracion tags icon completada }
+        viewers
+        participantes
+        chat_id
+        completion_percentage
+        fecha_creacion
+        updatedAt
       }
     }
   }`,

--- a/apps/appEventos/utils/apiEndpoints.ts
+++ b/apps/appEventos/utils/apiEndpoints.ts
@@ -84,8 +84,13 @@ export function resolveApiBodasGraphqlUrl(): string {
 
   if (typeof window !== 'undefined' && window?.location?.hostname) {
     const hostname = window.location.hostname;
-    const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
-    if (isLocalhost) return '/api/proxy-bodas/graphql';
+    // Misma barra que api.ts isLocalhost: -dev/-test van por proxy (CORS).
+    const useProxy =
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.includes('-dev.') ||
+      hostname.includes('-test.');
+    if (useProxy) return '/api/proxy-bodas/graphql';
   }
 
   return resolved;
@@ -102,13 +107,17 @@ export function resolveApiIaOrigin(): string {
 }
 
 export function resolveApiEventosOrigin(): string {
-  // Host del GraphQL canónico (api-mcp). NUNCA usar NEXT_PUBLIC_IMAGES_BASE_URL
-  // como fallback: ese apunta al host de IMÁGENES legacy (media-apiapp), y mezclarlos
-  // hacía que /api/proxy/graphql y el socket fallback golpearan un host muerto → 502/404.
+  // Host del GraphQL canónico (api-mcp). Misma fuente que resolveApiBodasGraphqlUrl.
+  // Antes solo leía BASE_URL → en DEV sin BASE_URL caía a api-mcp.eventosorganizador.com
+  // (prod) mientras ApiBodas usaba API_MCP_GRAPHQL_URL local → createTask fallback ERR_NETWORK.
+  failIfLegacyAliasSet();
   const raw =
+    process.env.API_MCP_GRAPHQL_URL ||
+    process.env.NEXT_PUBLIC_API_MCP_GRAPHQL_URL ||
     process.env.NEXT_PUBLIC_BASE_URL ||
     process.env.BASE_URL;
-  return (raw || DEFAULT_EVENTOS_ORIGIN).trim().replace(/\/+$/, '');
+  const url = (raw || DEFAULT_EVENTOS_ORIGIN).trim().replace(/\/+$/, '');
+  return url.replace(/\/graphql\/?$/i, '');
 }
 
 // Host que sirve los FICHEROS de imagen (slugs relativos de imágenes ya subidas).

--- a/apps/appEventos/utils/apiMcpAdapter.ts
+++ b/apps/appEventos/utils/apiMcpAdapter.ts
@@ -228,17 +228,13 @@ export const MCP_ADAPTERS: Record<string, McpAdapterEntry> = {
     mapResponse: (p) => ({ _id: p?.evento?._id, listaRegalos: p?.evento?.listaRegalos, success: p?.success, errors: p?.errors }),
   },
 
-  // ── eventUpdate (variable/value → input) ── captura los call-sites legacy que aún pasan
-  // {idEvento, variable, value}. Salta estatus/tipo (enum: estatus pendiente P3; tipo necesita mapeo)
-  // devolviendo null en mapVariables → cae a apiapp hasta que se resuelvan.
-  eventUpdate: {
+  // ── updateEvento / eventUpdate ──
+  // extractGraphqlField sobre queries.eventUpdate captura "updateEvento" (campo GQL),
+  // no "eventUpdate" (nombre del wrapper). Alias obligatorio o el adapter no corre.
+  // Soporta call-sites con {input} y legacy {variable, value}.
+  updateEvento: {
     canonicalQuery: `mutation($idEvento:ID!,$input:EventoUpdateInput!){ updateEvento(id:$idEvento, input:$input){ success errors{ field message code } evento{ _id } } }`,
     mapVariables: (v) => {
-      // DEFENSA imgEvento/imgInvitacion: al LEER, el adapter convierte estos campos String(slug)
-      // → objeto de tamaños ({i320,i640,...}) para pintar la UI. NUNCA reenviar ese objeto en un
-      // update: el schema de api-mcp los declara String y Mongoose rechaza el save del EVENTO
-      // entero → rompía crear invitado/grupo/menú (validation failed: imgInvitacion Cast to string).
-      // Se omiten del input cuando son objeto (el flujo real de imagen va por singleUpload).
       const stripImgObjects = (input: any) => {
         if (!input || typeof input !== 'object') return input;
         const out: any = { ...input };
@@ -247,15 +243,29 @@ export const MCP_ADAPTERS: Record<string, McpAdapterEntry> = {
         }
         return out;
       };
-      if (v.input) return { idEvento: v.idEvento, input: stripImgObjects(v.input) };
+      // listIdentifiers en Event es JSON (objetos {table,start_Id,end_Id}); el SDL de
+      // EventoUpdateInput aún dice [String!] — si llega stringificado, parsear.
+      const normalizeInput = (input: any) => {
+        const cleaned = stripImgObjects(input);
+        if (!cleaned || typeof cleaned !== 'object') return cleaned;
+        if (typeof cleaned.listIdentifiers === 'string') {
+          try { cleaned.listIdentifiers = JSON.parse(cleaned.listIdentifiers); } catch { /* leave */ }
+        }
+        if (typeof cleaned.itinerarios_array === 'string') {
+          try { cleaned.itinerarios_array = JSON.parse(cleaned.itinerarios_array); } catch { /* leave */ }
+        }
+        return cleaned;
+      };
+      if (v.input) return { idEvento: v.idEvento, input: normalizeInput(v.input) };
       if (v.variable == null) return null;
-      // Update de campo suelto: si es imgEvento/imgInvitacion como objeto, ignorarlo (no persistir).
       if ((v.variable === 'imgEvento' || v.variable === 'imgInvitacion') && v.value && typeof v.value === 'object') {
         return { idEvento: v.idEvento, input: {} };
       }
-      // P3 estatus: api-mcp ya acepta lowercase. tipo: el adapter mapea lowercase→enum EventoTipo.
-      const val = v.variable === 'tipo' ? mapTipo(v.value) : v.value;
-      return { idEvento: v.idEvento, input: { [v.variable]: val } };
+      let val = v.variable === 'tipo' ? mapTipo(v.value) : v.value;
+      if ((v.variable === 'listIdentifiers' || v.variable === 'itinerarios_array') && typeof val === 'string') {
+        try { val = JSON.parse(val); } catch { /* leave */ }
+      }
+      return { idEvento: v.idEvento, input: normalizeInput({ [v.variable]: val }) };
     },
     mapResponse: (p) => p,
   },
@@ -338,31 +348,111 @@ export const MCP_ADAPTERS: Record<string, McpAdapterEntry> = {
   // P1 ITINERARIO/TASKS — desplegado 2026-05-29
   // Front pasa itinerarioID (verificado). TareaInput: descripcion/fecha/responsable/duracion/tags/icon/completada.
   // ═══════════════════════════════════════════════════════════
-  // Front editTask(evento_id, task_id, development, updates:TaskUpdateInput) → actualizarTarea
+  // Front editTask (varias formas legacy) → actualizarTarea
+  // Formas: {evento_id,task_id,updates} | {eventID,itinerarioID,taskID,variable,valor}
+  // Sin itinerario_id el adapter devolvía null → editTask CRM (Task.id) → error "_id".
   editTask: {
     canonicalQuery: `mutation($evento_id:ID!,$itinerario_id:ID!,$tarea_id:ID!,$updates:TareaUpdateInput!){
       actualizarTarea(evento_id:$evento_id, itinerario_id:$itinerario_id, tarea_id:$tarea_id, updates:$updates){
         success errors{ field message code }
+        itinerario {
+          _id
+          tasks {
+            _id descripcion fecha responsable duracion tags icon completada
+            attachments comments commentsViewers fecha_creacion updatedAt
+          }
+        }
       }
     }`,
     mapVariables: (v) => {
-      const it = v.itinerario_id ?? v.itinerarioID;
-      const tk = v.tarea_id ?? v.task_id ?? v.taskID;
-      if (!it || !tk) return null;
-      return { evento_id: v.evento_id, itinerario_id: it, tarea_id: tk, updates: v.updates ?? {} };
+      const evento_id = v.evento_id ?? v.eventID ?? v.eventoID;
+      const itinerario_id = v.itinerario_id ?? v.itinerarioID;
+      const tarea_id = v.tarea_id ?? v.task_id ?? v.taskID;
+      if (!evento_id || !itinerario_id || !tarea_id) return null;
+
+      let updates: Record<string, unknown> =
+        v.updates && typeof v.updates === 'object' ? { ...v.updates } : {};
+      if (Object.keys(updates).length === 0 && v.variable != null) {
+        const key = String(v.variable);
+        let valor: unknown = v.valor;
+        if (key === 'all' && typeof valor === 'string') {
+          try { updates = JSON.parse(valor); } catch { updates = {}; }
+        } else {
+          if (typeof valor === 'string' && (valor.startsWith('{') || valor.startsWith('['))) {
+            try { valor = JSON.parse(valor); } catch { /* leave string */ }
+          }
+          updates = { [key]: valor };
+        }
+      }
+
+      // Front usa estatus (bool/string); api-v2 actualizarTarea persiste completada.
+      if (updates.estatus !== undefined && updates.completada === undefined) {
+        const e = updates.estatus;
+        updates.completada = e === true || e === 'true' || e === 1 || e === '1';
+      }
+      // fecha Date → string
+      if (updates.fecha instanceof Date) {
+        const d = updates.fecha;
+        updates.fecha = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      }
+      // Quitar campos que no van en TareaUpdateInput / no aplica el resolver
+      delete updates.itinerario_id;
+      delete updates.itinerarioID;
+      delete updates._id;
+
+      return { evento_id, itinerario_id, tarea_id, updates };
     },
-    mapResponse: (p) => ({ success: p?.success, errors: p?.errors, task: { _id: p?.itinerario?._id } }),
+    mapResponse: (p, v) => {
+      const tasks = Array.isArray(p?.itinerario?.tasks) ? p.itinerario.tasks : [];
+      const tid = (v as any)?.task_id ?? (v as any)?.taskID ?? (v as any)?.tarea_id;
+      const task = tid
+        ? tasks.find((t: any) => t?._id === tid) ?? (tasks.length ? tasks[tasks.length - 1] : null)
+        : (tasks.length ? tasks[tasks.length - 1] : null);
+      return { success: p?.success, errors: p?.errors, task };
+    },
   },
-  // Front createItinerario(evento_id, title, tipo) → crearItinerario(evento_id, itinerario:ItinerarioInput!)
+  // Front createItinerario(evento_id, itinerario:{title,tipo,...}) → crearItinerario
+  // Antes: canonical sin selection de itinerario → {success,errors} sin _id;
+  // mapVariables ignoraba v.itinerario y mandaba title:''.
   createItinerario: {
     canonicalQuery: `mutation($evento_id:ID!,$itinerario:ItinerarioInput!){
-      crearItinerario(evento_id:$evento_id, itinerario:$itinerario){ success errors{ field message code } }
+      crearItinerario(evento_id:$evento_id, itinerario:$itinerario){
+        success
+        errors{ field message code }
+        itinerario {
+          _id
+          title
+          tipo
+          tasks { _id descripcion fecha responsable duracion tags icon completada }
+          viewers
+          participantes
+          chat_id
+          completion_percentage
+          fecha_creacion
+          updatedAt
+        }
+      }
     }`,
-    mapVariables: (v) => ({
-      evento_id: v.evento_id,
-      itinerario: { title: v.title ?? v.nombre ?? '', tipo: v.tipo ?? 'itinerario', viewers: v.viewers, participantes: v.participantes },
+    mapVariables: (v) => {
+      const raw =
+        v.itinerario && typeof v.itinerario === 'object'
+          ? (v.itinerario as Record<string, unknown>)
+          : (v as Record<string, unknown>);
+      return {
+        evento_id: v.evento_id,
+        itinerario: {
+          title: (raw.title as string) ?? (raw.nombre as string) ?? (v.title as string) ?? '',
+          tipo: (raw.tipo as string) ?? (v.tipo as string) ?? 'itinerario',
+          viewers: (raw.viewers as string[]) ?? v.viewers,
+          participantes: (raw.participantes as string[]) ?? v.participantes,
+        },
+      };
+    },
+    mapResponse: (p) => ({
+      success: p?.success,
+      errors: p?.errors,
+      itinerario: p?.itinerario ?? null,
     }),
-    mapResponse: (p) => p,
   },
   // Front editItinerario(evento_id, itinerario_id, datos) → actualizarItinerario
   editItinerario: {
@@ -544,19 +634,61 @@ export const MCP_ADAPTERS: Record<string, McpAdapterEntry> = {
     mapResponse: (p) => p,
   },
 
-  // Front createTask(evento_id, development, task:TaskInput) → crearTarea
+  // Front createTask(evento_id, development, task:{itinerario_id,...}) → crearTarea
+  // Antes mapVariables solo miraba itinerario_id top-level → siempre null → ApiApp
+  // con query legacy (Task CRM) + proxy a host equivocado → ERR_NETWORK / 400.
   createTask: {
     canonicalQuery: `mutation($evento_id:ID!,$itinerario_id:ID!,$tarea:TareaInput!){
       crearTarea(evento_id:$evento_id, itinerario_id:$itinerario_id, tarea:$tarea){
         success errors{ field message code }
+        itinerario {
+          _id
+          tasks {
+            _id descripcion fecha responsable duracion tags icon completada
+            attachments comments commentsViewers fecha_creacion updatedAt
+          }
+        }
       }
     }`,
     mapVariables: (v) => {
-      const it = v.itinerario_id ?? v.itinerarioID;
-      if (!it) return null;
-      return { evento_id: v.evento_id, itinerario_id: it, tarea: v.task ?? v.tarea ?? {} };
+      const rawTask = (v.task ?? v.tarea ?? {}) as Record<string, unknown>;
+      const itinerario_id =
+        (v.itinerario_id as string | undefined) ??
+        (v.itinerarioID as string | undefined) ??
+        (rawTask.itinerario_id as string | undefined) ??
+        (rawTask.itinerarioID as string | undefined);
+      if (!itinerario_id || !v.evento_id) return null;
+      const {
+        itinerario_id: _drop1,
+        itinerarioID: _drop2,
+        ...rest
+      } = rawTask;
+      const tarea: Record<string, unknown> = { ...rest };
+      if (tarea.fecha instanceof Date) {
+        const d = tarea.fecha;
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        tarea.fecha = `${y}-${m}-${day}`;
+        if (tarea.hora == null) {
+          tarea.hora = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+        }
+      } else if (typeof tarea.fecha === 'number') {
+        const d = new Date(tarea.fecha);
+        if (!Number.isNaN(d.getTime())) {
+          tarea.fecha = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+        }
+      }
+      if (typeof tarea.descripcion !== 'string' || !tarea.descripcion) {
+        tarea.descripcion = 'Tarea nueva';
+      }
+      return { evento_id: v.evento_id, itinerario_id, tarea };
     },
-    mapResponse: (p) => ({ success: p?.success, errors: p?.errors, task: { _id: p?.itinerario?._id } }),
+    mapResponse: (p) => {
+      const tasks = Array.isArray(p?.itinerario?.tasks) ? p.itinerario.tasks : [];
+      const task = tasks.length ? tasks[tasks.length - 1] : null;
+      return { success: p?.success, errors: p?.errors, task };
+    },
   },
 
   // getPsTemplate(evento_id, development): JSON — front legacy pasa (uid, evento_id, development),
@@ -1178,6 +1310,13 @@ export const MCP_ADAPTERS: Record<string, McpAdapterEntry> = {
     mapResponse: (p) => p,
   },
 };
+
+// Alias: queries.eventUpdate (wrapper) vs campo GQL updateEvento — misma entrada.
+MCP_ADAPTERS.eventUpdate = MCP_ADAPTERS.updateEvento;
+// Alias: queries.createTask → campo GQL crearTarea; editTask → actualizarTarea.
+MCP_ADAPTERS.crearTarea = MCP_ADAPTERS.createTask;
+MCP_ADAPTERS.actualizarTarea = MCP_ADAPTERS.editTask;
+MCP_ADAPTERS.crearItinerario = MCP_ADAPTERS.createItinerario;
 
 export const ADAPTER_ENABLED = (field: string | null): boolean =>
   !!field && field in MCP_ADAPTERS;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dev:copilot:local": "pnpm --filter @bodasdehoy/chat-ia run dev:local",
     "dev:local": "turbo run dev:local --concurrency=12",
     "dev:web": "pnpm --filter @bodasdehoy/appEventos dev",
+    "dev:web:turbo": "pnpm --filter @bodasdehoy/appEventos run dev:turbo",
     "dev:safe:web": "bash scripts/dev-safe-appEventos.sh",
     "dev:web:local": "pnpm --filter @bodasdehoy/appEventos run dev:local",
     "lint": "turbo run lint",


### PR DESCRIPTION
…-dev y sin bucle de tabs

Migra createTask/editTask al SDL canónico con itinerario_id, alinea orígenes MCP/proxy en DEV, evita el loop de setEvent en listIdentifiers y añade scripts turbopack + ignore de node-compile-cache.