### PR TITLE
🐛 fix(auth-ui): login truncaba el email tecleado (inputs no-controlados)

### DIFF
--- a/packages/auth-ui/src/LoginForm.tsx
+++ b/packages/auth-ui/src/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 export interface LoginFormProps {
   /** Handler para login con email/contraseña */
@@ -200,8 +200,16 @@ export function LoginForm({
   primaryColor = '#A93E8C',
   enableProviderHint = true,
 }: LoginFormProps) {
+  // QA 10-ago: los inputs email/password eran CONTROLADOS (`value={state}`). Un re-render
+  // asíncrono durante el montaje (carrera con el tecleo) pisaba el estado y TRUNCABA el valor
+  // tecleado ("bodasdehoy.com@gmail.com" → "gmail.com"), provocando en chat-dev "Email o
+  // contraseña incorrectos" con credenciales correctas (reproducido con Playwright: reset
+  // one-shot, mismo nodo DOM = reset de estado controlado, no remount). Fix: inputs
+  // NO-CONTROLADOS (ref, el DOM es la fuente de verdad) → ningún re-render puede borrar lo
+  // tecleado. `email` se mantiene solo como espejo para el hint de provider (no autoritativo).
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
@@ -221,14 +229,17 @@ export function LoginForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!email || !password) {
+    // Fuente de verdad = DOM (inputs no-controlados), no el estado (ver nota arriba).
+    const emailVal = (emailRef.current?.value ?? '').trim();
+    const passwordVal = passwordRef.current?.value ?? '';
+    if (!emailVal || !passwordVal) {
       setError('Introduce tu email y contraseña.');
       return;
     }
     setError(null);
     setLoading(true);
     try {
-      await onEmailLogin(email, password);
+      await onEmailLogin(emailVal, passwordVal);
     } catch (err: any) {
       setError(err?.message || 'Email o contraseña incorrectos.');
     } finally {
@@ -337,11 +348,13 @@ export function LoginForm({
               autoComplete="email"
               disabled={anyLoading}
               name="email"
+              // No-controlado: onChange solo espeja `email` para el hint de provider; el
+              // valor autoritativo se lee de emailRef en el submit (evita truncación).
               onChange={(e) => setEmail(e.target.value)}
               placeholder="tu@email.com"
+              ref={emailRef}
               style={s.input}
               type="email"
-              value={email}
             />
           </div>
           {/* Hint multimarca auto-sugerir provider */}
@@ -397,11 +410,10 @@ export function LoginForm({
               autoComplete="current-password"
               disabled={anyLoading}
               name="password"
-              onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
+              ref={passwordRef}
               style={s.input}
               type={showPassword ? 'text' : 'password'}
-              value={password}
             />
             <button
               onClick={() => setShowPassword((v) => !v)}


### PR DESCRIPTION
## QA 10-ago — chat-dev login "Email o contraseña incorrectos" con credenciales VÁLIDAS

**Reproducido con Playwright en el build real** (no teoría): al teclear el email carácter a carácter, el valor se **trunca** ("bodasdehoy.com@gmail.com" → "gmail.com") por un **reset one-shot del estado controlado** durante un re-render async al montar (mismo nodo DOM = reset de estado, no remount). Firebase recibe un email incompleto → `user-not-found` → "Email o contraseña incorrectos".

**Evidencia de que la cuenta/contraseña estaban BIEN:**
- `createAuthUri` sobre el owner en `bodasdehoy-1063` → `["google.com","password"]`.
- appEventos usa el MISMO proyecto Firebase (`bodasdehoy-1063`) y app-dev entra con esas creds → la contraseña es válida; el único fallo era el input.

## Fix
Inputs email/password **NO-CONTROLADOS** (`ref` = el DOM es la fuente de verdad). Ningún re-render puede pisar lo tecleado; el submit lee de los refs. `email` se mantiene solo como espejo para el hint de provider (no autoritativo).

## Alcance
- chat-ia **transpila auth-ui desde src** → recoge el fix directamente.
- appEventos usa el **dist** de auth-ui (no lo incluye en transpilePackages) → **no se ve afectado** hasta que se reconstruya su dist (sin regresión en app-dev que ya pasa; recoge la mejora en su próximo build).

## Verificación
- `tsc --noEmit` auth-ui: limpio.
- Pendiente: re-ejecutar el repro Playwright contra el build nuevo de chat-dev para confirmar que ya NO trunca (en este PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)