### PR TITLE
🐛 fix(chat-ia): sesión coherente (AUTH-03) + unificar naming Bandeja

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/[channel]/page.tsx
@@ -55,7 +55,7 @@ function MobileBackButton() {
       >
         ←
       </button>
-      <span className="text-sm font-medium text-gray-700">Mensajes</span>
+      <span className="text-sm font-medium text-gray-700">Bandeja</span>
     </div>
   );
 }

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ChannelSidebar.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/components/ChannelSidebar.tsx
@@ -559,7 +559,7 @@ export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
 
         {/* ── Header ── */}
         <div className="flex shrink-0 items-center justify-between border-b border-gray-200 px-4 py-3">
-          <span className="text-sm font-semibold text-gray-900">Mensajes</span>
+          <span className="text-sm font-semibold text-gray-900">Bandeja</span>
           <div className="flex items-center gap-0.5">
             <Link
               className="flex h-7 w-7 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
@@ -745,8 +745,8 @@ export function ChannelSidebar({ compact = false }: ChannelSidebarProps) {
                   }
                   label={
                     channelFilter === 'all'
-                      ? 'Mensajes'
-                      : (FILTER_TABS.find((t) => t.key === channelFilter)?.label ?? 'Mensajes')
+                      ? 'Bandeja'
+                      : (FILTER_TABS.find((t) => t.key === channelFilter)?.label ?? 'Bandeja')
                   }
                 />
                 <div className="space-y-0 px-2">

--- a/apps/chat-ia/src/hooks/useDomainGuestUser.ts
+++ b/apps/chat-ia/src/hooks/useDomainGuestUser.ts
@@ -1,8 +1,26 @@
+import { useEffect, useState } from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { useChatStore } from '@/store/chat';
 import { externalChatSelectors } from '@/store/chat/selectors';
 import { useUserStore } from '@/store/user';
+
+// AUTH-03 / coherencia de sesión (QA 9-ago): un usuario autenticado por email/Google/SSO
+// tiene su JWT en localStorage (mcp_jwt_token/jwt_token) AUNQUE el chat store todavía no
+// haya poblado currentUserId (EventosAutoAuth en curso). Sin este fast-path,
+// isDomainGuestUser cae a guest=true durante el arranque ("sin id → guest") → el sidebar y
+// menús mostraban "Iniciar sesión" con contenido ya cargado, y /files el muro "Crear
+// cuenta" a usuarios YA logueados: identidad incoherente entre módulos. Mismo patrón que
+// ya usan bandeja/layout y settings. 0 impacto de seguridad: un visitante real no tiene JWT.
+function hasLocalJwt(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const t = localStorage.getItem('mcp_jwt_token') || localStorage.getItem('jwt_token');
+    return !!t && t.length > 20;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Invitado en dominio Bodas: combina chat store + nombre en useUserStore (Lobe),
@@ -21,8 +39,18 @@ export function useDomainGuestUser(): boolean {
     }),
     shallow,
   );
+  // Fast-path JWT local (lectura post-mount → SSR-safe: server y primer render cliente
+  // devuelven false, sin hydration mismatch; tras montar refleja el JWT real). Ver nota arriba.
+  const [hasJwt, setHasJwt] = useState(false);
+  useEffect(() => {
+    setHasJwt(hasLocalJwt());
+  }, []);
+
   const lobeName = (username || fullName || '').toLowerCase().trim();
   const isServerMode = process.env.NEXT_PUBLIC_SERVICE_MODE === 'server';
+
+  // Usuario con JWT local = autenticado → nunca invitado (coherencia en toda la app).
+  if (hasJwt) return false;
   // BUG MÓVIL (22-jul): un usuario autenticado por Bodas-SSO (EventosAutoAuth →
   // currentUserId en chatStore) tiene isSignedIn=false (no usa el auth NATIVO de
   // LobeChat). Esta línea lo trataba como GUEST → en móvil ocultaba la pestaña


### PR DESCRIPTION
## QA 9-ago (chat-dev) — dos hallazgos de esta ronda

### 1. Identidad de sesión incoherente (AUTH-03 + sidebar)
chat-dev mostraba señales de **visitante** ("Iniciar sesión" en el sidebar con contenido ya cargado, muro "Crear cuenta" en /files) a usuarios **YA autenticados**.

**Raíz:** `useDomainGuestUser` caía a `guest=true` durante el arranque SSO porque el chat store aún no había poblado `currentUserId` (EventosAutoAuth en curso) → regla "sin id → guest".

**Fix (raíz, mismo patrón que bandeja/layout + settings):** fast-path del **JWT local** (`mcp_jwt_token`/`jwt_token`). Con JWT presente = autenticado → nunca invitado. Cubre **sidebar, /files (AUTH-03), /bandeja y móvil** de una vez. Lectura post-mount (SSR-safe, sin hydration mismatch). **0 impacto de seguridad**: un visitante real no tiene JWT.

### 2. Duplicidad de nombres "Mensajes" vs "Bandeja"
El nav usa "Bandeja" en todos lados, pero cabeceras internas decían "Mensajes" → "el mismo sitio con dos nombres".
- ChannelSidebar (móvil) + /bandeja/[channel]: "Mensajes" → **"Bandeja"**.

## Verificación
- ESLint limpio en mis líneas (los errores que quedan en ChannelSidebar/[channel] son **preexistentes**: sort-keys 173, React-undef 184, prefer-switch 465 — no introducidos aquí).
- `tsc` aislado del hook sin errores propios; hooks-rules OK (hooks antes de returns).
- Dev server chat-ia :3210 → HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)