### PR TITLE
💄 fix(bandeja): quitar tab "Conversaciones" duplicada (QA H-4)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/BandejaTabs.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/BandejaTabs.tsx
@@ -1,20 +1,23 @@
 'use client';
 
 /**
- * BandejaTabs — wrapper de tabs principales /messages.
- * Diseño handoff v2 (24-jun) Sección "Las 3 pestañas".
+ * BandejaTabs — wrapper de tabs principales de /bandeja.
+ * Diseño handoff v2 (24-jun) planteó "3 pestañas", pero la pestaña
+ * "Conversaciones" solo REDIRIGÍA a /asistente (el chat), que YA está en el
+ * sidebar (icono 💬). Esa duplicidad confundía — una "tab" que en realidad
+ * teletransporta fuera de la bandeja (QA H-4, 8-ago). Retirada: quedan 2
+ * pestañas de contenido real dentro de la bandeja.
  *
- *   1. CONVERSACIONES (Workspace LobeChat actual integrado, ruta /chat)
- *   2. BANDEJA       (lista de conversaciones — vista actual de /messages)
- *   3. HISTORIAL     (feed notificaciones del sistema)
+ *   1. BANDEJA    (lista de conversaciones)
+ *   2. HISTORIAL  (feed de notificaciones del sistema)
  *
- * Sincronizado con URL via `?tab=conv|inbox|history`.
- * Default `inbox`. Si tab='conv' redirigimos a /chat (no embedimos).
+ * Sincronizado con URL via `?tab=inbox|history`. Default `inbox`.
+ * El acceso al chat sigue disponible desde el sidebar (💬 → /asistente).
  */
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback } from 'react';
 
-export type BandejaTab = 'conv' | 'inbox' | 'history';
+export type BandejaTab = 'inbox' | 'history';
 
 interface BandejaTabsProps {
   active: BandejaTab;
@@ -22,10 +25,9 @@ interface BandejaTabsProps {
   counts?: Partial<Record<BandejaTab, number>>;
 }
 
-const TAB_META: Array<{ id: BandejaTab; label: string; icon: string; redirectsTo?: string }> = [
-  { id: 'conv', icon: '💬', label: 'Conversaciones', redirectsTo: '/asistente' },
-  { id: 'inbox', icon: '📥', label: 'Bandeja' },
-  { id: 'history', icon: '🕒', label: 'Historial' },
+const TAB_META: Array<{ icon: string; id: BandejaTab; label: string }> = [
+  { icon: '📥', id: 'inbox', label: 'Bandeja' },
+  { icon: '🕒', id: 'history', label: 'Historial' },
 ];
 
 export function BandejaTabs({ active, counts }: BandejaTabsProps) {
@@ -34,10 +36,6 @@ export function BandejaTabs({ active, counts }: BandejaTabsProps) {
 
   const handleClick = useCallback(
     (tab: (typeof TAB_META)[number]) => {
-      if (tab.redirectsTo) {
-        router.push(tab.redirectsTo);
-        return;
-      }
       const params = new URLSearchParams(sp?.toString() ?? '');
       params.set('tab', tab.id);
       // Conservar otros params (scope, filtros, etc.)
@@ -85,10 +83,11 @@ export function BandejaTabs({ active, counts }: BandejaTabsProps) {
   );
 }
 
-/** Lee el tab activo desde la URL. Default 'inbox'. */
+/** Lee el tab activo desde la URL. Default 'inbox'. Cualquier valor legacy
+ *  (p.ej. `?tab=conv` de la pestaña "Conversaciones" retirada) cae a 'inbox'. */
 export function useActiveBandejaTab(): BandejaTab {
   const sp = useSearchParams();
   const t = sp?.get('tab');
-  if (t === 'conv' || t === 'history') return t;
+  if (t === 'history') return 'history';
   return 'inbox';
 }

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx
@@ -171,7 +171,8 @@ export default function MessagesPage() {
         <ChannelSidebar />
       </div>
 
-      {/* Desktop: tabs Conversaciones / Bandeja / Historial + feed por tab */}
+      {/* Desktop: tabs Bandeja / Historial + feed por tab. La tab "Conversaciones"
+          (redirigía a /asistente, ya en el sidebar) se retiró — QA H-4. */}
       <div className="hidden flex-1 flex-col overflow-hidden md:flex">
         {/* Tabs FASE B v2.0 Diseño 24-jun */}
         <BandejaTabs


### PR DESCRIPTION
## Qué

Retira la pestaña **"Conversaciones"** de `/bandeja`. Solo REDIRIGÍA a `/asistente` (el chat IA), que **ya está en el sidebar** (icono 💬). Presentada como tab pegada a "Bandeja", confundía — una "pestaña" que teletransporta fuera de la bandeja.

**QA H-4** (8-ago): duplicidad "Conversaciones vs Bandeja".

## Cambios
- `BandejaTabs.tsx`: retirada la tab `conv` → quedan **📥 Bandeja** + **🕒 Historial** (tabs de contenido real). Tipo `BandejaTab` estrechado a `'inbox' | 'history'`; eliminada la rama muerta `redirectsTo` en `handleClick`.
- `useActiveBandejaTab`: cualquier `?tab=conv` legacy cae a `inbox` (URLs viejas no rompen).
- `page.tsx`: comentario actualizado.

## No se pierde funcionalidad
- El chat sigue a 1 clic desde el **sidebar** (💬 → `/asistente`).
- Móvil (`BottomNavBar`) ya etiquetaba ese acceso como **"Asistente"** (no "Conversaciones") → sin cambios.

## Verificación
- ESLint: limpio en mis cambios (queda 1 `eqeqeq` **preexistente** en el badge de contador, no introducido aquí).
- `tsc` aislado sobre BandejaTabs: sin errores de tipo propios.
- Dev server chat-ia `:3210` → **HTTP 200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)