### PR TITLE
✨ feat(appEventos): rediseño UI — Invitaciones, encabezado, Resumen, Invitados (mismo backend)

### DIFF
--- a/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
+++ b/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
@@ -1,4 +1,5 @@
 import { FC, useCallback, useEffect, useRef, useState } from "react";
+import Head from "next/head";
 import { useTranslation } from "react-i18next";
 import { EventContextProvider } from "../../context/EventContext";
 import { AuthContextProvider } from "../../context/AuthContext";
@@ -21,7 +22,7 @@ import { fetchApiEventos, queries } from "../../utils/Fetching";
 
 // ---- Tipos y presets --------------------------------------------------------
 type TemplateKey = "elegante" | "clasica" | "moderna";
-type FontKey = "poppins" | "playfair" | "dancing";
+type FontKey = "elegante" | "moderna" | "script";
 type ChannelKey = "email" | "whatsapp" | "sms";
 
 interface DesignData {
@@ -44,19 +45,22 @@ const PINK_HOVER = "#D83E7C";
 const INK = "#3A3A42";
 const BORDER = "#E7E7EA";
 
-const PRESETS: Record<TemplateKey, { label: string; grad: string; accent: string }> = {
-  elegante: { label: "Elegante", grad: "linear-gradient(135deg,#FBD3E4,#F3A9CB)", accent: "#EF5B94" },
-  clasica: { label: "Clásica", grad: "linear-gradient(135deg,#EBE1CD,#D8C7A6)", accent: "#C79A3B" },
-  moderna: { label: "Moderna", grad: "linear-gradient(135deg,#DcCcFb,#B79BF0)", accent: "#7C5CFF" },
+// Gradientes de plantilla EXACTOS del HTML "Invitaciones estudio"
+const PRESETS: Record<TemplateKey, { label: string; grad: string }> = {
+  elegante: { label: "Elegante", grad: "linear-gradient(135deg,#f7c2da,#EF5B94)" },
+  clasica: { label: "Clásica", grad: "linear-gradient(135deg,#ece4d6,#dccdb4)" },
+  moderna: { label: "Moderna", grad: "linear-gradient(135deg,#dfe6ec,#b9cbdb)" },
 };
 
+// Tipografías del diseño: Elegante=Playfair · Moderna=Poppins · Script=Dancing Script
 const FONTS: Record<FontKey, { label: string; family: string }> = {
-  poppins: { label: "Poppins", family: "'Poppins',sans-serif" },
-  playfair: { label: "Playfair", family: "'Playfair Display',serif" },
-  dancing: { label: "Dancing", family: "'Dancing Script',cursive" },
+  elegante: { label: "Elegante", family: "'Playfair Display',serif" },
+  moderna: { label: "Moderna", family: "'Poppins',sans-serif" },
+  script: { label: "Script", family: "'Dancing Script',cursive" },
 };
 
-const ACCENTS = ["#EF5B94", "#C79A3B", "#7C5CFF", "#2FB37E", "#E76F51", "#3A3A42"];
+// Paleta "Color de acento" (tonos suaves): rosa · crema · oliva · azul acero · oro
+const ACCENTS = ["#C99AA6", "#E8DEC5", "#8DA07A", "#6E8BAA", "#C9A24B"];
 
 const TEXT_FIELDS: { key: keyof DesignData; label: string; area?: boolean }[] = [
   { key: "title", label: "Encabezado" },
@@ -71,8 +75,8 @@ const TEXT_FIELDS: { key: keyof DesignData; label: string; area?: boolean }[] = 
 const defaultDesign = (event: any): DesignData => ({
   _studio: "v1",
   template: "elegante",
-  font: "poppins",
-  accent: PRESETS.elegante.accent,
+  font: "elegante",
+  accent: "#C99AA6",
   cover: "",
   title: "NOS CASAMOS",
   names: event?.nombre || "Ana & Marcos",
@@ -175,6 +179,10 @@ export const InvitacionesStudio: FC = () => {
 
   return (
     <div style={{ background: "#f1f1f4", minHeight: "100%", fontFamily: "'Poppins',sans-serif" }}>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&family=Playfair+Display:wght@500;600;700&family=Dancing+Script:wght@600;700&display=swap" rel="stylesheet" />
+      </Head>
       <div style={{ maxWidth: 1000, margin: "0 auto", padding: "22px 30px 60px" }}>
 
         {/* Barra de título */}
@@ -296,7 +304,7 @@ export const InvitacionesStudio: FC = () => {
                   {(Object.keys(PRESETS) as TemplateKey[]).map((k) => {
                     const sel = design.template === k;
                     return (
-                      <div key={k} onClick={() => update({ template: k, accent: PRESETS[k].accent })} style={{ border: `2px solid ${sel ? PINK : "#f0f0f2"}`, borderRadius: 12, overflow: "hidden", cursor: "pointer", background: "#fff" }}>
+                      <div key={k} onClick={() => update({ template: k })} style={{ border: `2px solid ${sel ? PINK : "#f0f0f2"}`, borderRadius: 12, overflow: "hidden", cursor: "pointer", background: "#fff" }}>
                         <div style={{ height: 70, background: PRESETS[k].grad }} />
                         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 10px" }}>
                           <span style={{ font: "600 12px Poppins", color: INK }}>{PRESETS[k].label}</span>

--- a/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
+++ b/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
@@ -1,6 +1,8 @@
 import { FC, useCallback, useEffect, useRef, useState } from "react";
 import Head from "next/head";
 import { useTranslation } from "react-i18next";
+import BlockTitle from "../Utils/BlockTitle";
+import { subir_archivo } from "./ModuloSubida";
 import { EventContextProvider } from "../../context/EventContext";
 import { AuthContextProvider } from "../../context/AuthContext";
 import { useToast } from "../../hooks/useToast";
@@ -119,6 +121,9 @@ export const InvitacionesStudio: FC = () => {
   const [templateId, setTemplateId] = useState<string | undefined>(event?.templateEmailSelect);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("saved");
   const [showOnb, setShowOnb] = useState(true);
+  const [coverLocal, setCoverLocal] = useState<string>("");
+  const [uploadingCover, setUploadingCover] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
   const loadedRef = useRef(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout>>();
 
@@ -169,6 +174,23 @@ export const InvitacionesStudio: FC = () => {
     });
   }, [persist]);
 
+  // Subida de la foto de portada — MISMO backend (singleUpload → R2, subir_archivo reutilizado)
+  const handleCoverFile = useCallback(async (file?: File | null) => {
+    if (!file || !event?._id) return;
+    setCoverLocal(URL.createObjectURL(file)); // preview inmediato mientras sube
+    setUploadingCover(true);
+    try {
+      const r: any = await subir_archivo({ imagePreviewUrl: { file }, event, use: "portada" });
+      const url = r?.i1024 || r?.i800 || r?.i640;
+      if (url) update({ cover: url });
+      else toast("error", "No se pudo subir la imagen");
+    } catch {
+      toast("error", "No se pudo subir la imagen");
+    } finally {
+      setUploadingCover(false);
+    }
+  }, [event, update, toast]);
+
   const preset = PRESETS[design.template];
   const invFont = FONTS[design.font].family;
 
@@ -185,18 +207,9 @@ export const InvitacionesStudio: FC = () => {
       </Head>
       <div style={{ maxWidth: 1000, margin: "0 auto", padding: "22px 30px 60px" }}>
 
-        {/* Barra de título */}
-        <div style={{ ...card, padding: "16px 22px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, marginBottom: 20 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-            <div style={{ font: "700 20px Poppins", color: "#4a4a52" }}>Invitaciones</div>
-            <span style={{ display: "flex", alignItems: "center", gap: 6, background: "#FEF6D8", color: "#B8860B", font: "600 11.5px Poppins", padding: "5px 12px", borderRadius: 20 }}>★ Propietario</span>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-            <div style={{ lineHeight: 1.2, textAlign: "right" }}>
-              <div style={{ font: "600 10px Poppins", color: PINK, letterSpacing: ".4px" }}>BODA</div>
-              <div style={{ font: "700 13px Poppins", color: INK }}>{event?.nombre || "—"}</div>
-            </div>
-          </div>
+        {/* Cabecera ESTÁNDAR compartida (misma que presupuesto/mesas/invitados) */}
+        <div style={{ marginBottom: 20 }}>
+          <BlockTitle title={"Invitaciones"} />
         </div>
 
         {/* Tabs 1 Diseñar / 2 Enviar */}
@@ -252,8 +265,15 @@ export const InvitacionesStudio: FC = () => {
                     </div>
                   </div>
                   <div style={{ width: "100%", background: "#fff", borderRadius: 18, boxShadow: "0 12px 34px rgba(0,0,0,.12)", overflow: "hidden", border: "1px solid #f0f0f2" }}>
-                    <div style={{ height: 190, background: design.cover ? `url(${design.cover}) center/cover` : preset.grad, borderBottom: `3px solid ${design.accent}`, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,.85)", font: "600 12px Poppins", flexDirection: "column", gap: 4 }}>
-                      <span style={{ fontSize: 26 }}>🖼</span>Arrastra la foto de portada
+                    <div
+                      onClick={() => coverInputRef.current?.click()}
+                      onDragOver={(e) => e.preventDefault()}
+                      onDrop={(e) => { e.preventDefault(); handleCoverFile(e.dataTransfer.files?.[0]); }}
+                      style={{ height: 190, background: (design.cover || coverLocal) ? `url(${design.cover || coverLocal}) center/cover` : preset.grad, borderBottom: `3px solid ${design.accent}`, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,.92)", font: "600 12px Poppins", flexDirection: "column", gap: 4, cursor: "pointer", position: "relative" }}
+                    >
+                      {!(design.cover || coverLocal) && (<><span style={{ fontSize: 26 }}>🖼</span>Arrastra la foto de portada<span style={{ fontSize: 10, opacity: .85, textDecoration: "underline" }}>o haz clic para subir</span></>)}
+                      {uploadingCover && (<span style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,.35)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", font: "600 12px Poppins" }}>Subiendo…</span>)}
+                      <input ref={coverInputRef} type="file" accept="image/*" onChange={(e) => handleCoverFile(e.target.files?.[0])} style={{ display: "none" }} />
                     </div>
                     {face === "front" ? (
                       <div style={{ padding: "26px 26px 30px", textAlign: "center" }}>

--- a/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
+++ b/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
@@ -216,6 +216,14 @@ export const InvitacionesStudio: FC = () => {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&family=Playfair+Display:wght@500;600;700&family=Dancing+Script:wght@600;700&display=swap" rel="stylesheet" />
       </Head>
+      {/* Keyframes del HTML (fadein/slidein) + responsive del studio */}
+      <style dangerouslySetInnerHTML={{ __html: `
+        @keyframes fadein{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+        @keyframes slidein{from{transform:translateX(-26px);opacity:0}to{transform:translateX(0);opacity:1}}
+        @media (max-width:900px){.inv-design-grid{grid-template-columns:1fr !important}}
+        @media (max-width:720px){.inv-stats-grid{grid-template-columns:repeat(2,1fr) !important}}
+        @media (max-width:560px){.inv-stats-grid{grid-template-columns:1fr !important}}
+      ` }} />
       <div style={{ maxWidth: 1000, margin: "0 auto", padding: "22px 30px 60px" }}>
 
         {/* Cabecera estándar compartida */}
@@ -248,7 +256,7 @@ export const InvitacionesStudio: FC = () => {
         )}
 
         {tab === "diseno" && (
-          <div style={{ animation: "fadein .2s ease", display: "grid", gridTemplateColumns: "380px 1fr", gap: 22, alignItems: "start" }}>
+          <div className="inv-design-grid" style={{ animation: "fadein .2s ease", display: "grid", gridTemplateColumns: "380px 1fr", gap: 22, alignItems: "start" }}>
 
             {/* LIVE PREVIEW */}
             <div style={{ position: "sticky", top: 20 }}>
@@ -494,7 +502,7 @@ export const InvitacionesStudio: FC = () => {
           return (
             <div style={{ animation: "fadein .2s ease" }}>
               {/* Stats */}
-              <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 16 }}>
+              <div className="inv-stats-grid" style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 16 }}>
                 {stats.map((s, i) => (
                   <div key={i} style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: "15px 18px", boxShadow: "0 4px 14px rgba(0,0,0,.05)" }}>
                     <div style={{ font: `700 22px Poppins`, color: s.c }}>{s.v}</div>

--- a/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
+++ b/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
@@ -36,7 +36,7 @@ interface DesignData {
 
 // Gradientes de plantilla EXACTOS del HTML
 const PRESETS: Record<TemplateKey, { label: string; grad: string }> = {
-  elegante: { label: "Elegante", grad: "linear-gradient(135deg,#f7c2da,#EF5B94)" },
+  elegante: { label: "Elegante", grad: "linear-gradient(135deg,#e9d6c3,#d8bfa3)" },
   clasica: { label: "Clásica", grad: "linear-gradient(135deg,#ece4d6,#dccdb4)" },
   moderna: { label: "Moderna", grad: "linear-gradient(135deg,#dfe6ec,#b9cbdb)" },
 };
@@ -88,7 +88,7 @@ const chanIcon = (c: ChannelKey, color: string): ReactNode => {
 };
 
 export const InvitacionesStudio: FC = () => {
-  useTranslation();
+  const { i18n } = useTranslation();
   const { event } = EventContextProvider() as any;
   const auth = AuthContextProvider() as any;
   const toast = useToast();
@@ -97,12 +97,20 @@ export const InvitacionesStudio: FC = () => {
   const [channel, setChannel] = useState<ChannelKey>("email");
   const [face, setFace] = useState<"front" | "back">("front");
   const [previewMobile, setPreviewMobile] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
   const [design, setDesign] = useState<DesignData>(() => defaultDesign(event));
   const [templateId, setTemplateId] = useState<string | undefined>(event?.templateEmailSelect);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("saved");
   const [showOnb, setShowOnb] = useState(true);
   const [coverLocal, setCoverLocal] = useState<string>("");
   const [uploadingCover, setUploadingCover] = useState(false);
+  // Paso "Enviar" (Fase B)
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [searchB, setSearchB] = useState("");
+  const [filterB, setFilterB] = useState<"todos" | "sin" | "enviadas" | "abiertas" | "pend">("todos");
+  const [sendChan, setSendChan] = useState<ChannelKey>("email");
+  const [sendMode, setSendMode] = useState<"now" | "sched">("now");
+  const [sending, setSending] = useState(false);
   const coverInputRef = useRef<HTMLInputElement>(null);
   const loadedRef = useRef(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout>>();
@@ -156,6 +164,35 @@ export const InvitacionesStudio: FC = () => {
     } catch { toast("error", "No se pudo subir la imagen"); }
     finally { setUploadingCover(false); }
   }, [event, update, toast]);
+
+  // Envío real — mismo backend que el módulo actual (sendComunications: email/whatsapp).
+  const doSend = useCallback(async () => {
+    const ids = Object.keys(checked).filter((k) => checked[k]);
+    if (!ids.length) { toast("error", "Selecciona al menos un invitado"); return; }
+    if (sendChan === "sms") { toast("error", "El envío por SMS aún no está disponible"); return; }
+    if (sendChan === "email" && !templateId) { toast("error", "Diseña y guarda la invitación antes de enviar"); return; }
+    if (sendChan === "whatsapp" && !event?.templateWhatsappSelect) { toast("error", "Configura una plantilla de WhatsApp antes de enviar"); return; }
+    setSending(true);
+    try {
+      await fetchApiEventos({
+        query: queries.sendComunications,
+        variables: {
+          evento_id: event?._id,
+          invitados_ids_array: ids,
+          dominio: auth?.config?.dominio || auth?.config?.domain,
+          transport: sendChan,
+          lang: i18n?.language || "es",
+          template_id: sendChan === "email" ? templateId : event?.templateWhatsappSelect,
+        },
+      });
+      toast("success", sendChan === "email" ? "Envío por email exitoso" : "Envío por WhatsApp exitoso");
+      setChecked({});
+    } catch {
+      toast("error", "Error al enviar invitaciones");
+    } finally {
+      setSending(false);
+    }
+  }, [checked, sendChan, templateId, event, auth, i18n, toast]);
 
   const grad = PRESETS[design.template].grad;
   const invFont = FONTS[design.font].family;
@@ -236,8 +273,13 @@ export const InvitacionesStudio: FC = () => {
                       <div key={f} onClick={() => setFace(f)} style={{ padding: "6px 13px", borderRadius: 7, background: face === f ? "#fff" : "transparent", color: face === f ? "#D83E7C" : "#9aa0a8", font: "600 11px Poppins", cursor: "pointer" }}>{f === "front" ? "Portada" : "Detalles"}</div>
                     ))}
                   </div>
-                  <div onClick={() => setPreviewMobile((v) => !v)} style={{ display: "flex", alignItems: "center", gap: 6, marginLeft: "auto", padding: "6px 12px", borderRadius: 9, border: `1.5px solid ${previewMobile ? "#EF5B94" : "#E7E7EA"}`, background: "#fff", color: previewMobile ? "#D83E7C" : "#6b6b72", font: "600 11px Poppins", cursor: "pointer" }}>
-                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><rect x="7" y="2" width="10" height="20" rx="2.5" /><path d="M11 18h2" /></svg>Móvil
+                  <div onClick={() => setPreviewMobile((v) => !v)} style={{ display: "flex", alignItems: "center", gap: 6, marginLeft: "auto", padding: "6px 12px", borderRadius: 9, border: "1.5px solid #EF5B94", background: "#fff", color: "#D83E7C", font: "600 11px Poppins", cursor: "pointer" }}>
+                    {previewMobile ? (
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><rect x="2" y="4" width="20" height="13" rx="2" /><path d="M8 21h8M12 17v4" /></svg>
+                    ) : (
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><rect x="7" y="2" width="10" height="20" rx="2.5" /><path d="M11 18h2" /></svg>
+                    )}
+                    {previewMobile ? "Escritorio" : "Móvil"}
                   </div>
                 </div>
               )}
@@ -249,7 +291,7 @@ export const InvitacionesStudio: FC = () => {
                   <div style={{ width: "100%", background: "#fff", borderRadius: 18, boxShadow: "0 12px 34px rgba(0,0,0,.12)", overflow: "hidden", border: "1px solid #f0f0f2" }}>
                     <div onClick={() => coverInputRef.current?.click()} onDragOver={(e) => e.preventDefault()} onDrop={(e) => { e.preventDefault(); handleCoverFile(e.dataTransfer.files?.[0]); }}
                       style={{ height: 190, position: "relative", background: coverBg, borderBottom: `3px solid ${accent}`, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 4, color: "rgba(255,255,255,.92)", font: "600 12px Poppins", cursor: "pointer" }}>
-                      {!(design.cover || coverLocal) && (<><span style={{ fontSize: 26 }}>🖼</span>Arrastra la foto de portada<span style={{ fontSize: 10, opacity: .85, textDecoration: "underline" }}>o haz clic para subir</span></>)}
+                      {!(design.cover || coverLocal) && (<>Arrastra la foto de portada<span style={{ fontSize: 10, opacity: .85, textDecoration: "underline" }}>o haz clic para subir</span></>)}
                       {uploadingCover && <span style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,.35)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", font: "600 12px Poppins" }}>Subiendo…</span>}
                       <input ref={coverInputRef} type="file" accept="image/*" onChange={(e) => handleCoverFile(e.target.files?.[0])} style={{ display: "none" }} />
                     </div>
@@ -389,7 +431,7 @@ export const InvitacionesStudio: FC = () => {
 
               {/* Botones */}
               <div style={{ display: "flex", justifyContent: "flex-end", gap: 10 }}>
-                <button style={{ padding: "12px 20px", borderRadius: 10, border: "1.5px solid #E7E7EA", background: "#fff", color: "#6b6b72", font: "600 13px Poppins", cursor: "pointer" }}>Vista previa completa</button>
+                <button onClick={() => setShowPreview(true)} style={{ padding: "12px 20px", borderRadius: 10, border: "1.5px solid #E7E7EA", background: "#fff", color: "#6b6b72", font: "600 13px Poppins", cursor: "pointer" }}>Vista previa completa</button>
                 <button onClick={() => setTab("envio")} style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 24px", borderRadius: 10, background: "#EF5B94", color: "#fff", font: "600 13px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.3)", cursor: "pointer" }}>
                   Continuar a enviar
                   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
@@ -399,12 +441,202 @@ export const InvitacionesStudio: FC = () => {
           </div>
         )}
 
-        {tab === "envio" && (
-          <div style={{ ...cardBox, padding: 40, textAlign: "center", color: "#9aa0a8", font: "600 14px Poppins" }}>
-            Paso “Enviar” — Fase B (tabla de invitados + barra de envío). Próximamente.
-          </div>
-        )}
+        {tab === "envio" && (() => {
+          const invitados: any[] = event?.invitados_array || [];
+          const isSent = (inv: any) => !!inv.invitacion;
+          const total = invitados.length;
+          const sentN = invitados.filter(isSent).length;
+          const unsentN = total - sentN;
+          const openN = 0; // el backend aún no rastrea aperturas
+          const stMap: Record<string, [string, string]> = {
+            "Enviada": ["#2FB37E", "#E4F5EE"], "Abierta": ["#EF5B94", "#FCE7F0"],
+            "Pendiente": ["#E0A32B", "#FBF0DA"], "Sin enviar": ["#b3b3ba", "#f2f2f4"], "Programada": ["#6E8BAA", "#EEF2F6"],
+          };
+          const avPal = ["#EF5B94", "#f588b3", "#d86fa0", "#EF5B94", "#f588b3"];
+          const stats = [
+            { v: total, l: "Total invitados", c: "#3A3A42" },
+            { v: sentN, l: "Enviadas", c: "#2FB37E" },
+            { v: openN, l: "Abiertas", c: "#EF5B94" },
+            { v: unsentN, l: "Sin enviar", c: "#E0A32B" },
+          ];
+          const q = searchB.trim().toLowerCase();
+          const rows = invitados.map((inv, i) => {
+            const st = isSent(inv) ? "Enviada" : "Sin enviar";
+            const ch: ChannelKey = inv.correo ? "email" : (inv.telefono ? "whatsapp" : "email");
+            return {
+              id: inv._id as string, initial: ((inv.nombre || "?").trim().charAt(0) || "?").toUpperCase(),
+              name: inv.nombre || "Sin nombre", email: inv.correo || "Sin correo",
+              channel: ch === "email" ? "Email" : ch === "whatsapp" ? "WhatsApp" : "SMS", channelKey: ch,
+              status: st, action: st === "Sin enviar" ? "Enviar" : "Reenviar", avBg: avPal[i % avPal.length],
+            };
+          });
+          const fMap: Record<string, string | null> = { todos: null, sin: "Sin enviar", enviadas: "Enviada", abiertas: "Abierta", pend: "Pendiente" };
+          const want = fMap[filterB];
+          const guests = rows.filter((g) => (!want || g.status === want) && (!q || g.name.toLowerCase().includes(q) || g.email.toLowerCase().includes(q)));
+          const fbDefs: [typeof filterB, string, number][] = [
+            ["todos", "Todos", total], ["sin", "Sin enviar", unsentN], ["enviadas", "Enviadas", sentN], ["abiertas", "Abiertas", openN], ["pend", "Pendientes", 0],
+          ];
+          const selIds = Object.keys(checked).filter((k) => checked[k]);
+          const selN = selIds.length;
+          const visibleIds = guests.map((g) => g.id);
+          const allOn = visibleIds.length > 0 && visibleIds.every((id) => checked[id]);
+          const toggleAll = () => {
+            const c = { ...checked };
+            if (allOn) visibleIds.forEach((id) => delete c[id]); else visibleIds.forEach((id) => { c[id] = true; });
+            setChecked(c);
+          };
+          const noEmailN = selIds.filter((id) => { const inv = invitados.find((x) => x._id === id); return inv && !inv.correo; }).length;
+          const checkMark = <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3.2} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>;
+          const sumTpl = PRESETS[design.template].label;
+          const sendChanLabel = sendChan === "email" ? "Email" : sendChan === "whatsapp" ? "WhatsApp" : "SMS";
+          const sendPreview = sendChan === "email" ? "Correo con diseño completo e imagen de portada." : sendChan === "whatsapp" ? `${design.names} · ¡Nos casamos! ${design.message} 📅 ${design.date}` : smsText;
+
+          return (
+            <div style={{ animation: "fadein .2s ease" }}>
+              {/* Stats */}
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 16 }}>
+                {stats.map((s, i) => (
+                  <div key={i} style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: "15px 18px", boxShadow: "0 4px 14px rgba(0,0,0,.05)" }}>
+                    <div style={{ font: `700 22px Poppins`, color: s.c }}>{s.v}</div>
+                    <div style={{ font: "500 11px Poppins", color: "#8a8a90" }}>{s.l}</div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Toolbar: invitación + buscador */}
+              <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: "12px 16px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 14, flexWrap: "wrap", boxShadow: "0 4px 14px rgba(0,0,0,.05)", marginBottom: 14 }}>
+                <div onClick={() => setTab("diseno")} title="Editar el diseño de la invitación" style={{ display: "flex", alignItems: "center", gap: 9, border: "1.5px solid #f0d9e4", background: "#fdf8fa", borderRadius: 11, padding: "9px 14px", cursor: "pointer" }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={1.8}><rect x="4" y="4" width="16" height="16" rx="2" /><path d="M8 9h8M8 13h5" /></svg>
+                  <span style={{ font: "500 11.5px Poppins", color: "#8a8a90" }}>Invitación:</span>
+                  <span style={{ font: "600 11.5px Poppins", color: "#3A3A42" }}>{sumTpl}</span>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9" /><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" /></svg>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 9, background: "#faf9fb", border: "1.5px solid #E7E7EA", borderRadius: 11, padding: "8px 13px" }}>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" /></svg>
+                  <input value={searchB} onChange={(e) => setSearchB(e.target.value)} type="text" placeholder="Buscar invitado" style={{ border: "none", outline: "none", background: "transparent", font: "500 12px Poppins", width: 130 }} />
+                </div>
+              </div>
+
+              {/* Filtros + seleccionar todos */}
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginBottom: 14, flexWrap: "wrap" }}>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  {fbDefs.map(([key, label, count]) => {
+                    const a = filterB === key;
+                    return (
+                      <div key={key} onClick={() => setFilterB(key)} style={{ display: "flex", alignItems: "center", gap: 7, padding: "8px 14px", borderRadius: 10, border: `1.5px solid ${a ? "#EF5B94" : "#E7E7EA"}`, background: a ? "#EF5B94" : "#fff", color: a ? "#fff" : "#6b6b72", font: "600 12px Poppins", cursor: "pointer" }}>
+                        {label}<span style={{ font: "600 10.5px Poppins", color: a ? "#fff" : "#a0a0a8" }}>{count}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div onClick={toggleAll} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 15px", borderRadius: 10, background: allOn ? "#EF5B94" : "#fff", border: `1.5px solid ${allOn ? "#EF5B94" : "#E7E7EA"}`, color: allOn ? "#fff" : "#6b6b72", font: "600 12px Poppins", cursor: "pointer", flex: "none" }}>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><path d="M9 11l3 3L22 4" /><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" /></svg>
+                  {allOn ? "Quitar selección" : "Seleccionar todos"}
+                </div>
+              </div>
+
+              {/* Tabla */}
+              <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 6px 20px rgba(0,0,0,.05)", overflow: "hidden" }}>
+                <div style={{ display: "grid", gridTemplateColumns: "34px 1.6fr 1fr 1fr 1fr", gap: 12, alignItems: "center", padding: "10px 22px", background: "#faf9fb", borderBottom: "1px solid #f0f0f2", font: "700 10px Poppins", color: "#a0a0a8", letterSpacing: ".5px", textTransform: "uppercase" }}>
+                  <div><div onClick={toggleAll} style={{ width: 17, height: 17, borderRadius: 5, border: `1.8px solid ${allOn ? "#EF5B94" : "#d8d8de"}`, background: allOn ? "#EF5B94" : "#fff", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>{allOn ? checkMark : null}</div></div>
+                  <div style={{ textAlign: "left" }}>Invitado</div><div style={{ textAlign: "left" }}>Canal</div><div style={{ textAlign: "left" }}>Estado</div><div style={{ textAlign: "left" }}>Acción</div>
+                </div>
+                {guests.length === 0 && (
+                  <div style={{ padding: "40px 22px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{total === 0 ? "Aún no tienes invitados en este evento." : "No hay invitados que coincidan con el filtro."}</div>
+                )}
+                {guests.map((g) => {
+                  const on = !!checked[g.id];
+                  const st = stMap[g.status];
+                  return (
+                    <div key={g.id} style={{ display: "grid", gridTemplateColumns: "34px 1.6fr 1fr 1fr 1fr", gap: 12, alignItems: "center", padding: "13px 22px", borderBottom: "1px solid #f5f5f7" }}>
+                      <div><div onClick={() => setChecked((c) => ({ ...c, [g.id]: !c[g.id] }))} style={{ width: 17, height: 17, borderRadius: 5, border: `1.8px solid ${on ? "#EF5B94" : "#d8d8de"}`, background: on ? "#EF5B94" : "#fff", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>{on ? checkMark : null}</div></div>
+                      <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+                        <div style={{ width: 32, height: 32, borderRadius: "50%", flex: "none", background: g.avBg, color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", font: "700 12px Poppins" }}>{g.initial}</div>
+                        <div style={{ minWidth: 0 }}>
+                          <div style={{ font: "600 12.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{g.name}</div>
+                          <div style={{ font: "500 10.5px Poppins", color: "#a0a0a8", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{g.email}</div>
+                        </div>
+                      </div>
+                      <div style={{ display: "flex", alignItems: "center", gap: 6, font: "600 11.5px Poppins", color: "#8a8a90" }}>{chanIcon(g.channelKey, "#8a8a90")}{g.channel}</div>
+                      <div><span style={{ display: "inline-flex", alignItems: "center", gap: 6, background: st[1], color: st[0], font: "600 10.5px Poppins", padding: "5px 10px", borderRadius: 20 }}><span style={{ width: 6, height: 6, borderRadius: "50%", background: st[0] }} />{g.status}</span></div>
+                      <div style={{ justifySelf: "start" }}><button onClick={() => setChecked((c) => ({ ...c, [g.id]: true }))} style={{ padding: "7px 15px", borderRadius: 9, border: "1.5px solid #EF5B94", background: "#fff", color: "#EF5B94", font: "600 11px Poppins", cursor: "pointer" }}>{g.action}</button></div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Barra flotante de envío / aviso vacío */}
+              {selN > 0 ? (
+                <div style={{ position: "sticky", bottom: 20, marginTop: 18, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "14px 20px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, flexWrap: "wrap", boxShadow: "0 14px 34px rgba(0,0,0,.16)", animation: "fadein .2s ease" }}>
+                  <div style={{ flexBasis: "100%", display: "flex", alignItems: "flex-start", gap: 11, background: "#faf9fb", border: "1px solid #f0f0f2", borderRadius: 12, padding: "11px 14px" }}>
+                    <div style={{ width: 30, height: 30, borderRadius: 8, flex: "none", background: "#FCE7F0", display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94" }}>{chanIcon(sendChan, "#EF5B94")}</div>
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ font: "700 10px Poppins", color: "#a0a0a8", letterSpacing: ".5px", textTransform: "uppercase" }}>Vista previa · {sendChanLabel}</div>
+                      <div style={{ font: "500 12px Poppins", color: "#4a4a52", marginTop: 3, lineHeight: 1.5 }}>{sendPreview}</div>
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                    <div style={{ width: 34, height: 34, borderRadius: "50%", background: "#EF5B94", color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", font: "700 13px Poppins", flex: "none" }}>{selN}</div>
+                    <div style={{ lineHeight: 1.3 }}>
+                      <div style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{selN} seleccionado{selN > 1 ? "s" : ""}</div>
+                      <div onClick={() => setChecked({})} style={{ font: "500 11px Poppins", color: "#EF5B94", cursor: "pointer" }}>Quitar selección</div>
+                    </div>
+                    {noEmailN > 0 && <span style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "#FBF0DA", color: "#B8860B", font: "600 10.5px Poppins", padding: "5px 10px", borderRadius: 20 }}>⚠ {noEmailN} sin correo · se enviarán por WhatsApp</span>}
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 14, flexWrap: "wrap" }}>
+                    <div style={{ display: "flex", gap: 4, background: "#f2f2f4", borderRadius: 11, padding: 4 }}>
+                      <div onClick={() => setSendMode("now")} style={{ padding: "8px 13px", borderRadius: 8, background: sendMode === "now" ? "#fff" : "transparent", color: sendMode === "now" ? "#3A3A42" : "#8a8a90", font: "600 11.5px Poppins", cursor: "pointer", boxShadow: sendMode === "now" ? "0 1px 3px rgba(0,0,0,.12)" : "none" }}>Ahora</div>
+                      <div title="Próximamente" style={{ padding: "8px 13px", borderRadius: 8, background: "transparent", color: "#c5c5cc", font: "600 11.5px Poppins", cursor: "not-allowed" }}>Programar</div>
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ font: "500 11.5px Poppins", color: "#8a8a90" }}>Enviar por</span>
+                      <div style={{ display: "flex", gap: 4, background: "#f2f2f4", borderRadius: 11, padding: 4 }}>
+                        {(["email", "whatsapp", "sms"] as ChannelKey[]).map((c) => {
+                          const a = sendChan === c;
+                          return <div key={c} onClick={() => setSendChan(c)} style={{ display: "flex", alignItems: "center", gap: 6, padding: "8px 13px", borderRadius: 8, background: a ? "#fff" : "transparent", color: a ? "#3A3A42" : "#8a8a90", font: "600 11.5px Poppins", cursor: "pointer", boxShadow: a ? "0 1px 3px rgba(0,0,0,.12)" : "none" }}>{chanIcon(c, a ? "#EF5B94" : "#9aa0a8")}{c === "email" ? "Email" : c === "whatsapp" ? "WhatsApp" : "SMS"}</div>;
+                        })}
+                      </div>
+                    </div>
+                    <button onClick={doSend} disabled={sending} style={{ display: "flex", alignItems: "center", gap: 8, padding: "11px 22px", borderRadius: 10, background: "#EF5B94", color: "#fff", font: "600 13px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.35)", border: "none", cursor: sending ? "wait" : "pointer", opacity: sending ? .7 : 1 }}>
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" /></svg>
+                      {sending ? "Enviando…" : `Enviar por ${sendChanLabel}`}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div style={{ marginTop: 16, display: "flex", alignItems: "center", justifyContent: "center", gap: 9, padding: 14, border: "1.5px dashed #e6d0da", borderRadius: 14, background: "#fdf8fa" }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={1.8}><path d="M9 11l3 3L22 4" /><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" /></svg>
+                  <span style={{ font: "500 12.5px Poppins", color: "#8a8a90" }}>Marca los invitados que quieras y elige cómo enviarles la invitación.</span>
+                </div>
+              )}
+            </div>
+          );
+        })()}
       </div>
+
+      {/* Modal "Vista previa de la invitación" — markup exacto del HTML */}
+      {showPreview && (
+        <div onClick={() => setShowPreview(false)} style={{ position: "fixed", inset: 0, background: "rgba(43,43,48,.62)", zIndex: 64, display: "flex", alignItems: "center", justifyContent: "center", padding: "40px 20px", overflow: "auto" }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ width: 420, maxWidth: "100%", animation: "fadein .22s ease" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
+              <div style={{ font: "600 13px Poppins", color: "#fff" }}>Vista previa de la invitación</div>
+              <div onClick={() => setShowPreview(false)} style={{ width: 34, height: 34, borderRadius: "50%", background: "rgba(255,255,255,.16)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", cursor: "pointer" }}>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M6 6l12 12M18 6L6 18" /></svg>
+              </div>
+            </div>
+            <div style={{ background: "#fff", borderRadius: 22, overflow: "hidden", boxShadow: "0 30px 80px rgba(0,0,0,.4)" }}>
+              <div style={{ height: 300, background: coverBg, borderBottom: `3px solid ${accent}` }} />
+              <div style={{ padding: "40px 40px 46px", textAlign: "center" }}>
+                <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 16, color: accent, letterSpacing: 4 }}>{design.title}</div>
+                <div style={{ height: 1, background: accent, opacity: .4, margin: "16px 44px" }} />
+                <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 34, color: "#3A3A42" }}>{design.names}</div>
+                <div style={{ font: "600 14px Poppins", color: accent, marginTop: 12, letterSpacing: ".5px" }}>{design.date}</div>
+                <div style={{ fontFamily: invFont, fontSize: 14, color: "#8a8a90", marginTop: 20, lineHeight: 1.7 }}>{design.message}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
+++ b/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useRef, useState, ReactNode } from "react";
 import Head from "next/head";
 import { useTranslation } from "react-i18next";
 import BlockTitle from "../Utils/BlockTitle";
@@ -9,20 +9,12 @@ import { useToast } from "../../hooks/useToast";
 import { fetchApiEventos, queries } from "../../utils/Fetching";
 
 /**
- * InvitacionesStudio — Rediseño UI del módulo de Invitaciones (wizard 2 pasos).
- *
- * FASE A: paso "Diseñar invitación". Réplica del HTML "Invitaciones estudio" (paleta
- * rosa #EF5B94 / Poppins). MISMO BACKEND: el diseñador estructurado persiste vía las
- * operaciones existentes `updateEmailTemplate`/`createEmailTemplate` (design + html),
- * SIN tocar Fetching.ts ni las 16 operaciones. `design` guarda nuestro JSON estructurado
- * (esquema `DesignData` con marca `_studio:'v1'`); `html` = email renderizado.
- * Plantillas antiguas (Unlayer) siguen enviándose; simplemente no se abren aquí (esquema
- * distinto) → se cae a valores por defecto del evento.
- *
- * El paso "Enviar" (Fase B) queda como placeholder en este primer corte.
+ * InvitacionesStudio — Rediseño UI (wizard 2 pasos). FASE A: paso "Diseñar invitación".
+ * CSS replicado VERBATIM del HTML "Invitaciones estudio" (estilos inline exactos).
+ * MISMO BACKEND: persiste vía updateEmailTemplate/createEmailTemplate ({design, html});
+ * design = JSON estructurado (_studio:'v1'); html = email renderizado. No toca Fetching.ts.
  */
 
-// ---- Tipos y presets --------------------------------------------------------
 type TemplateKey = "elegante" | "clasica" | "moderna";
 type FontKey = "elegante" | "moderna" | "script";
 type ChannelKey = "email" | "whatsapp" | "sms";
@@ -42,37 +34,19 @@ interface DesignData {
   rsvp: string;
 }
 
-const PINK = "#EF5B94";
-const PINK_HOVER = "#D83E7C";
-const INK = "#3A3A42";
-const BORDER = "#E7E7EA";
-
-// Gradientes de plantilla EXACTOS del HTML "Invitaciones estudio"
+// Gradientes de plantilla EXACTOS del HTML
 const PRESETS: Record<TemplateKey, { label: string; grad: string }> = {
   elegante: { label: "Elegante", grad: "linear-gradient(135deg,#f7c2da,#EF5B94)" },
   clasica: { label: "Clásica", grad: "linear-gradient(135deg,#ece4d6,#dccdb4)" },
   moderna: { label: "Moderna", grad: "linear-gradient(135deg,#dfe6ec,#b9cbdb)" },
 };
-
-// Tipografías del diseño: Elegante=Playfair · Moderna=Poppins · Script=Dancing Script
 const FONTS: Record<FontKey, { label: string; family: string }> = {
   elegante: { label: "Elegante", family: "'Playfair Display',serif" },
   moderna: { label: "Moderna", family: "'Poppins',sans-serif" },
   script: { label: "Script", family: "'Dancing Script',cursive" },
 };
-
 // Paleta "Color de acento" (tonos suaves): rosa · crema · oliva · azul acero · oro
 const ACCENTS = ["#C99AA6", "#E8DEC5", "#8DA07A", "#6E8BAA", "#C9A24B"];
-
-const TEXT_FIELDS: { key: keyof DesignData; label: string; area?: boolean }[] = [
-  { key: "title", label: "Encabezado" },
-  { key: "names", label: "Nombres" },
-  { key: "date", label: "Fecha" },
-  { key: "message", label: "Mensaje", area: true },
-  { key: "venue", label: "Lugar (reverso)" },
-  { key: "time", label: "Hora" },
-  { key: "rsvp", label: "RSVP" },
-];
 
 const defaultDesign = (event: any): DesignData => ({
   _studio: "v1",
@@ -84,12 +58,11 @@ const defaultDesign = (event: any): DesignData => ({
   names: event?.nombre || "Ana & Marcos",
   date: event?.fecha ? new Date(event.fecha).toLocaleDateString("es-ES", { day: "numeric", month: "long", year: "numeric" }) : "12 de Junio, 2028",
   message: "Nos encantaría compartir contigo este día tan especial.",
-  venue: event?.poblacion || "",
+  venue: "",
   time: "",
   rsvp: "Confirma tu asistencia",
 });
 
-// ---- Render del email (html que se persiste) --------------------------------
 const renderEmailHtml = (d: DesignData): string => {
   const p = PRESETS[d.template];
   const font = FONTS[d.font].family;
@@ -102,14 +75,20 @@ const renderEmailHtml = (d: DesignData): string => {
       <div style="font-weight:700;font-size:26px;color:#3A3A42;">${d.names}</div>
       <div style="font-weight:600;font-size:12px;color:${d.accent};margin-top:8px;">${d.date}</div>
       <div style="font-size:13.5px;color:#8a8a90;margin-top:14px;line-height:1.6;">${d.message}</div>
-      <a href="#" style="display:inline-block;margin-top:20px;background:${d.accent};color:#fff;text-decoration:none;font-weight:600;font-size:13px;padding:11px 22px;border-radius:10px;">Ver invitación y confirmar</a>
     </div>
   </div></body></html>`;
 };
 
-// ---- Componente -------------------------------------------------------------
+// SVG de canales (como el HTML: iconos, no emoji)
+const chanIcon = (c: ChannelKey, color: string): ReactNode => {
+  const common = { width: 15, height: 15, viewBox: "0 0 24 24", fill: "none", stroke: color, strokeWidth: 1.8, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
+  if (c === "email") return (<svg {...common}><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 7l9 6 9-6" /></svg>);
+  if (c === "whatsapp") return (<svg {...common}><path d="M21 11.5a8.4 8.4 0 0 1-11.6 7.8L3 21l1.9-5.4A8.4 8.4 0 1 1 21 11.5z" /></svg>);
+  return (<svg {...common}><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>);
+};
+
 export const InvitacionesStudio: FC = () => {
-  const { t } = useTranslation();
+  useTranslation();
   const { event } = EventContextProvider() as any;
   const auth = AuthContextProvider() as any;
   const toast = useToast();
@@ -117,6 +96,7 @@ export const InvitacionesStudio: FC = () => {
   const [tab, setTab] = useState<"diseno" | "envio">("diseno");
   const [channel, setChannel] = useState<ChannelKey>("email");
   const [face, setFace] = useState<"front" | "back">("front");
+  const [previewMobile, setPreviewMobile] = useState(false);
   const [design, setDesign] = useState<DesignData>(() => defaultDesign(event));
   const [templateId, setTemplateId] = useState<string | undefined>(event?.templateEmailSelect);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("saved");
@@ -127,7 +107,6 @@ export const InvitacionesStudio: FC = () => {
   const loadedRef = useRef(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout>>();
 
-  // Carga del diseño actual (si la plantilla es de nuestro esquema estructurado)
   useEffect(() => {
     const id = event?.templateEmailSelect;
     if (!id || loadedRef.current) return;
@@ -139,10 +118,9 @@ export const InvitacionesStudio: FC = () => {
         const dz = tpl?.design;
         if (dz && dz._studio === "v1") setDesign({ ...defaultDesign(event), ...dz });
       })
-      .catch(() => {/* plantilla antigua/no legible → defaults */});
+      .catch(() => {/* plantilla antigua → defaults */});
   }, [event?._id, event?.templateEmailSelect]);
 
-  // Autosave (debounce) — MISMO backend: updateEmailTemplate / createEmailTemplate
   const persist = useCallback((d: DesignData) => {
     if (!event?._id) return;
     setSaveState("saving");
@@ -150,17 +128,10 @@ export const InvitacionesStudio: FC = () => {
     const done = (id?: string) => { if (id) setTemplateId(id); setSaveState("saved"); };
     if (templateId) {
       fetchApiEventos({ query: queries.updateEmailTemplate, variables: { evento_id: event._id, template_id: templateId, design: d, html } })
-        .then((res: any) => done(Array.isArray(res) ? res[0]?._id : res?._id))
-        .catch(() => setSaveState("idle"));
+        .then((res: any) => done(Array.isArray(res) ? res[0]?._id : res?._id)).catch(() => setSaveState("idle"));
     } else {
-      fetchApiEventos({
-        query: queries.createEmailTemplate,
-        variables: {
-          evento_id: event._id, design: d, html,
-          configTemplate: { name: "Invitación", subject: d.title || "Invitación" },
-          domain: auth?.config?.dominio || auth?.config?.domain,
-        },
-      }).then((res: any) => done(res?._id)).catch(() => setSaveState("idle"));
+      fetchApiEventos({ query: queries.createEmailTemplate, variables: { evento_id: event._id, design: d, html, configTemplate: { name: "Invitación", subject: d.title || "Invitación" }, domain: auth?.config?.dominio || auth?.config?.domain } })
+        .then((res: any) => done(res?._id)).catch(() => setSaveState("idle"));
     }
   }, [event?._id, templateId, auth]);
 
@@ -174,30 +145,33 @@ export const InvitacionesStudio: FC = () => {
     });
   }, [persist]);
 
-  // Subida de la foto de portada — MISMO backend (singleUpload → R2, subir_archivo reutilizado)
   const handleCoverFile = useCallback(async (file?: File | null) => {
     if (!file || !event?._id) return;
-    setCoverLocal(URL.createObjectURL(file)); // preview inmediato mientras sube
+    setCoverLocal(URL.createObjectURL(file));
     setUploadingCover(true);
     try {
       const r: any = await subir_archivo({ imagePreviewUrl: { file }, event, use: "portada" });
       const url = r?.i1024 || r?.i800 || r?.i640;
-      if (url) update({ cover: url });
-      else toast("error", "No se pudo subir la imagen");
-    } catch {
-      toast("error", "No se pudo subir la imagen");
-    } finally {
-      setUploadingCover(false);
-    }
+      if (url) update({ cover: url }); else toast("error", "No se pudo subir la imagen");
+    } catch { toast("error", "No se pudo subir la imagen"); }
+    finally { setUploadingCover(false); }
   }, [event, update, toast]);
 
-  const preset = PRESETS[design.template];
+  const grad = PRESETS[design.template].grad;
   const invFont = FONTS[design.font].family;
+  const accent = design.accent;
+  const coverBg = (design.cover || coverLocal) ? `url(${design.cover || coverLocal}) center/cover` : grad;
+  const smsText = `${design.names}: ${design.message} ${design.date}. Confirma: bod.as/xxxx`;
 
-  // ---- estilos reutilizables ----
-  const card: React.CSSProperties = { background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)" };
-  const label: React.CSSProperties = { font: "600 12px Poppins", color: PINK, marginBottom: 6, display: "block" };
-  const input: React.CSSProperties = { width: "100%", border: `1.5px solid ${BORDER}`, borderRadius: 10, padding: "11px 14px", font: "500 13px Poppins", color: INK, outline: "none", background: "#fff" };
+  // helpers de estilo replicando el HTML
+  const cardBox: React.CSSProperties = { background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: "20px 22px" };
+  const cardTitle: React.CSSProperties = { font: "600 13.5px Poppins", color: "#3A3A42", marginBottom: 14 };
+  const fieldLabel: React.CSSProperties = { font: "600 11px Poppins", color: "#EF5B94", marginBottom: 6 };
+  const fieldInput: React.CSSProperties = { width: "100%", border: "1.5px solid #E7E7EA", borderRadius: 10, padding: "10px 13px", font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" };
+
+  const TEXTS: { k: keyof DesignData; label: string }[] = [
+    { k: "title", label: "Encabezado" }, { k: "names", label: "Nombres" }, { k: "date", label: "Fecha" },
+  ];
 
   return (
     <div style={{ background: "#f1f1f4", minHeight: "100%", fontFamily: "'Poppins',sans-serif" }}>
@@ -207,18 +181,16 @@ export const InvitacionesStudio: FC = () => {
       </Head>
       <div style={{ maxWidth: 1000, margin: "0 auto", padding: "22px 30px 60px" }}>
 
-        {/* Cabecera ESTÁNDAR compartida (misma que presupuesto/mesas/invitados) */}
-        <div style={{ marginBottom: 20 }}>
-          <BlockTitle title={"Invitaciones"} />
-        </div>
+        {/* Cabecera estándar compartida */}
+        <div style={{ marginBottom: 20 }}><BlockTitle title={"Invitaciones"} /></div>
 
         {/* Tabs 1 Diseñar / 2 Enviar */}
-        <div style={{ display: "inline-flex", gap: 6, ...card, borderRadius: 14, padding: 6, marginBottom: 24 }}>
+        <div style={{ display: "inline-flex", gap: 6, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: 6, marginBottom: 24 }}>
           {([["diseno", "1", "Diseñar invitación"], ["envio", "2", "Enviar"]] as const).map(([key, num, txt]) => {
-            const active = tab === key;
+            const a = tab === key;
             return (
-              <div key={key} onClick={() => setTab(key)} style={{ display: "flex", alignItems: "center", gap: 9, padding: "10px 22px", borderRadius: 10, background: active ? PINK : "transparent", color: active ? "#fff" : "#6b6b72", font: `${active ? 700 : 600} 14px Poppins`, cursor: "pointer" }}>
-                <span style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 20, height: 20, borderRadius: "50%", background: active ? "rgba(255,255,255,.25)" : "#EDEDF0", color: active ? "#fff" : "#9aa0a8", font: "700 11px Poppins" }}>{num}</span>
+              <div key={key} onClick={() => setTab(key)} style={{ display: "flex", alignItems: "center", gap: 9, padding: "10px 22px", borderRadius: 10, background: a ? "#FCE7F0" : "transparent", color: a ? "#D83E7C" : "#6b6b72", font: `${a ? 700 : 600} 14px Poppins`, cursor: "pointer" }}>
+                <span style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 20, height: 20, borderRadius: "50%", background: a ? "#EF5B94" : "#EDEDF0", color: a ? "#fff" : "#9aa0a8", font: "700 11px Poppins", flex: "none" }}>{num}</span>
                 {txt}
               </div>
             );
@@ -228,19 +200,20 @@ export const InvitacionesStudio: FC = () => {
         {/* Onboarding */}
         {showOnb && (
           <div style={{ display: "flex", marginBottom: 16 }}>
-            <div style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "#FCE7F0", borderRadius: 999, padding: "10px 18px" }}>
-              <span style={{ font: "700 14px Poppins", color: "#B23A6B" }}>ⓘ</span>
+            <div style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "#FCE7F0", borderRadius: 999, padding: "10px 18px", whiteSpace: "nowrap" }}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#B23A6B" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" style={{ flex: "none" }}><circle cx="12" cy="12" r="10" /><path d="M12 16v-4M12 8h.01" /></svg>
               <span style={{ font: "600 13px Poppins", color: "#B23A6B" }}>Diseña tu invitación y envíala por email, WhatsApp o SMS.</span>
-              <div onClick={() => setShowOnb(false)} style={{ cursor: "pointer", color: "#B23A6B", marginLeft: 4 }}>✕</div>
+              <div onClick={() => setShowOnb(false)} style={{ cursor: "pointer", color: "#B23A6B", display: "flex", marginLeft: 4 }}>
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M6 6l12 12M18 6L6 18" /></svg>
+              </div>
             </div>
           </div>
         )}
 
-        {/* PASO DISEÑAR */}
         {tab === "diseno" && (
           <div style={{ animation: "fadein .2s ease", display: "grid", gridTemplateColumns: "380px 1fr", gap: 22, alignItems: "start" }}>
 
-            {/* Vista previa (sticky) */}
+            {/* LIVE PREVIEW */}
             <div style={{ position: "sticky", top: 20 }}>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -249,86 +222,107 @@ export const InvitacionesStudio: FC = () => {
                   {saveState === "saving" && <span style={{ font: "600 10px Poppins", color: "#a0a0a8", background: "#f0f0f2", padding: "3px 8px", borderRadius: 10 }}>Guardando…</span>}
                 </div>
                 <div style={{ display: "flex", gap: 3, background: "#ececed", borderRadius: 9, padding: 3 }}>
-                  {(["email", "whatsapp", "sms"] as ChannelKey[]).map((c) => (
-                    <div key={c} onClick={() => setChannel(c)} title={c} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 30, height: 26, borderRadius: 7, background: channel === c ? "#fff" : "transparent", color: channel === c ? PINK : "#9aa0a8", cursor: "pointer", boxShadow: channel === c ? "0 1px 4px rgba(0,0,0,.12)" : "none", font: "600 10px Poppins", textTransform: "uppercase" }}>{c === "email" ? "✉" : c === "whatsapp" ? "💬" : "▤"}</div>
-                  ))}
+                  {(["email", "whatsapp", "sms"] as ChannelKey[]).map((c) => {
+                    const a = channel === c;
+                    return <div key={c} onClick={() => setChannel(c)} title={c} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 30, height: 26, borderRadius: 7, background: a ? "#fff" : "transparent", boxShadow: a ? "0 1px 3px rgba(0,0,0,.14)" : "none", cursor: "pointer" }}>{chanIcon(c, a ? "#EF5B94" : "#9aa0a8")}</div>;
+                  })}
                 </div>
               </div>
 
               {channel === "email" && (
-                <>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
-                    <div style={{ display: "flex", gap: 3, background: "#ececed", borderRadius: 9, padding: 3 }}>
-                      {(["front", "back"] as const).map((f) => (
-                        <div key={f} onClick={() => setFace(f)} style={{ padding: "6px 13px", borderRadius: 7, background: face === f ? "#fff" : "transparent", color: face === f ? INK : "#9aa0a8", font: "600 11px Poppins", cursor: "pointer" }}>{f === "front" ? "Portada" : "Detalles"}</div>
-                      ))}
-                    </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+                  <div style={{ display: "flex", gap: 3, background: "#ececed", borderRadius: 9, padding: 3 }}>
+                    {(["front", "back"] as const).map((f) => (
+                      <div key={f} onClick={() => setFace(f)} style={{ padding: "6px 13px", borderRadius: 7, background: face === f ? "#fff" : "transparent", color: face === f ? "#D83E7C" : "#9aa0a8", font: "600 11px Poppins", cursor: "pointer" }}>{f === "front" ? "Portada" : "Detalles"}</div>
+                    ))}
                   </div>
+                  <div onClick={() => setPreviewMobile((v) => !v)} style={{ display: "flex", alignItems: "center", gap: 6, marginLeft: "auto", padding: "6px 12px", borderRadius: 9, border: `1.5px solid ${previewMobile ? "#EF5B94" : "#E7E7EA"}`, background: "#fff", color: previewMobile ? "#D83E7C" : "#6b6b72", font: "600 11px Poppins", cursor: "pointer" }}>
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><rect x="7" y="2" width="10" height="20" rx="2.5" /><path d="M11 18h2" /></svg>Móvil
+                  </div>
+                </div>
+              )}
+
+              {/* EMAIL face */}
+              {channel === "email" && (
+                <div style={{ margin: previewMobile ? "0 auto" : undefined, maxWidth: previewMobile ? 300 : undefined }}>
+                  {previewMobile && <div style={{ width: 52, height: 5, borderRadius: 3, background: "#3a3a42", margin: "2px auto 10px" }} />}
                   <div style={{ width: "100%", background: "#fff", borderRadius: 18, boxShadow: "0 12px 34px rgba(0,0,0,.12)", overflow: "hidden", border: "1px solid #f0f0f2" }}>
-                    <div
-                      onClick={() => coverInputRef.current?.click()}
-                      onDragOver={(e) => e.preventDefault()}
-                      onDrop={(e) => { e.preventDefault(); handleCoverFile(e.dataTransfer.files?.[0]); }}
-                      style={{ height: 190, background: (design.cover || coverLocal) ? `url(${design.cover || coverLocal}) center/cover` : preset.grad, borderBottom: `3px solid ${design.accent}`, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,.92)", font: "600 12px Poppins", flexDirection: "column", gap: 4, cursor: "pointer", position: "relative" }}
-                    >
+                    <div onClick={() => coverInputRef.current?.click()} onDragOver={(e) => e.preventDefault()} onDrop={(e) => { e.preventDefault(); handleCoverFile(e.dataTransfer.files?.[0]); }}
+                      style={{ height: 190, position: "relative", background: coverBg, borderBottom: `3px solid ${accent}`, display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 4, color: "rgba(255,255,255,.92)", font: "600 12px Poppins", cursor: "pointer" }}>
                       {!(design.cover || coverLocal) && (<><span style={{ fontSize: 26 }}>🖼</span>Arrastra la foto de portada<span style={{ fontSize: 10, opacity: .85, textDecoration: "underline" }}>o haz clic para subir</span></>)}
-                      {uploadingCover && (<span style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,.35)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", font: "600 12px Poppins" }}>Subiendo…</span>)}
+                      {uploadingCover && <span style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,.35)", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", font: "600 12px Poppins" }}>Subiendo…</span>}
                       <input ref={coverInputRef} type="file" accept="image/*" onChange={(e) => handleCoverFile(e.target.files?.[0])} style={{ display: "none" }} />
                     </div>
                     {face === "front" ? (
-                      <div style={{ padding: "26px 26px 30px", textAlign: "center" }}>
-                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 15, color: design.accent, letterSpacing: 3 }}>{design.title}</div>
-                        <div style={{ height: 1, background: design.accent, opacity: .4, margin: "14px 34px" }} />
-                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 26, color: INK }}>{design.names}</div>
-                        <div style={{ font: "600 12px Poppins", color: design.accent, marginTop: 8, letterSpacing: ".5px" }}>{design.date}</div>
+                      <div style={{ padding: "26px 26px 30px", textAlign: "center", background: "#fff" }}>
+                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 15, color: accent, letterSpacing: 3 }}>{design.title}</div>
+                        <div style={{ height: 1, background: accent, opacity: .4, margin: "14px 34px" }} />
+                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 26, color: "#3A3A42" }}>{design.names}</div>
+                        <div style={{ font: "600 12px Poppins", color: accent, marginTop: 8, letterSpacing: ".5px" }}>{design.date}</div>
                         <div style={{ fontFamily: invFont, fontSize: 13.5, color: "#8a8a90", marginTop: 14, lineHeight: 1.6 }}>{design.message}</div>
                       </div>
                     ) : (
-                      <div style={{ padding: "28px 26px 32px", textAlign: "center" }}>
-                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 14, color: design.accent, letterSpacing: 2 }}>DETALLES</div>
-                        <div style={{ height: 1, background: design.accent, opacity: .4, margin: "14px 34px" }} />
+                      <div style={{ padding: "28px 26px 32px", textAlign: "center", background: "#fff" }}>
+                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 14, color: accent, letterSpacing: 2 }}>DETALLES</div>
+                        <div style={{ height: 1, background: accent, opacity: .4, margin: "14px 34px" }} />
                         <div style={{ font: "600 11px Poppins", color: "#a0a0a8" }}>Lugar</div>
-                        <div style={{ fontFamily: invFont, fontSize: 16, color: INK }}>{design.venue || "—"}</div>
+                        <div style={{ fontFamily: invFont, fontSize: 16, color: "#3A3A42" }}>{design.venue || "—"}</div>
                         <div style={{ font: "600 11px Poppins", color: "#a0a0a8", marginTop: 12 }}>Hora</div>
-                        <div style={{ fontFamily: invFont, fontSize: 16, color: INK }}>{design.time || "—"}</div>
-                        <div style={{ font: "600 12px Poppins", color: design.accent, marginTop: 14 }}>{design.rsvp}</div>
+                        <div style={{ fontFamily: invFont, fontSize: 16, color: "#3A3A42" }}>{design.time || "—"}</div>
+                        <div style={{ marginTop: 18, display: "inline-block", background: accent, color: "#fff", font: "600 11.5px Poppins", padding: "8px 16px", borderRadius: 20 }}>{design.rsvp}</div>
                       </div>
                     )}
                   </div>
+                  <div style={{ font: "500 11px Poppins", color: "#a0a0a8", marginTop: 10, textAlign: "center" }}>Correo con diseño completo e imagen de portada.</div>
+                </div>
+              )}
+
+              {/* WHATSAPP face */}
+              {channel === "whatsapp" && (
+                <>
+                  <div style={{ width: "100%", background: "#E5DDD5", borderRadius: 20, boxShadow: "0 12px 34px rgba(0,0,0,.12)", padding: "20px 16px", border: "1px solid #f0f0f2" }}>
+                    <div style={{ maxWidth: 270, background: "#fff", borderRadius: "4px 14px 14px 14px", boxShadow: "0 1px 2px rgba(0,0,0,.15)", overflow: "hidden" }}>
+                      <div style={{ height: 150, background: coverBg }} />
+                      <div style={{ padding: "10px 12px 12px" }}>
+                        <div style={{ font: "700 13px Poppins", color: "#3A3A42" }}>{design.names} · ¡Nos casamos!</div>
+                        <div style={{ font: "400 12px Poppins", color: "#4a4a52", marginTop: 4, lineHeight: 1.5 }}>{design.message} 📅 {design.date}</div>
+                        <div style={{ font: "500 12px Poppins", color: "#EF5B94", marginTop: 8 }}>Ver invitación y confirmar →</div>
+                        <div style={{ textAlign: "right", font: "400 9px Poppins", color: "#9aa0a6", marginTop: 6 }}>12:30 ✓✓</div>
+                      </div>
+                    </div>
+                  </div>
+                  <div style={{ font: "500 11px Poppins", color: "#a0a0a8", marginTop: 10, textAlign: "center" }}>Mensaje con imagen, texto corto y enlace a la invitación.</div>
                 </>
               )}
 
-              {channel === "whatsapp" && (
-                <div style={{ ...card, padding: 18 }}>
-                  <div style={{ font: "700 13px Poppins", color: INK }}>{design.names} · ¡Nos casamos!</div>
-                  <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", marginTop: 8, lineHeight: 1.6 }}>{design.message} 📅 {design.date}</div>
-                  <div style={{ color: PINK, font: "600 12.5px Poppins", marginTop: 10 }}>Ver invitación y confirmar →</div>
-                  <div style={{ font: "500 10px Poppins", color: "#a0a0a8", marginTop: 12 }}>Mensaje con imagen, texto corto y enlace a la invitación.</div>
-                </div>
-              )}
-
+              {/* SMS face */}
               {channel === "sms" && (
-                <div style={{ ...card, padding: 18 }}>
-                  <div style={{ font: "500 13px Poppins", color: INK, lineHeight: 1.6 }}>{design.names}: {design.message} {design.date}. Confirma: bod.as/xxxx</div>
-                  <div style={{ font: "500 10px Poppins", color: "#a0a0a8", marginTop: 12 }}>Solo texto y enlace, sin imagen.</div>
-                </div>
+                <>
+                  <div style={{ width: "100%", background: "#f2f2f4", borderRadius: 20, boxShadow: "0 12px 34px rgba(0,0,0,.12)", padding: "22px 18px", border: "1px solid #f0f0f2", minHeight: 150 }}>
+                    <div style={{ maxWidth: 250, background: "#E9E9EB", borderRadius: "16px 16px 16px 4px", padding: "12px 15px" }}>
+                      <div style={{ font: "400 12.5px Poppins", color: "#3A3A42", lineHeight: 1.55 }}>{smsText}</div>
+                    </div>
+                    <div style={{ font: "400 9.5px Poppins", color: "#a0a0a8", marginTop: 6, paddingLeft: 4 }}>Entregado</div>
+                  </div>
+                  <div style={{ font: "500 11px Poppins", color: smsText.length > 160 ? "#E76F51" : "#a0a0a8", marginTop: 10, textAlign: "center" }}>{smsText.length} caracteres · sin imagen, solo texto y enlace.</div>
+                </>
               )}
             </div>
 
-            {/* Controles */}
-            <div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+            {/* CONTROLS */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
               {/* Plantilla */}
-              <div style={{ ...card, padding: 20 }}>
-                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Plantilla</div>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
+              <div style={cardBox}>
+                <div style={cardTitle}>Plantilla</div>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12 }}>
                   {(Object.keys(PRESETS) as TemplateKey[]).map((k) => {
                     const sel = design.template === k;
                     return (
-                      <div key={k} onClick={() => update({ template: k })} style={{ border: `2px solid ${sel ? PINK : "#f0f0f2"}`, borderRadius: 12, overflow: "hidden", cursor: "pointer", background: "#fff" }}>
-                        <div style={{ height: 70, background: PRESETS[k].grad }} />
-                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 10px" }}>
-                          <span style={{ font: "600 12px Poppins", color: INK }}>{PRESETS[k].label}</span>
-                          <span style={{ width: 16, height: 16, borderRadius: "50%", background: PINK, color: "#fff", font: "700 10px Poppins", display: "flex", alignItems: "center", justifyContent: "center" }}>{sel ? "✓" : ""}</span>
+                      <div key={k} onClick={() => update({ template: k })} style={{ border: `2px solid ${sel ? "#EF5B94" : "#f0f0f2"}`, borderRadius: 13, overflow: "hidden", cursor: "pointer" }}>
+                        <div style={{ height: 76, background: PRESETS[k].grad }} />
+                        <div style={{ padding: "8px 10px", display: "flex", alignItems: "center", justifyContent: "space-between", background: "#fff" }}>
+                          <span style={{ font: "600 11px Poppins", color: "#3A3A42" }}>{PRESETS[k].label}</span>
+                          <div style={{ width: 16, height: 16, borderRadius: "50%", background: "#EF5B94", display: "flex", alignItems: "center", justifyContent: "center", color: "#fff", font: "700 9px Poppins" }}>{sel ? "✓" : ""}</div>
                         </div>
                       </div>
                     );
@@ -337,15 +331,15 @@ export const InvitacionesStudio: FC = () => {
               </div>
 
               {/* Tipografía */}
-              <div style={{ ...card, padding: 20 }}>
-                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Tipografía</div>
-                <div style={{ display: "flex", gap: 10 }}>
+              <div style={cardBox}>
+                <div style={cardTitle}>Tipografía</div>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 10 }}>
                   {(Object.keys(FONTS) as FontKey[]).map((f) => {
                     const sel = design.font === f;
                     return (
-                      <div key={f} onClick={() => update({ font: f })} style={{ flex: 1, textAlign: "center", border: `1.5px solid ${sel ? PINK : BORDER}`, borderRadius: 10, padding: "10px 6px", cursor: "pointer", background: sel ? "#FDF2F7" : "#fff" }}>
-                        <div style={{ fontFamily: FONTS[f].family, fontSize: 20, color: INK }}>Aa</div>
-                        <div style={{ font: "600 10.5px Poppins", color: sel ? PINK : "#9aa0a8", marginTop: 4 }}>{FONTS[f].label}</div>
+                      <div key={f} onClick={() => update({ font: f })} style={{ border: `1.5px solid ${sel ? "#EF5B94" : "#E7E7EA"}`, background: sel ? "#FCE7F0" : "#fff", borderRadius: 11, padding: "12px 8px", textAlign: "center", cursor: "pointer" }}>
+                        <div style={{ fontFamily: FONTS[f].family, fontSize: 22, color: "#3A3A42", lineHeight: 1 }}>Aa</div>
+                        <div style={{ font: "600 10.5px Poppins", color: sel ? "#D83E7C" : "#9aa0a8", marginTop: 6 }}>{FONTS[f].label}</div>
                       </div>
                     );
                   })}
@@ -353,46 +347,60 @@ export const InvitacionesStudio: FC = () => {
               </div>
 
               {/* Textos */}
-              <div style={{ ...card, padding: 20 }}>
-                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Textos</div>
-                <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
-                  {TEXT_FIELDS.map((f) => (
-                    <div key={f.key}>
-                      <label style={label}>{f.label}</label>
-                      {f.area ? (
-                        <textarea value={(design[f.key] as string) || ""} onChange={(e) => update({ [f.key]: e.target.value } as any)} rows={3} style={{ ...input, resize: "vertical" }} />
-                      ) : (
-                        <input value={(design[f.key] as string) || ""} onChange={(e) => update({ [f.key]: e.target.value } as any)} style={input} />
-                      )}
+              <div style={cardBox}>
+                <div style={cardTitle}>Textos</div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  {TEXTS.map((f) => (
+                    <div key={f.k}>
+                      <div style={fieldLabel}>{f.label}</div>
+                      <input value={(design[f.k] as string) || ""} onChange={(e) => update({ [f.k]: e.target.value } as any)} style={fieldInput} />
                     </div>
                   ))}
+                  <div>
+                    <div style={fieldLabel}>Mensaje</div>
+                    <textarea value={design.message} onChange={(e) => update({ message: e.target.value })} rows={3} style={{ ...fieldInput, resize: "none" }} />
+                  </div>
+                  <div>
+                    <div style={fieldLabel}>Lugar (reverso)</div>
+                    <input value={design.venue} onChange={(e) => update({ venue: e.target.value })} style={fieldInput} />
+                  </div>
+                  <div style={{ display: "flex", gap: 10 }}>
+                    <div style={{ flex: 1 }}>
+                      <div style={fieldLabel}>Hora</div>
+                      <input value={design.time} onChange={(e) => update({ time: e.target.value })} style={fieldInput} />
+                    </div>
+                    <div style={{ flex: 1 }}>
+                      <div style={fieldLabel}>RSVP</div>
+                      <input value={design.rsvp} onChange={(e) => update({ rsvp: e.target.value })} style={fieldInput} />
+                    </div>
+                  </div>
                 </div>
               </div>
 
               {/* Color de acento */}
-              <div style={{ ...card, padding: 20 }}>
-                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Color de acento</div>
-                <div style={{ display: "flex", gap: 10 }}>
+              <div style={cardBox}>
+                <div style={cardTitle}>Color de acento</div>
+                <div style={{ display: "flex", gap: 12 }}>
                   {ACCENTS.map((c) => (
-                    <div key={c} onClick={() => update({ accent: c })} style={{ width: 30, height: 30, borderRadius: "50%", background: c, cursor: "pointer", border: design.accent === c ? "3px solid #fff" : "3px solid transparent", boxShadow: design.accent === c ? `0 0 0 2px ${c}` : "0 1px 4px rgba(0,0,0,.12)" }} />
+                    <div key={c} onClick={() => update({ accent: c })} style={{ width: 34, height: 34, borderRadius: "50%", background: c, cursor: "pointer", border: `3px solid ${design.accent === c ? "#3A3A42" : "transparent"}`, boxShadow: "0 2px 6px rgba(0,0,0,.12)" }} />
                   ))}
                 </div>
               </div>
 
-              {/* Continuar */}
-              <div style={{ display: "flex", justifyContent: "flex-end", gap: 12 }}>
-                <button onClick={() => setTab("envio")} style={{ background: PINK, color: "#fff", font: "600 13px Poppins", padding: "12px 24px", borderRadius: 10, boxShadow: "0 4px 12px rgba(239,91,148,.35)" }}
-                  onMouseOver={(e) => (e.currentTarget.style.background = PINK_HOVER)} onMouseOut={(e) => (e.currentTarget.style.background = PINK)}>
-                  Continuar a enviar →
+              {/* Botones */}
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 10 }}>
+                <button style={{ padding: "12px 20px", borderRadius: 10, border: "1.5px solid #E7E7EA", background: "#fff", color: "#6b6b72", font: "600 13px Poppins", cursor: "pointer" }}>Vista previa completa</button>
+                <button onClick={() => setTab("envio")} style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 24px", borderRadius: 10, background: "#EF5B94", color: "#fff", font: "600 13px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.3)", cursor: "pointer" }}>
+                  Continuar a enviar
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M13 6l6 6-6 6" /></svg>
                 </button>
               </div>
             </div>
           </div>
         )}
 
-        {/* PASO ENVIAR (Fase B — placeholder) */}
         {tab === "envio" && (
-          <div style={{ ...card, padding: 40, textAlign: "center", color: "#9aa0a8", font: "600 14px Poppins" }}>
+          <div style={{ ...cardBox, padding: 40, textAlign: "center", color: "#9aa0a8", font: "600 14px Poppins" }}>
             Paso “Enviar” — Fase B (tabla de invitados + barra de envío). Próximamente.
           </div>
         )}

--- a/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
+++ b/apps/appEventos/components/Invitaciones/InvitacionesStudio.tsx
@@ -1,0 +1,376 @@
+import { FC, useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { EventContextProvider } from "../../context/EventContext";
+import { AuthContextProvider } from "../../context/AuthContext";
+import { useToast } from "../../hooks/useToast";
+import { fetchApiEventos, queries } from "../../utils/Fetching";
+
+/**
+ * InvitacionesStudio — Rediseño UI del módulo de Invitaciones (wizard 2 pasos).
+ *
+ * FASE A: paso "Diseñar invitación". Réplica del HTML "Invitaciones estudio" (paleta
+ * rosa #EF5B94 / Poppins). MISMO BACKEND: el diseñador estructurado persiste vía las
+ * operaciones existentes `updateEmailTemplate`/`createEmailTemplate` (design + html),
+ * SIN tocar Fetching.ts ni las 16 operaciones. `design` guarda nuestro JSON estructurado
+ * (esquema `DesignData` con marca `_studio:'v1'`); `html` = email renderizado.
+ * Plantillas antiguas (Unlayer) siguen enviándose; simplemente no se abren aquí (esquema
+ * distinto) → se cae a valores por defecto del evento.
+ *
+ * El paso "Enviar" (Fase B) queda como placeholder en este primer corte.
+ */
+
+// ---- Tipos y presets --------------------------------------------------------
+type TemplateKey = "elegante" | "clasica" | "moderna";
+type FontKey = "poppins" | "playfair" | "dancing";
+type ChannelKey = "email" | "whatsapp" | "sms";
+
+interface DesignData {
+  _studio: "v1";
+  template: TemplateKey;
+  font: FontKey;
+  accent: string;
+  cover: string;
+  title: string;
+  names: string;
+  date: string;
+  message: string;
+  venue: string;
+  time: string;
+  rsvp: string;
+}
+
+const PINK = "#EF5B94";
+const PINK_HOVER = "#D83E7C";
+const INK = "#3A3A42";
+const BORDER = "#E7E7EA";
+
+const PRESETS: Record<TemplateKey, { label: string; grad: string; accent: string }> = {
+  elegante: { label: "Elegante", grad: "linear-gradient(135deg,#FBD3E4,#F3A9CB)", accent: "#EF5B94" },
+  clasica: { label: "Clásica", grad: "linear-gradient(135deg,#EBE1CD,#D8C7A6)", accent: "#C79A3B" },
+  moderna: { label: "Moderna", grad: "linear-gradient(135deg,#DcCcFb,#B79BF0)", accent: "#7C5CFF" },
+};
+
+const FONTS: Record<FontKey, { label: string; family: string }> = {
+  poppins: { label: "Poppins", family: "'Poppins',sans-serif" },
+  playfair: { label: "Playfair", family: "'Playfair Display',serif" },
+  dancing: { label: "Dancing", family: "'Dancing Script',cursive" },
+};
+
+const ACCENTS = ["#EF5B94", "#C79A3B", "#7C5CFF", "#2FB37E", "#E76F51", "#3A3A42"];
+
+const TEXT_FIELDS: { key: keyof DesignData; label: string; area?: boolean }[] = [
+  { key: "title", label: "Encabezado" },
+  { key: "names", label: "Nombres" },
+  { key: "date", label: "Fecha" },
+  { key: "message", label: "Mensaje", area: true },
+  { key: "venue", label: "Lugar (reverso)" },
+  { key: "time", label: "Hora" },
+  { key: "rsvp", label: "RSVP" },
+];
+
+const defaultDesign = (event: any): DesignData => ({
+  _studio: "v1",
+  template: "elegante",
+  font: "poppins",
+  accent: PRESETS.elegante.accent,
+  cover: "",
+  title: "NOS CASAMOS",
+  names: event?.nombre || "Ana & Marcos",
+  date: event?.fecha ? new Date(event.fecha).toLocaleDateString("es-ES", { day: "numeric", month: "long", year: "numeric" }) : "12 de Junio, 2028",
+  message: "Nos encantaría compartir contigo este día tan especial.",
+  venue: event?.poblacion || "",
+  time: "",
+  rsvp: "Confirma tu asistencia",
+});
+
+// ---- Render del email (html que se persiste) --------------------------------
+const renderEmailHtml = (d: DesignData): string => {
+  const p = PRESETS[d.template];
+  const font = FONTS[d.font].family;
+  return `<!doctype html><html><body style="margin:0;background:#f1f1f4;font-family:${font};">
+  <div style="max-width:420px;margin:0 auto;background:#fff;border-radius:16px;overflow:hidden;border:1px solid #f0f0f2;">
+    <div style="height:190px;background:${d.cover ? `url(${d.cover}) center/cover` : p.grad};border-bottom:3px solid ${d.accent};"></div>
+    <div style="padding:26px 26px 30px;text-align:center;">
+      <div style="font-weight:700;font-size:15px;color:${d.accent};letter-spacing:3px;">${d.title}</div>
+      <div style="height:1px;background:${d.accent};opacity:.4;margin:14px 34px;"></div>
+      <div style="font-weight:700;font-size:26px;color:#3A3A42;">${d.names}</div>
+      <div style="font-weight:600;font-size:12px;color:${d.accent};margin-top:8px;">${d.date}</div>
+      <div style="font-size:13.5px;color:#8a8a90;margin-top:14px;line-height:1.6;">${d.message}</div>
+      <a href="#" style="display:inline-block;margin-top:20px;background:${d.accent};color:#fff;text-decoration:none;font-weight:600;font-size:13px;padding:11px 22px;border-radius:10px;">Ver invitación y confirmar</a>
+    </div>
+  </div></body></html>`;
+};
+
+// ---- Componente -------------------------------------------------------------
+export const InvitacionesStudio: FC = () => {
+  const { t } = useTranslation();
+  const { event } = EventContextProvider() as any;
+  const auth = AuthContextProvider() as any;
+  const toast = useToast();
+
+  const [tab, setTab] = useState<"diseno" | "envio">("diseno");
+  const [channel, setChannel] = useState<ChannelKey>("email");
+  const [face, setFace] = useState<"front" | "back">("front");
+  const [design, setDesign] = useState<DesignData>(() => defaultDesign(event));
+  const [templateId, setTemplateId] = useState<string | undefined>(event?.templateEmailSelect);
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved">("saved");
+  const [showOnb, setShowOnb] = useState(true);
+  const loadedRef = useRef(false);
+  const saveTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // Carga del diseño actual (si la plantilla es de nuestro esquema estructurado)
+  useEffect(() => {
+    const id = event?.templateEmailSelect;
+    if (!id || loadedRef.current) return;
+    loadedRef.current = true;
+    setTemplateId(id);
+    fetchApiEventos({ query: queries.getEmailTemplate, variables: { template_id: id } })
+      .then((res: any) => {
+        const tpl = Array.isArray(res) ? res[0] : res;
+        const dz = tpl?.design;
+        if (dz && dz._studio === "v1") setDesign({ ...defaultDesign(event), ...dz });
+      })
+      .catch(() => {/* plantilla antigua/no legible → defaults */});
+  }, [event?._id, event?.templateEmailSelect]);
+
+  // Autosave (debounce) — MISMO backend: updateEmailTemplate / createEmailTemplate
+  const persist = useCallback((d: DesignData) => {
+    if (!event?._id) return;
+    setSaveState("saving");
+    const html = renderEmailHtml(d);
+    const done = (id?: string) => { if (id) setTemplateId(id); setSaveState("saved"); };
+    if (templateId) {
+      fetchApiEventos({ query: queries.updateEmailTemplate, variables: { evento_id: event._id, template_id: templateId, design: d, html } })
+        .then((res: any) => done(Array.isArray(res) ? res[0]?._id : res?._id))
+        .catch(() => setSaveState("idle"));
+    } else {
+      fetchApiEventos({
+        query: queries.createEmailTemplate,
+        variables: {
+          evento_id: event._id, design: d, html,
+          configTemplate: { name: "Invitación", subject: d.title || "Invitación" },
+          domain: auth?.config?.dominio || auth?.config?.domain,
+        },
+      }).then((res: any) => done(res?._id)).catch(() => setSaveState("idle"));
+    }
+  }, [event?._id, templateId, auth]);
+
+  const update = useCallback((patch: Partial<DesignData>) => {
+    setDesign((prev) => {
+      const next = { ...prev, ...patch };
+      setSaveState("saving");
+      clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => persist(next), 800);
+      return next;
+    });
+  }, [persist]);
+
+  const preset = PRESETS[design.template];
+  const invFont = FONTS[design.font].family;
+
+  // ---- estilos reutilizables ----
+  const card: React.CSSProperties = { background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)" };
+  const label: React.CSSProperties = { font: "600 12px Poppins", color: PINK, marginBottom: 6, display: "block" };
+  const input: React.CSSProperties = { width: "100%", border: `1.5px solid ${BORDER}`, borderRadius: 10, padding: "11px 14px", font: "500 13px Poppins", color: INK, outline: "none", background: "#fff" };
+
+  return (
+    <div style={{ background: "#f1f1f4", minHeight: "100%", fontFamily: "'Poppins',sans-serif" }}>
+      <div style={{ maxWidth: 1000, margin: "0 auto", padding: "22px 30px 60px" }}>
+
+        {/* Barra de título */}
+        <div style={{ ...card, padding: "16px 22px", display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, marginBottom: 20 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{ font: "700 20px Poppins", color: "#4a4a52" }}>Invitaciones</div>
+            <span style={{ display: "flex", alignItems: "center", gap: 6, background: "#FEF6D8", color: "#B8860B", font: "600 11.5px Poppins", padding: "5px 12px", borderRadius: 20 }}>★ Propietario</span>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{ lineHeight: 1.2, textAlign: "right" }}>
+              <div style={{ font: "600 10px Poppins", color: PINK, letterSpacing: ".4px" }}>BODA</div>
+              <div style={{ font: "700 13px Poppins", color: INK }}>{event?.nombre || "—"}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tabs 1 Diseñar / 2 Enviar */}
+        <div style={{ display: "inline-flex", gap: 6, ...card, borderRadius: 14, padding: 6, marginBottom: 24 }}>
+          {([["diseno", "1", "Diseñar invitación"], ["envio", "2", "Enviar"]] as const).map(([key, num, txt]) => {
+            const active = tab === key;
+            return (
+              <div key={key} onClick={() => setTab(key)} style={{ display: "flex", alignItems: "center", gap: 9, padding: "10px 22px", borderRadius: 10, background: active ? PINK : "transparent", color: active ? "#fff" : "#6b6b72", font: `${active ? 700 : 600} 14px Poppins`, cursor: "pointer" }}>
+                <span style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 20, height: 20, borderRadius: "50%", background: active ? "rgba(255,255,255,.25)" : "#EDEDF0", color: active ? "#fff" : "#9aa0a8", font: "700 11px Poppins" }}>{num}</span>
+                {txt}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Onboarding */}
+        {showOnb && (
+          <div style={{ display: "flex", marginBottom: 16 }}>
+            <div style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "#FCE7F0", borderRadius: 999, padding: "10px 18px" }}>
+              <span style={{ font: "700 14px Poppins", color: "#B23A6B" }}>ⓘ</span>
+              <span style={{ font: "600 13px Poppins", color: "#B23A6B" }}>Diseña tu invitación y envíala por email, WhatsApp o SMS.</span>
+              <div onClick={() => setShowOnb(false)} style={{ cursor: "pointer", color: "#B23A6B", marginLeft: 4 }}>✕</div>
+            </div>
+          </div>
+        )}
+
+        {/* PASO DISEÑAR */}
+        {tab === "diseno" && (
+          <div style={{ animation: "fadein .2s ease", display: "grid", gridTemplateColumns: "380px 1fr", gap: 22, alignItems: "start" }}>
+
+            {/* Vista previa (sticky) */}
+            <div style={{ position: "sticky", top: 20 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div style={{ font: "700 10.5px Poppins", color: "#a0a0a8", letterSpacing: ".8px", textTransform: "uppercase" }}>Vista previa</div>
+                  {saveState === "saved" && <span style={{ display: "inline-flex", alignItems: "center", gap: 4, font: "600 10px Poppins", color: "#2FB37E", background: "#E4F5EE", padding: "3px 8px", borderRadius: 10 }}>✓ Guardado</span>}
+                  {saveState === "saving" && <span style={{ font: "600 10px Poppins", color: "#a0a0a8", background: "#f0f0f2", padding: "3px 8px", borderRadius: 10 }}>Guardando…</span>}
+                </div>
+                <div style={{ display: "flex", gap: 3, background: "#ececed", borderRadius: 9, padding: 3 }}>
+                  {(["email", "whatsapp", "sms"] as ChannelKey[]).map((c) => (
+                    <div key={c} onClick={() => setChannel(c)} title={c} style={{ display: "flex", alignItems: "center", justifyContent: "center", width: 30, height: 26, borderRadius: 7, background: channel === c ? "#fff" : "transparent", color: channel === c ? PINK : "#9aa0a8", cursor: "pointer", boxShadow: channel === c ? "0 1px 4px rgba(0,0,0,.12)" : "none", font: "600 10px Poppins", textTransform: "uppercase" }}>{c === "email" ? "✉" : c === "whatsapp" ? "💬" : "▤"}</div>
+                  ))}
+                </div>
+              </div>
+
+              {channel === "email" && (
+                <>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+                    <div style={{ display: "flex", gap: 3, background: "#ececed", borderRadius: 9, padding: 3 }}>
+                      {(["front", "back"] as const).map((f) => (
+                        <div key={f} onClick={() => setFace(f)} style={{ padding: "6px 13px", borderRadius: 7, background: face === f ? "#fff" : "transparent", color: face === f ? INK : "#9aa0a8", font: "600 11px Poppins", cursor: "pointer" }}>{f === "front" ? "Portada" : "Detalles"}</div>
+                      ))}
+                    </div>
+                  </div>
+                  <div style={{ width: "100%", background: "#fff", borderRadius: 18, boxShadow: "0 12px 34px rgba(0,0,0,.12)", overflow: "hidden", border: "1px solid #f0f0f2" }}>
+                    <div style={{ height: 190, background: design.cover ? `url(${design.cover}) center/cover` : preset.grad, borderBottom: `3px solid ${design.accent}`, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,.85)", font: "600 12px Poppins", flexDirection: "column", gap: 4 }}>
+                      <span style={{ fontSize: 26 }}>🖼</span>Arrastra la foto de portada
+                    </div>
+                    {face === "front" ? (
+                      <div style={{ padding: "26px 26px 30px", textAlign: "center" }}>
+                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 15, color: design.accent, letterSpacing: 3 }}>{design.title}</div>
+                        <div style={{ height: 1, background: design.accent, opacity: .4, margin: "14px 34px" }} />
+                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 26, color: INK }}>{design.names}</div>
+                        <div style={{ font: "600 12px Poppins", color: design.accent, marginTop: 8, letterSpacing: ".5px" }}>{design.date}</div>
+                        <div style={{ fontFamily: invFont, fontSize: 13.5, color: "#8a8a90", marginTop: 14, lineHeight: 1.6 }}>{design.message}</div>
+                      </div>
+                    ) : (
+                      <div style={{ padding: "28px 26px 32px", textAlign: "center" }}>
+                        <div style={{ fontFamily: invFont, fontWeight: 700, fontSize: 14, color: design.accent, letterSpacing: 2 }}>DETALLES</div>
+                        <div style={{ height: 1, background: design.accent, opacity: .4, margin: "14px 34px" }} />
+                        <div style={{ font: "600 11px Poppins", color: "#a0a0a8" }}>Lugar</div>
+                        <div style={{ fontFamily: invFont, fontSize: 16, color: INK }}>{design.venue || "—"}</div>
+                        <div style={{ font: "600 11px Poppins", color: "#a0a0a8", marginTop: 12 }}>Hora</div>
+                        <div style={{ fontFamily: invFont, fontSize: 16, color: INK }}>{design.time || "—"}</div>
+                        <div style={{ font: "600 12px Poppins", color: design.accent, marginTop: 14 }}>{design.rsvp}</div>
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
+
+              {channel === "whatsapp" && (
+                <div style={{ ...card, padding: 18 }}>
+                  <div style={{ font: "700 13px Poppins", color: INK }}>{design.names} · ¡Nos casamos!</div>
+                  <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", marginTop: 8, lineHeight: 1.6 }}>{design.message} 📅 {design.date}</div>
+                  <div style={{ color: PINK, font: "600 12.5px Poppins", marginTop: 10 }}>Ver invitación y confirmar →</div>
+                  <div style={{ font: "500 10px Poppins", color: "#a0a0a8", marginTop: 12 }}>Mensaje con imagen, texto corto y enlace a la invitación.</div>
+                </div>
+              )}
+
+              {channel === "sms" && (
+                <div style={{ ...card, padding: 18 }}>
+                  <div style={{ font: "500 13px Poppins", color: INK, lineHeight: 1.6 }}>{design.names}: {design.message} {design.date}. Confirma: bod.as/xxxx</div>
+                  <div style={{ font: "500 10px Poppins", color: "#a0a0a8", marginTop: 12 }}>Solo texto y enlace, sin imagen.</div>
+                </div>
+              )}
+            </div>
+
+            {/* Controles */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+              {/* Plantilla */}
+              <div style={{ ...card, padding: 20 }}>
+                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Plantilla</div>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
+                  {(Object.keys(PRESETS) as TemplateKey[]).map((k) => {
+                    const sel = design.template === k;
+                    return (
+                      <div key={k} onClick={() => update({ template: k, accent: PRESETS[k].accent })} style={{ border: `2px solid ${sel ? PINK : "#f0f0f2"}`, borderRadius: 12, overflow: "hidden", cursor: "pointer", background: "#fff" }}>
+                        <div style={{ height: 70, background: PRESETS[k].grad }} />
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "8px 10px" }}>
+                          <span style={{ font: "600 12px Poppins", color: INK }}>{PRESETS[k].label}</span>
+                          <span style={{ width: 16, height: 16, borderRadius: "50%", background: PINK, color: "#fff", font: "700 10px Poppins", display: "flex", alignItems: "center", justifyContent: "center" }}>{sel ? "✓" : ""}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Tipografía */}
+              <div style={{ ...card, padding: 20 }}>
+                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Tipografía</div>
+                <div style={{ display: "flex", gap: 10 }}>
+                  {(Object.keys(FONTS) as FontKey[]).map((f) => {
+                    const sel = design.font === f;
+                    return (
+                      <div key={f} onClick={() => update({ font: f })} style={{ flex: 1, textAlign: "center", border: `1.5px solid ${sel ? PINK : BORDER}`, borderRadius: 10, padding: "10px 6px", cursor: "pointer", background: sel ? "#FDF2F7" : "#fff" }}>
+                        <div style={{ fontFamily: FONTS[f].family, fontSize: 20, color: INK }}>Aa</div>
+                        <div style={{ font: "600 10.5px Poppins", color: sel ? PINK : "#9aa0a8", marginTop: 4 }}>{FONTS[f].label}</div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Textos */}
+              <div style={{ ...card, padding: 20 }}>
+                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Textos</div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+                  {TEXT_FIELDS.map((f) => (
+                    <div key={f.key}>
+                      <label style={label}>{f.label}</label>
+                      {f.area ? (
+                        <textarea value={(design[f.key] as string) || ""} onChange={(e) => update({ [f.key]: e.target.value } as any)} rows={3} style={{ ...input, resize: "vertical" }} />
+                      ) : (
+                        <input value={(design[f.key] as string) || ""} onChange={(e) => update({ [f.key]: e.target.value } as any)} style={input} />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Color de acento */}
+              <div style={{ ...card, padding: 20 }}>
+                <div style={{ font: "700 14px Poppins", color: INK, marginBottom: 14 }}>Color de acento</div>
+                <div style={{ display: "flex", gap: 10 }}>
+                  {ACCENTS.map((c) => (
+                    <div key={c} onClick={() => update({ accent: c })} style={{ width: 30, height: 30, borderRadius: "50%", background: c, cursor: "pointer", border: design.accent === c ? "3px solid #fff" : "3px solid transparent", boxShadow: design.accent === c ? `0 0 0 2px ${c}` : "0 1px 4px rgba(0,0,0,.12)" }} />
+                  ))}
+                </div>
+              </div>
+
+              {/* Continuar */}
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: 12 }}>
+                <button onClick={() => setTab("envio")} style={{ background: PINK, color: "#fff", font: "600 13px Poppins", padding: "12px 24px", borderRadius: 10, boxShadow: "0 4px 12px rgba(239,91,148,.35)" }}
+                  onMouseOver={(e) => (e.currentTarget.style.background = PINK_HOVER)} onMouseOut={(e) => (e.currentTarget.style.background = PINK)}>
+                  Continuar a enviar →
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* PASO ENVIAR (Fase B — placeholder) */}
+        {tab === "envio" && (
+          <div style={{ ...card, padding: 40, textAlign: "center", color: "#9aa0a8", font: "600 14px Poppins" }}>
+            Paso “Enviar” — Fase B (tabla de invitados + barra de envío). Próximamente.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InvitacionesStudio;

--- a/apps/appEventos/components/Invitados/InvitadosStudio.tsx
+++ b/apps/appEventos/components/Invitados/InvitadosStudio.tsx
@@ -1,0 +1,167 @@
+import { FC, ReactNode, useState } from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { EventContextProvider } from "../../context";
+import BlockTitle from "../Utils/BlockTitle";
+
+/**
+ * InvitadosStudio — rediseño de la tabla de Invitados fiel al HTML "Prototipo tablas v2".
+ * MISMO backend: todo del objeto `event` (invitados_array, grupos_array, planSpace,
+ * allFilterGuests, menus_array). Gated tras ?studio=1.
+ * FASE 1: cabecera + stats + botones + buscador + tabla agrupada (lectura, datos reales).
+ */
+export const InvitadosStudio: FC = () => {
+  const router = useRouter();
+  const { event, allFilterGuests } = EventContextProvider() as any;
+  const [closed, setClosed] = useState<Record<string, boolean>>({});
+  const [search, setSearch] = useState("");
+
+  const all: any[] = event?.invitados_array || [];
+  const fathers = all.filter((inv) => !inv?.father);
+  const grupos: string[] = event?.grupos_array || [];
+
+  // Stats reales (como BlockCabecera)
+  const total = all.length;
+  const adultos = all.filter((x) => x?.grupo_edad === "adulto").length;
+  const ninos = all.filter((x) => x?.grupo_edad === "niño").length;
+  const conf = all.filter((x) => x?.asistencia === "confirmado").length;
+  const pend = all.filter((x) => x?.asistencia === "pendiente").length;
+  const canc = all.filter((x) => x?.asistencia === "cancelado").length;
+
+  // Asientos recepción/ceremonia (mismo derivado que BlockTableroInvitados)
+  const tablesRec = event?.planSpace?.find((e: any) => e?.title === "recepción")?.tables;
+  const tablesCer = event?.planSpace?.find((e: any) => e?.title === "ceremonia")?.tables;
+  const seatOf = (id: string, idx: 0 | 1) => {
+    const g = allFilterGuests?.[idx]?.sentados?.find((e: any) => e._id === id);
+    const tables = idx === 0 ? tablesRec : tablesCer;
+    const table = tables?.find((t: any) => t._id === g?.tableID);
+    return table?.title || "no asignado";
+  };
+
+  // Estado (asistencia) → color/soft/icono
+  const stMap: Record<string, [string, string]> = {
+    confirmado: ["#2FB37E", "#E4F5EE"], pendiente: ["#E0A32B", "#FBF0DA"], cancelado: ["#D83E7C", "#FBE4EF"],
+  };
+  const stIcon = (st: string): ReactNode => {
+    if (st === "confirmado") return <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3.4} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>;
+    if (st === "cancelado") return <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3.4} strokeLinecap="round" strokeLinejoin="round"><path d="M6 6l12 12M18 6L6 18" /></svg>;
+    return <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.6} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9" /><path d="M12 8v4l2.5 1.5" /></svg>;
+  };
+  const cap = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : "Pendiente");
+
+  const q = search.trim().toLowerCase();
+  // Agrupar padres por rol (grupo), como BlockTableroInvitados
+  const groups = [...grupos, "no asignado"].map((name) => {
+    const guests = fathers.filter((g) => {
+      const rol = (g?.rol || "").toLowerCase();
+      const inGroup = name === "no asignado" ? !grupos.some((gr) => gr.toLowerCase() === rol) : rol === name.toLowerCase();
+      return inGroup && (!q || (g?.nombre || "").toLowerCase().includes(q));
+    });
+    return { name, guests };
+  }).filter((gr) => gr.guests.length > 0 || (!q && gr.name !== "no asignado"));
+
+  const GRID = "2.4fr 1.1fr 1fr 1.2fr 1.2fr 1.2fr 40px";
+  const th: React.CSSProperties = { font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" };
+  const btnGhost: React.CSSProperties = { display: "flex", alignItems: "center", gap: 7, padding: "9px 16px", borderRadius: 11, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12.5px Poppins", cursor: "pointer" };
+  const plusW = <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.2} strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>;
+  const plusG = <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={2.2} strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>;
+
+  return (
+    <div style={{ background: "#f1f1f4", minHeight: "100%", fontFamily: "'Poppins',sans-serif" }}>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+      </Head>
+      <style dangerouslySetInnerHTML={{ __html: `@keyframes fadein{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}` }} />
+
+      <div style={{ maxWidth: 1040, margin: "0 auto", padding: "22px 20px 60px", animation: "fadein .2s ease" }}>
+        {/* Cabecera estándar */}
+        <div style={{ marginBottom: 16 }}><BlockTitle title={"Mis invitados"} /></div>
+
+        {/* STATS */}
+        <div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap", marginBottom: 18 }}>
+          <div style={{ font: "800 22px Poppins", color: "#EF5B94" }}>{total} <span style={{ font: "600 14px Poppins", color: "#3A3A42" }}>Invitados</span></div>
+          <span style={{ font: "500 12px Poppins", color: "#a0a0a8" }}>{adultos} adultos · {ninos} niños</span>
+          <div style={{ flex: 1 }} />
+          <div style={{ display: "flex", alignItems: "center", gap: 7, background: "#FBF0DA", color: "#E0A32B", font: "600 12px Poppins", padding: "8px 14px", borderRadius: 20 }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#E0A32B" }} />{pend} por confirmar</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 7, background: "#E4F5EE", color: "#2FB37E", font: "600 12px Poppins", padding: "8px 14px", borderRadius: 20 }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#2FB37E" }} />{conf} confirmados</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 7, background: "#FBE4EF", color: "#D83E7C", font: "600 12px Poppins", padding: "8px 14px", borderRadius: 20 }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#D83E7C" }} />{canc} cancelados</div>
+          <button onClick={() => router.push("/mesas")} style={{ display: "flex", alignItems: "center", gap: 8, padding: "11px 18px", borderRadius: 10, background: "#EF5B94", color: "#fff", font: "600 13px Poppins", border: "none", cursor: "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="8" width="18" height="4" rx="1" /><path d="M6 12v6M18 12v6" /></svg>Sentar invitados</button>
+        </div>
+
+        {/* divisor rosa */}
+        <div style={{ height: 3, borderRadius: 3, background: "linear-gradient(90deg,#EF5B94,#f9b6d1)", marginBottom: 18 }} />
+
+        {/* ACTION BUTTONS */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 18, flexWrap: "wrap" }}>
+          <button style={{ display: "flex", alignItems: "center", gap: 7, padding: "9px 16px", borderRadius: 11, background: "#EF5B94", color: "#fff", font: "600 12.5px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.3)", border: "none", cursor: "pointer" }}>{plusW}Invitados</button>
+          <button style={btnGhost}>{plusG}Grupo</button>
+          <button style={btnGhost}>{plusG}Menú</button>
+          <button style={btnGhost}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" /></svg>Importar</button>
+          <div style={{ flex: 1 }} />
+          <div style={{ display: "flex", alignItems: "center", gap: 9, background: "#fff", border: "1.5px solid #E7E7EA", borderRadius: 11, padding: "9px 14px" }}>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" /></svg>
+            <input value={search} onChange={(e) => setSearch(e.target.value)} type="text" placeholder="Buscar invitado" style={{ border: "none", outline: "none", background: "transparent", font: "500 12.5px Poppins", color: "#3A3A42", width: 150 }} />
+          </div>
+        </div>
+
+        {/* TABLE */}
+        <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 6px 20px rgba(0,0,0,.05)", overflow: "hidden" }}>
+          <div style={{ display: "grid", gridTemplateColumns: GRID, alignItems: "center", gap: 10, padding: "15px 24px", background: "#f7f7f9", borderBottom: "1px solid #f0f0f2" }}>
+            <div style={th}>Invitado</div>
+            <div style={{ ...th, textAlign: "center" }}>Asistencia</div>
+            <div style={th}>Menú</div>
+            <div style={{ ...th, lineHeight: 1.35 }}>Asientos<br />recepción</div>
+            <div style={{ ...th, lineHeight: 1.35 }}>Asientos<br />ceremonia</div>
+            <div style={th}>Acompañantes</div>
+            <div />
+          </div>
+
+          {groups.length === 0 && (
+            <div style={{ padding: "40px 24px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{total === 0 ? "Aún no tienes invitados." : "No hay invitados que coincidan."}</div>
+          )}
+
+          {groups.map((gr) => {
+            const open = q ? true : !closed[gr.name];
+            return (
+              <div key={gr.name}>
+                <div onClick={() => setClosed((c) => ({ ...c, [gr.name]: !c[gr.name] }))} style={{ display: "flex", alignItems: "center", gap: 9, padding: "14px 24px", background: "#fbfbfc", borderBottom: "1px solid #f2f2f4", cursor: "pointer" }}>
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#c4c4cc" strokeWidth={2.6} strokeLinecap="round" strokeLinejoin="round" style={{ transition: "transform .18s", transform: `rotate(${open ? 90 : 0}deg)` }}><path d="M9 6l6 6-6 6" /></svg>
+                  <span style={{ font: "500 14px Poppins", color: "#6b6b72", textTransform: "capitalize" }}>{gr.name}</span>
+                  <span style={{ font: "600 10px Poppins", color: "#c4c4cc", background: "#f2f2f4", padding: "2px 8px", borderRadius: 10 }}>{gr.guests.length}</span>
+                </div>
+                {open && (
+                  <div style={{ animation: "fadein .18s ease" }}>
+                    {gr.guests.length === 0 && <div style={{ padding: "20px 24px", font: "500 12.5px Poppins", color: "#c4c4cc", textAlign: "center" }}>No hay invitados</div>}
+                    {gr.guests.map((r) => {
+                      const st = (r?.asistencia || "pendiente").toLowerCase();
+                      const c = stMap[st] || stMap.pendiente;
+                      const acomp = all.filter((x) => x?.father === r._id).length;
+                      const initial = (r?.nombre || "?").trim().charAt(0).toUpperCase() || "?";
+                      return (
+                        <div key={r._id} style={{ display: "grid", gridTemplateColumns: GRID, alignItems: "center", gap: 10, padding: "16px 24px", borderBottom: "1px solid #f5f5f7" }}>
+                          <div style={{ display: "flex", alignItems: "center", gap: 11, minWidth: 0 }}>
+                            <div style={{ width: 34, height: 34, borderRadius: "50%", flex: "none", background: "#EFEFF2", color: "#8a8a90", display: "flex", alignItems: "center", justifyContent: "center", font: "700 12px Poppins" }}>{initial}</div>
+                            <span style={{ font: "500 13px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{r?.nombre}</span>
+                          </div>
+                          <div style={{ display: "flex", justifyContent: "center" }}>
+                            <div style={{ display: "flex", alignItems: "center", gap: 7 }}><span style={{ width: 18, height: 18, borderRadius: "50%", background: c[0], display: "flex", alignItems: "center", justifyContent: "center", flex: "none" }}>{stIcon(st)}</span><span style={{ font: "600 12px Poppins", color: c[0] }}>{cap(st)}</span></div>
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 5 }}><span style={{ font: "500 12px Poppins", color: "#6b6b72" }}>{r?.nombre_menu || "—"}</span></div>
+                          <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 0)}</div>
+                          <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 1)}</div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 5, font: "600 12px Poppins", color: "#6b6b72" }}>{acomp}</div>
+                          <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 9, color: "#c4c4cc" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" /></svg></div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/appEventos/components/Invitados/InvitadosStudio.tsx
+++ b/apps/appEventos/components/Invitados/InvitadosStudio.tsx
@@ -1,8 +1,11 @@
 import { FC, ReactNode, useState } from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import ClickAwayListener from "react-click-away-listener";
 import { EventContextProvider } from "../../context";
 import BlockTitle from "../Utils/BlockTitle";
+import { fetchApiBodas, queries } from "../../utils/Fetching";
+import { useToast } from "../../hooks/useToast";
 
 /**
  * InvitadosStudio — rediseño de la tabla de Invitados fiel al HTML "Prototipo tablas v2".
@@ -12,9 +15,29 @@ import BlockTitle from "../Utils/BlockTitle";
  */
 export const InvitadosStudio: FC = () => {
   const router = useRouter();
-  const { event, allFilterGuests } = EventContextProvider() as any;
+  const { event, allFilterGuests, setEvent } = EventContextProvider() as any;
+  const toast = useToast();
   const [closed, setClosed] = useState<Record<string, boolean>>({});
   const [search, setSearch] = useState("");
+  const [ddSt, setDdSt] = useState<string | null>(null);
+  const [ddMn, setDdMn] = useState<string | null>(null);
+
+  // Opciones de menú del evento + guardado inline (mismo patrón que BlockTableroInvitados)
+  const menuOpts: string[] = (event?.menus_array || []).map((m: any) => m?.nombre_menu || m).filter(Boolean);
+  const saveGuestField = (guestId: string, field: string, value: any) => {
+    setEvent((prev: any) => {
+      const arr = prev?.invitados_array || [];
+      const next = arr.map((inv: any) => {
+        if (inv._id === guestId) {
+          fetchApiBodas({ query: queries.editGuests, variables: { eventID: event._id, guestID: inv._id, datos: { [field]: value } } });
+          return { ...inv, [field]: value };
+        }
+        return inv;
+      });
+      return { ...prev, invitados_array: next };
+    });
+    toast("success", "Cambio guardado");
+  };
 
   const all: any[] = event?.invitados_array || [];
   const fathers = all.filter((inv) => !inv?.father);
@@ -137,17 +160,38 @@ export const InvitadosStudio: FC = () => {
                       const st = (r?.asistencia || "pendiente").toLowerCase();
                       const c = stMap[st] || stMap.pendiente;
                       const acomp = all.filter((x) => x?.father === r._id).length;
-                      const initial = (r?.nombre || "?").trim().charAt(0).toUpperCase() || "?";
+                      const isWoman = (r?.sexo || "").toLowerCase() === "mujer";
                       return (
                         <div key={r._id} style={{ display: "grid", gridTemplateColumns: GRID, alignItems: "center", gap: 10, padding: "16px 24px", borderBottom: "1px solid #f5f5f7" }}>
                           <div style={{ display: "flex", alignItems: "center", gap: 11, minWidth: 0 }}>
-                            <div style={{ width: 34, height: 34, borderRadius: "50%", flex: "none", background: "#EFEFF2", color: "#8a8a90", display: "flex", alignItems: "center", justifyContent: "center", font: "700 12px Poppins" }}>{initial}</div>
+                            <div style={{ width: 34, height: 34, borderRadius: "50%", flex: "none", overflow: "hidden", background: "#c9c9cf" }}><img src={isWoman ? "/profile_woman.png" : "/profile_men.png"} alt={isWoman ? "Mujer" : "Hombre"} style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} /></div>
                             <span style={{ font: "500 13px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{r?.nombre}</span>
                           </div>
-                          <div style={{ display: "flex", justifyContent: "center" }}>
-                            <div style={{ display: "flex", alignItems: "center", gap: 7 }}><span style={{ width: 18, height: 18, borderRadius: "50%", background: c[0], display: "flex", alignItems: "center", justifyContent: "center", flex: "none" }}>{stIcon(st)}</span><span style={{ font: "600 12px Poppins", color: c[0] }}>{cap(st)}</span></div>
+                          <div style={{ position: "relative", display: "flex", justifyContent: "center" }}>
+                            <div onClick={() => { setDdMn(null); setDdSt(ddSt === r._id ? null : r._id); }} style={{ display: "flex", alignItems: "center", gap: 7, cursor: "pointer" }}><span style={{ width: 18, height: 18, borderRadius: "50%", background: c[0], display: "flex", alignItems: "center", justifyContent: "center", flex: "none" }}>{stIcon(st)}</span><span style={{ font: "600 12px Poppins", color: c[0] }}>{cap(st)}</span></div>
+                            {ddSt === r._id && (
+                              <ClickAwayListener onClickAway={() => setDdSt(null)}>
+                                <div style={{ position: "absolute", top: "100%", left: "50%", transform: "translateX(-50%)", marginTop: 8, background: "#fff", border: "1px solid #eee", borderRadius: 12, boxShadow: "0 12px 30px rgba(0,0,0,.16)", zIndex: 8, padding: 6, minWidth: 150 }}>
+                                  {["confirmado", "pendiente", "cancelado"].map((o) => { const oc = stMap[o]; return (
+                                    <div key={o} onClick={() => { saveGuestField(r._id, "asistencia", o); setDdSt(null); }} style={{ display: "flex", alignItems: "center", gap: 9, padding: "9px 12px", borderRadius: 9, cursor: "pointer" }}><span style={{ width: 18, height: 18, borderRadius: "50%", background: oc[0], display: "flex", alignItems: "center", justifyContent: "center", flex: "none" }}>{stIcon(o)}</span><span style={{ font: "600 12px Poppins", color: oc[0] }}>{cap(o)}</span></div>
+                                  ); })}
+                                </div>
+                              </ClickAwayListener>
+                            )}
                           </div>
-                          <div style={{ display: "flex", alignItems: "center", gap: 5 }}><span style={{ font: "500 12px Poppins", color: "#6b6b72" }}>{r?.nombre_menu || "—"}</span></div>
+                          <div style={{ position: "relative" }}>
+                            <div onClick={() => { setDdSt(null); setDdMn(ddMn === r._id ? null : r._id); }} style={{ display: "flex", alignItems: "center", gap: 5, cursor: "pointer" }}><span style={{ font: "500 12px Poppins", color: "#6b6b72" }}>{r?.nombre_menu || "—"}</span><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#c4c4cc" strokeWidth={2.4}><path d="M6 9l6 6 6-6" /></svg></div>
+                            {ddMn === r._id && (
+                              <ClickAwayListener onClickAway={() => setDdMn(null)}>
+                                <div style={{ position: "absolute", top: "100%", left: 0, marginTop: 8, background: "#fff", border: "1px solid #eee", borderRadius: 12, boxShadow: "0 12px 30px rgba(0,0,0,.16)", zIndex: 8, padding: 6, minWidth: 150, maxHeight: 190, overflow: "auto" }}>
+                                  {menuOpts.length === 0 && <div style={{ padding: "9px 12px", font: "500 12px Poppins", color: "#a0a0a8" }}>Sin menús</div>}
+                                  {menuOpts.map((m, mi) => (
+                                    <div key={mi} onClick={() => { saveGuestField(r._id, "nombre_menu", m); setDdMn(null); }} style={{ padding: "9px 12px", borderRadius: 9, font: "500 12px Poppins", color: "#3A3A42", cursor: "pointer" }}>{m}</div>
+                                  ))}
+                                </div>
+                              </ClickAwayListener>
+                            )}
+                          </div>
                           <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 0)}</div>
                           <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 1)}</div>
                           <div style={{ display: "flex", alignItems: "center", gap: 5, font: "600 12px Poppins", color: "#6b6b72" }}>{acomp}</div>

--- a/apps/appEventos/components/Invitados/InvitadosStudio.tsx
+++ b/apps/appEventos/components/Invitados/InvitadosStudio.tsx
@@ -14,6 +14,7 @@ import FormCrearMenu from "../Forms/FormCrearMenu";
 import FormAcompañante from "../Forms/FormAcompañante";
 import FormEditarInvitado from "../Forms/FormEditarInvitado";
 import { BorrarInvitado } from "../../hooks/EditarInvitado";
+import { CopiarLink } from "../Utils/Compartir";
 
 /**
  * InvitadosStudio — rediseño de la tabla de Invitados fiel al HTML "Prototipo tablas v2".
@@ -36,7 +37,17 @@ export const InvitadosStudio: FC = () => {
   const [acompFather, setAcompFather] = useState<string | null>(null);
   const [editGuest, setEditGuest] = useState<any>(null);
   const [rowMenu, setRowMenu] = useState<string | null>(null);
+  const [shareOpen, setShareOpen] = useState<string | null>(null);
+  const [grpMenu, setGrpMenu] = useState<string | null>(null);
   const openForm = (type: string) => { setFormShow(type); setIsMounted(true); setRowMenu(null); };
+  const guestLink = (id: string) => `${typeof window !== "undefined" ? window.location.origin : ""}?pGuestEvent=${id}${event?._id?.slice(3, 9)}${event?._id}`;
+  const delGroup = (name: string) => {
+    setGrpMenu(null);
+    if (typeof window !== "undefined" && !window.confirm(`¿Borrar el grupo "${name}"? No se podrá recuperar.`)) return;
+    fetchApiBodas({ query: `mutation($evento_id:ID!,$grupo_id:ID!){ borraGrupo(evento_id:$evento_id, grupo_id:$grupo_id){ success errors{ field message code } } }`, variables: { evento_id: event._id, grupo_id: name } });
+    setEvent((old: any) => ({ ...old, grupos_array: (old?.grupos_array || []).filter((e: string) => e !== name) }));
+    toast("success", "Grupo borrado");
+  };
   const delGuest = (r: any) => {
     setRowMenu(null);
     if (typeof window !== "undefined" && !window.confirm(`¿Eliminar a ${r?.nombre || "este invitado"}?`)) return;
@@ -203,6 +214,19 @@ export const InvitadosStudio: FC = () => {
                   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#c4c4cc" strokeWidth={2.6} strokeLinecap="round" strokeLinejoin="round" style={{ transition: "transform .18s", transform: `rotate(${open ? 90 : 0}deg)` }}><path d="M9 6l6 6-6 6" /></svg>
                   <span style={{ font: "500 14px Poppins", color: "#6b6b72", textTransform: "capitalize" }}>{gr.name}</span>
                   <span style={{ font: "600 10px Poppins", color: "#c4c4cc", background: "#f2f2f4", padding: "2px 8px", borderRadius: 10 }}>{gr.guests.length}</span>
+                  <div style={{ flex: 1 }} />
+                  {gr.name !== "no asignado" && (
+                    <div style={{ position: "relative" }} onClick={(e) => e.stopPropagation()}>
+                      <svg onClick={() => setGrpMenu(grpMenu === gr.name ? null : gr.name)} width="16" height="16" viewBox="0 0 24 24" fill="#c4c4cc" style={{ cursor: "pointer" }}><circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" /></svg>
+                      {grpMenu === gr.name && (
+                        <ClickAwayListener onClickAway={() => setGrpMenu(null)}>
+                          <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, background: "#fff", border: "1px solid #eee", borderRadius: 12, boxShadow: "0 12px 30px rgba(0,0,0,.16)", zIndex: 9, padding: 6, minWidth: 150 }}>
+                            <div onClick={() => delGroup(gr.name)} style={{ padding: "9px 12px", borderRadius: 9, font: "600 12px Poppins", color: "#D83E7C", cursor: "pointer" }}>Borrar grupo</div>
+                          </div>
+                        </ClickAwayListener>
+                      )}
+                    </div>
+                  )}
                 </div>
                 {open && (
                   <div style={{ animation: "fadein .18s ease" }}>
@@ -247,7 +271,18 @@ export const InvitadosStudio: FC = () => {
                           <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 1)}</div>
                           <div style={{ display: "flex", alignItems: "center", gap: 5, font: "600 12px Poppins", color: "#6b6b72" }}>{acomp}</div>
                           <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 9, color: "#c4c4cc" }}>
-                            <svg onClick={() => { setDdSt(null); setDdMn(null); setRowMenu(rowMenu === r._id ? null : r._id); }} width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style={{ cursor: "pointer" }}><circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" /></svg>
+                            <div style={{ position: "relative", display: "flex" }}>
+                              <svg onClick={() => { setRowMenu(null); setShareOpen(shareOpen === r._id ? null : r._id); }} width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} style={{ cursor: "pointer" }}><title>Compartir invitación</title><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1" /><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" /></svg>
+                              {shareOpen === r._id && (
+                                <ClickAwayListener onClickAway={() => setShareOpen(null)}>
+                                  <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 8, background: "#fff", border: "1px solid #eee", borderRadius: 12, boxShadow: "0 12px 30px rgba(0,0,0,.16)", zIndex: 9, padding: 12, width: 300 }}>
+                                    <div style={{ font: "600 11px Poppins", color: "#6b6b72", marginBottom: 8 }}>Compartir invitación de {r?.nombre}</div>
+                                    <CopiarLink link={guestLink(r._id)} />
+                                  </div>
+                                </ClickAwayListener>
+                              )}
+                            </div>
+                            <svg onClick={() => { setDdSt(null); setDdMn(null); setShareOpen(null); setRowMenu(rowMenu === r._id ? null : r._id); }} width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style={{ cursor: "pointer" }}><circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" /></svg>
                             {rowMenu === r._id && (
                               <ClickAwayListener onClickAway={() => setRowMenu(null)}>
                                 <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, background: "#fff", border: "1px solid #eee", borderRadius: 12, boxShadow: "0 12px 30px rgba(0,0,0,.16)", zIndex: 9, padding: 6, minWidth: 180 }}>

--- a/apps/appEventos/components/Invitados/InvitadosStudio.tsx
+++ b/apps/appEventos/components/Invitados/InvitadosStudio.tsx
@@ -6,6 +6,14 @@ import { EventContextProvider } from "../../context";
 import BlockTitle from "../Utils/BlockTitle";
 import { fetchApiBodas, queries } from "../../utils/Fetching";
 import { useToast } from "../../hooks/useToast";
+import { useDelayUnmount } from "../../utils/Funciones";
+import ModalLeft from "../Utils/ModalLeft";
+import FormInvitado from "../Forms/FormInvitado";
+import FormCrearGrupo from "../Forms/FormCrearGrupo";
+import FormCrearMenu from "../Forms/FormCrearMenu";
+import FormAcompañante from "../Forms/FormAcompañante";
+import FormEditarInvitado from "../Forms/FormEditarInvitado";
+import { BorrarInvitado } from "../../hooks/EditarInvitado";
 
 /**
  * InvitadosStudio — rediseño de la tabla de Invitados fiel al HTML "Prototipo tablas v2".
@@ -21,6 +29,21 @@ export const InvitadosStudio: FC = () => {
   const [search, setSearch] = useState("");
   const [ddSt, setDdSt] = useState<string | null>(null);
   const [ddMn, setDdMn] = useState<string | null>(null);
+  // Formularios (reusa los del módulo actual vía ModalLeft) + menú de fila
+  const [formShow, setFormShow] = useState<string | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+  const shouldRenderChild = useDelayUnmount(isMounted, 500);
+  const [acompFather, setAcompFather] = useState<string | null>(null);
+  const [editGuest, setEditGuest] = useState<any>(null);
+  const [rowMenu, setRowMenu] = useState<string | null>(null);
+  const openForm = (type: string) => { setFormShow(type); setIsMounted(true); setRowMenu(null); };
+  const delGuest = (r: any) => {
+    setRowMenu(null);
+    if (typeof window !== "undefined" && !window.confirm(`¿Eliminar a ${r?.nombre || "este invitado"}?`)) return;
+    setEvent((prev: any) => ({ ...prev, invitados_array: (prev?.invitados_array || []).filter((x: any) => x._id !== r._id && x.father !== r._id) }));
+    BorrarInvitado(event._id, r._id);
+    toast("success", "Invitado eliminado");
+  };
 
   // Opciones de menú del evento + guardado inline (mismo patrón que BlockTableroInvitados)
   const menuOpts: string[] = (event?.menus_array || []).map((m: any) => m?.nombre_menu || m).filter(Boolean);
@@ -89,6 +112,23 @@ export const InvitadosStudio: FC = () => {
   const plusW = <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.2} strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>;
   const plusG = <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={2.2} strokeLinecap="round"><path d="M12 5v14M5 12h14" /></svg>;
 
+  // Exportar a PDF (imprime la tabla → PDF del navegador), como el mock
+  const genPDF = () => {
+    const stC: Record<string, string> = { confirmado: "#2FB37E", pendiente: "#E0A32B", cancelado: "#D83E7C" };
+    const body = groups.map((gr) => {
+      const head = `<tr><td colspan="6" style="background:#fbfbfc;font-weight:600;color:#6b6b72;padding:8px 12px;text-transform:capitalize;">${gr.name} (${gr.guests.length})</td></tr>`;
+      const rows = gr.guests.map((r) => {
+        const st = (r?.asistencia || "pendiente").toLowerCase();
+        return `<tr><td>${r?.nombre || ""}</td><td style="color:${stC[st] || "#E0A32B"};text-transform:capitalize;">${cap(st)}</td><td>${r?.nombre_menu || "—"}</td><td>${seatOf(r._id, 0)}</td><td>${seatOf(r._id, 1)}</td><td>${all.filter((x) => x?.father === r._id).length}</td></tr>`;
+      }).join("");
+      return head + rows;
+    }).join("");
+    const html = `<html><head><meta charset="utf-8"><title>Invitados — ${event?.nombre || ""}</title><style>body{font-family:Poppins,Arial,sans-serif;padding:24px;color:#3A3A42}h1{color:#EF5B94;font-size:20px;margin:0 0 4px}.sub{font-size:12px;color:#8a8a90;margin-bottom:16px}table{width:100%;border-collapse:collapse;font-size:12px}th,td{border:1px solid #eee;padding:8px 10px;text-align:left}th{background:#f7f7f9;color:#5a5a62;text-transform:uppercase;font-size:10px}</style></head><body><h1>Invitados — ${event?.nombre || ""}</h1><div class="sub">${total} invitados · ${adultos} adultos · ${ninos} niños · ${conf} confirmados · ${pend} por confirmar · ${canc} cancelados</div><table><thead><tr><th>Invitado</th><th>Asistencia</th><th>Menú</th><th>Asientos recepción</th><th>Asientos ceremonia</th><th>Acompañantes</th></tr></thead><tbody>${body}</tbody></table></body></html>`;
+    const w = window.open("", "_blank");
+    if (!w) { toast("error", "Permite ventanas emergentes para exportar"); return; }
+    w.document.write(html); w.document.close(); w.focus(); setTimeout(() => { try { w.print(); } catch { /* noop */ } }, 350);
+  };
+
   return (
     <div style={{ background: "#f1f1f4", minHeight: "100%", fontFamily: "'Poppins',sans-serif" }}>
       <Head>
@@ -96,6 +136,17 @@ export const InvitadosStudio: FC = () => {
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
       </Head>
       <style dangerouslySetInnerHTML={{ __html: `@keyframes fadein{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}` }} />
+
+      {/* Formularios (reusa los del módulo actual vía ModalLeft) */}
+      {shouldRenderChild && (
+        <ModalLeft state={isMounted} set={setIsMounted}>
+          {formShow === "invitado" && <FormInvitado state={isMounted} set={setIsMounted} />}
+          {formShow === "grupo" && <FormCrearGrupo state={isMounted} set={setIsMounted} />}
+          {formShow === "menu" && <FormCrearMenu state={isMounted} set={setIsMounted} />}
+          {formShow === "acompañante" && <FormAcompañante state={isMounted} set={setIsMounted} guestFather={acompFather as string} />}
+          {formShow === "editar" && <FormEditarInvitado state={isMounted} set={setIsMounted} invitado={editGuest} setInvitadoSelected={setEditGuest} />}
+        </ModalLeft>
+      )}
 
       <div style={{ maxWidth: 1040, margin: "0 auto", padding: "22px 20px 60px", animation: "fadein .2s ease" }}>
         {/* Cabecera estándar */}
@@ -117,10 +168,10 @@ export const InvitadosStudio: FC = () => {
 
         {/* ACTION BUTTONS */}
         <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 18, flexWrap: "wrap" }}>
-          <button style={{ display: "flex", alignItems: "center", gap: 7, padding: "9px 16px", borderRadius: 11, background: "#EF5B94", color: "#fff", font: "600 12.5px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.3)", border: "none", cursor: "pointer" }}>{plusW}Invitados</button>
-          <button style={btnGhost}>{plusG}Grupo</button>
-          <button style={btnGhost}>{plusG}Menú</button>
-          <button style={btnGhost}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" /></svg>Importar</button>
+          <button onClick={() => openForm("invitado")} style={{ display: "flex", alignItems: "center", gap: 7, padding: "9px 16px", borderRadius: 11, background: "#EF5B94", color: "#fff", font: "600 12.5px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.3)", border: "none", cursor: "pointer" }}>{plusW}Invitados</button>
+          <button onClick={() => openForm("grupo")} style={btnGhost}>{plusG}Grupo</button>
+          <button onClick={() => openForm("menu")} style={btnGhost}>{plusG}Menú</button>
+          <button onClick={genPDF} style={btnGhost}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3" /></svg>Exportar</button>
           <div style={{ flex: 1 }} />
           <div style={{ display: "flex", alignItems: "center", gap: 9, background: "#fff", border: "1.5px solid #E7E7EA", borderRadius: 11, padding: "9px 14px" }}>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" /></svg>
@@ -195,7 +246,18 @@ export const InvitadosStudio: FC = () => {
                           <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 0)}</div>
                           <div style={{ font: "600 11px Poppins", color: "#6b6b72", letterSpacing: ".4px", textTransform: "uppercase" }}>{seatOf(r._id, 1)}</div>
                           <div style={{ display: "flex", alignItems: "center", gap: 5, font: "600 12px Poppins", color: "#6b6b72" }}>{acomp}</div>
-                          <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 9, color: "#c4c4cc" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" /></svg></div>
+                          <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 9, color: "#c4c4cc" }}>
+                            <svg onClick={() => { setDdSt(null); setDdMn(null); setRowMenu(rowMenu === r._id ? null : r._id); }} width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style={{ cursor: "pointer" }}><circle cx="12" cy="5" r="1.6" /><circle cx="12" cy="12" r="1.6" /><circle cx="12" cy="19" r="1.6" /></svg>
+                            {rowMenu === r._id && (
+                              <ClickAwayListener onClickAway={() => setRowMenu(null)}>
+                                <div style={{ position: "absolute", top: "100%", right: 0, marginTop: 6, background: "#fff", border: "1px solid #eee", borderRadius: 12, boxShadow: "0 12px 30px rgba(0,0,0,.16)", zIndex: 9, padding: 6, minWidth: 180 }}>
+                                  <div onClick={() => { setEditGuest(r); openForm("editar"); }} style={{ padding: "9px 12px", borderRadius: 9, font: "600 12px Poppins", color: "#3A3A42", cursor: "pointer" }}>Editar invitado</div>
+                                  <div onClick={() => { setAcompFather(r._id); openForm("acompañante"); }} style={{ padding: "9px 12px", borderRadius: 9, font: "600 12px Poppins", color: "#3A3A42", cursor: "pointer" }}>Añadir acompañante</div>
+                                  <div onClick={() => delGuest(r)} style={{ padding: "9px 12px", borderRadius: 9, font: "600 12px Poppins", color: "#D83E7C", cursor: "pointer" }}>Eliminar</div>
+                                </div>
+                              </ClickAwayListener>
+                            )}
+                          </div>
                         </div>
                       );
                     })}

--- a/apps/appEventos/components/Resumen/ResumenStudio.tsx
+++ b/apps/appEventos/components/Resumen/ResumenStudio.tsx
@@ -1,0 +1,249 @@
+import { FC, ReactNode, useState } from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import { EventContextProvider, AuthContextProvider } from "../../context";
+import { ModalAddUserToEvent } from "../Utils/Compartir";
+import { defaultImagenes } from "../Home/Card";
+
+/**
+ * ResumenStudio — rediseño de la hoja de Resumen fiel al HTML "Resumen.dc.html".
+ * MISMO backend: todo se deriva del objeto `event` (api-mcp). Gated tras ?studio=1.
+ * FASE 1: Hero + estado + métricas + checklist (derivado) + necesita atención + Presupuesto/Invitados.
+ */
+export const ResumenStudio: FC = () => {
+  const router = useRouter();
+  const { event } = EventContextProvider() as any;
+  const { user } = AuthContextProvider() as any;
+  const [openShare, setOpenShare] = useState(false);
+
+  const inv: any[] = event?.invitados_array || [];
+  const total = inv.length;
+  const pendientes = inv.filter((x) => x?.asistencia === "pendiente").length;
+  const confirmados = inv.filter((x) => x?.asistencia === "confirmado").length;
+  const cancelados = inv.filter((x) => x?.asistencia === "cancelado").length;
+  const seated = inv.filter((x) => x?.nombre_mesa && String(x.nombre_mesa).toLowerCase() !== "no asignado").length;
+  const enviadas = inv.filter((x) => !!x?.invitacion).length;
+  const sinEnviar = total - enviadas;
+
+  const estimado = Number(event?.presupuesto_objeto?.coste_estimado || 0);
+  const gastado = Number(event?.presupuesto_objeto?.coste_final || 0);
+  const cur = event?.presupuesto_objeto?.currency || "€";
+  const over = gastado > estimado && estimado > 0;
+  const fmt = (n: number) => `${Math.round(n).toLocaleString("es-ES")} ${cur}`;
+  const presupPct = estimado > 0 ? Math.min((gastado / estimado) * 100, 100) : 0;
+  const presupColor = over ? "#E0A32B" : "#EF5B94";
+
+  const isOwner = event?.usuario_id === user?.uid;
+
+  const fechaObj = event?.fecha ? new Date(event.fecha) : null;
+  const fechaValida = !!fechaObj && !isNaN(fechaObj.getTime());
+  const fechaTxt = fechaValida ? fechaObj!.toLocaleDateString("es-ES", { day: "numeric", month: "long", year: "numeric" }) : "Fecha por definir";
+  const dias = fechaValida ? Math.max(0, Math.ceil((fechaObj!.getTime() - Date.now()) / 86400000)) : null;
+  const tipoTxt = event?.tipo ? event.tipo.charAt(0).toUpperCase() + event.tipo.slice(1).toLowerCase() : "Evento";
+
+  // Checklist derivado del estado real del evento
+  const steps: { title: string; done: boolean; to: string | null }[] = [
+    { title: "Datos del evento", done: !!(event?.nombre && event?.fecha), to: null },
+    { title: "Lista de invitados", done: total > 0, to: "/invitados" },
+    { title: "Presupuesto", done: estimado > 0 || gastado > 0, to: "/presupuesto" },
+    { title: "Plano de mesas", done: seated > 0, to: "/mesas" },
+    { title: "Enviar invitaciones", done: enviadas > 0, to: "/invitaciones" },
+    { title: "Crear itinerario", done: (event?.itinerarios_array?.length || 0) > 0, to: "/itinerario" },
+  ];
+  const doneN = steps.filter((s) => s.done).length;
+  const totalSteps = steps.length;
+  const pct = Math.round((doneN / totalSteps) * 100);
+  const firstPending = steps.findIndex((s) => !s.done);
+  const estadoMsg = pct === 0 ? "¡Empieza tu evento!" : pct < 50 ? "¡Vamos comenzando!" : pct < 100 ? "¡Vas por buen camino!" : "¡A celebrar!";
+  const ticks = [1, 2, 3, 4, 5].map((k) => ({ left: `${((k / totalSteps) * 100).toFixed(1)}%`, on: (k / totalSteps) * 100 <= pct }));
+
+  const metricas = [
+    { big: `${doneN} de ${totalSteps}`, label: "Pasos para completar tu evento" },
+    { big: String(total), label: "Invitados" },
+    { big: `${seated} de ${total}`, label: "Invitados sentados" },
+  ];
+
+  // Alertas reales (solo las que aplican)
+  type Alert = { icon: ReactNode; wrap: string; color: string; title: string; desc: string; cta: string; ctaColor: string; to: string };
+  const alerts: Alert[] = [];
+  if (over) alerts.push({ icon: <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M10.3 3.9L1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" /><path d="M12 9v4M12 17h0" /></svg>, wrap: "#FBF0DA", color: "#B4801F", title: "Presupuesto excedido", desc: `Superas el estimado en ${fmt(gastado - estimado)}.`, cta: "Revisar", ctaColor: "#B4801F", to: "/presupuesto" });
+  if (sinEnviar > 0) alerts.push({ icon: <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 7l9 6 9-6" /></svg>, wrap: "#FCE7F0", color: "#EF5B94", title: "Invitaciones sin enviar", desc: `${enviadas} de ${total} enviadas.`, cta: "Enviar", ctaColor: "#EF5B94", to: "/invitaciones" });
+  if (pendientes > 0) alerts.push({ icon: <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M17 11l2 2 4-4" /></svg>, wrap: "#FCE7F0", color: "#EF5B94", title: "Invitados sin confirmar", desc: `${confirmados} de ${total} confirmados.`, cta: "Gestionar", ctaColor: "#EF5B94", to: "/invitados" });
+
+  const heroSrc = (event?.imgEvento?.i640 || event?.imgEvento?.i800 || event?.imgEvento?.i320)
+    ? `/api/proxy-image?url=${encodeURIComponent(`https://api-mcp.eventosorganizador.com/${event.imgEvento.i640 || event.imgEvento.i800 || event.imgEvento.i320}`)}`
+    : (defaultImagenes[event?.tipo?.toLowerCase()] || defaultImagenes["otro"]);
+
+  // Invitados (3 stats)
+  const invStats = [
+    { count: `${pendientes} de ${total}`, label: "por confirmar", soft: "#FBF0DA", fg: "#E0A32B", icon: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9" /><path d="M12 8v4l2.5 1.5" /></svg> },
+    { count: `${confirmados} de ${total}`, label: "confirmadas", soft: "#E4F5EE", fg: "#2FB37E", icon: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg> },
+    { count: `${cancelados} de ${total}`, label: "canceladas", soft: "#FBE4EF", fg: "#D83E7C", icon: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M6 6l12 12M18 6L6 18" /></svg> },
+  ];
+
+  const dashBtn: React.CSSProperties = { alignSelf: "center", marginTop: "auto", height: 42, width: 160, padding: "0 18px", borderRadius: 11, background: "transparent", border: "1.5px dashed #F4A9C8", color: "#EF5B94", font: "600 12.5px Poppins", cursor: "pointer" };
+
+  return (
+    <div style={{ background: "#ECECEE", minHeight: "100%", fontFamily: "'Poppins',sans-serif" }}>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+      </Head>
+      <style dangerouslySetInnerHTML={{ __html: `
+        @keyframes fadein{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:translateY(0)}}
+        @media (max-width:820px){.rs-hero{grid-template-columns:1fr !important}.rs-2col{grid-template-columns:1fr !important}.rs-3col{grid-template-columns:1fr !important}.rs-check{grid-template-columns:repeat(2,1fr) !important}}
+      ` }} />
+      {isOwner && <ModalAddUserToEvent openModal={openShare} setOpenModal={setOpenShare} event={event} />}
+
+      <div style={{ maxWidth: 1040, margin: "0 auto", padding: "24px 20px 48px", animation: "fadein .2s ease" }}>
+
+        {/* HERO EVENTO */}
+        <div className="rs-hero" style={{ display: "grid", gridTemplateColumns: "44% 1fr", background: "#fff", border: "1px solid #f0f0f2", borderRadius: 18, overflow: "hidden", boxShadow: "0 6px 20px rgba(0,0,0,.06)", marginBottom: 16 }}>
+          <div style={{ position: "relative", minHeight: 230, background: "#f2f2f4" }}>
+            <img src={heroSrc} alt={event?.nombre} style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }} onError={(e) => { (e.target as HTMLImageElement).src = defaultImagenes[event?.tipo?.toLowerCase()] || defaultImagenes["otro"]; }} />
+          </div>
+          <div style={{ padding: "22px 26px", display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "flex-end", gap: 8 }}>
+              <div onClick={() => isOwner && setOpenShare(true)} title="Personas con acceso" style={{ position: "relative", width: 34, height: 34, borderRadius: "50%", background: "#7a7a7a", color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", font: "700 14px Poppins", cursor: isOwner ? "pointer" : "default" }}>
+                {(user?.displayName || event?.nombre || "?").charAt(0).toUpperCase()}
+                <span style={{ position: "absolute", bottom: 0, right: 0, width: 9, height: 9, borderRadius: "50%", background: "#37c46b", border: "1.5px solid #fff" }} />
+              </div>
+              <div onClick={() => isOwner && setOpenShare(true)} title="Compartir" style={{ width: 32, height: 32, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94", cursor: isOwner ? "pointer" : "default" }}>
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><circle cx="18" cy="5" r="2.5" /><circle cx="6" cy="12" r="2.5" /><circle cx="18" cy="19" r="2.5" /><path d="M8.2 10.8l7.6-4.4M8.2 13.2l7.6 4.4" /></svg>
+              </div>
+              <div title="Editar evento (próximamente)" style={{ width: 32, height: 32, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94", opacity: .5, cursor: "default" }}>
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" /></svg>
+              </div>
+            </div>
+            <div style={{ textAlign: "center", marginTop: 2 }}>
+              <div style={{ font: "700 24px Poppins", color: "#4a4a52", letterSpacing: ".3px" }}>{event?.nombre}</div>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8, marginTop: 8, font: "600 13px Poppins", color: "#8a8a90" }}>
+                {fechaTxt}<span style={{ background: "#FCE7F0", color: "#EF5B94", font: "600 11.5px Poppins", padding: "3px 11px", borderRadius: 20 }}>{tipoTxt}</span>
+              </div>
+              {dias !== null && (
+                <div style={{ display: "inline-flex", alignItems: "center", gap: 7, marginTop: 9, background: "linear-gradient(135deg,#EF5B94,#f588b3)", color: "#fff", font: "500 13px Poppins", padding: "6px 15px", borderRadius: 22, boxShadow: "0 6px 16px rgba(239,91,148,.28)" }}>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M6 2h12M6 22h12M6 2c0 5 4 6 4 10s-4 5-4 10M18 2c0 5-4 6-4 10s4 5 4 10" /></svg>
+                  {dias === 0 ? "¡Es hoy!" : `Faltan ${dias.toLocaleString("es-ES")} días`}
+                </div>
+              )}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: "auto", paddingTop: 18 }}>
+              <div style={{ font: "600 11.5px Poppins", color: "#8a8a90" }}>Estado <span style={{ color: "#3A3A42" }}>· {pct}%</span></div>
+              <div style={{ font: "600 11.5px Poppins", color: "#EF5B94", whiteSpace: "nowrap" }}>{estadoMsg}</div>
+            </div>
+            <div style={{ position: "relative", height: 8, borderRadius: 8, background: "#f0f0f2", marginTop: 8 }}>
+              <div style={{ position: "absolute", inset: 0, height: "100%", width: `${pct}%`, background: "linear-gradient(90deg,#EF5B94,#f588b3)", borderRadius: 8, transition: "width .9s cubic-bezier(.2,.7,.2,1)" }} />
+              {ticks.map((t, i) => (<div key={i} style={{ position: "absolute", top: "50%", left: t.left, transform: "translate(-50%,-50%)", width: 5, height: 5, borderRadius: "50%", background: t.on ? "#fff" : "#d8d8de" }} />))}
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 12, marginTop: 16 }}>
+              {metricas.map((m, i) => (
+                <div key={i} style={{ textAlign: "center", padding: "4px 2px" }}>
+                  <div style={{ font: "600 16px Poppins", color: "#3A3A42" }}>{m.big}</div>
+                  <div style={{ font: "500 10.5px Poppins", color: "#a0a0a8", marginTop: 2 }}>{m.label}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* CHECKLIST: PASOS PARA COMPLETAR */}
+        <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "2px 0", marginBottom: 16 }}>
+          <div style={{ font: "500 11px Poppins", color: "#a0a0a8", whiteSpace: "nowrap", flex: "none" }}>Toca para completar</div>
+          <div className="rs-check" style={{ display: "grid", gridTemplateColumns: "repeat(6,1fr)", gap: 8, flex: 1 }}>
+            {steps.map((s, i) => {
+              const active = i === firstPending;
+              const dotBg = s.done ? "#EF5B94" : active ? "#EF5B94" : "#f0f0f2";
+              const dotFg = s.done || active ? "#fff" : "#b3b3ba";
+              const bg = s.done ? "#f4f4f6" : active ? "#FDEEF4" : "#faf9fb";
+              const border = s.done ? "#e4e4e8" : active ? "#EF5B94" : "#f0f0f2";
+              return (
+                <div key={i} onClick={() => s.to && router.push(s.to)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 10px", borderRadius: 10, background: bg, border: `1.5px ${active ? "dashed" : "solid"} ${border}`, boxShadow: active ? "0 3px 12px rgba(239,91,148,.22)" : "none", cursor: s.to ? "pointer" : "default" }}>
+                  <div style={{ width: 20, height: 20, borderRadius: "50%", background: dotBg, display: "flex", alignItems: "center", justifyContent: "center", color: dotFg, font: "700 10px Poppins", flex: "none" }}>
+                    {s.done ? <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3.5} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg> : i + 1}
+                  </div>
+                  <div style={{ font: "500 10.5px Poppins", color: s.done ? "#a0a0a8" : active ? "#3A3A42" : "#a0a0a8", lineHeight: 1.2 }}>{s.title}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* NECESITA TU ATENCIÓN */}
+        {alerts.length > 0 && (
+          <>
+            <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 11 }}>
+              <span style={{ font: "600 16px Poppins", color: "#6b6b72" }}>Necesita tu atención</span>
+            </div>
+            <div className="rs-3col" style={{ display: "grid", gridTemplateColumns: `repeat(${Math.min(alerts.length, 3)},1fr)`, gap: 14, marginBottom: 22 }}>
+              {alerts.map((a, i) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: 12, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: "14px 16px", boxShadow: "0 4px 14px rgba(0,0,0,.05)" }}>
+                  <div style={{ width: 38, height: 38, flex: "none", borderRadius: 11, background: a.wrap, display: "flex", alignItems: "center", justifyContent: "center", color: a.color }}>{a.icon}</div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{a.title}</div>
+                    <div style={{ font: "500 11.5px Poppins", color: "#a0a0a8", marginTop: 2 }}>{a.desc}</div>
+                  </div>
+                  <span onClick={() => router.push(a.to)} style={{ font: "600 12px Poppins", color: a.ctaColor, whiteSpace: "nowrap", cursor: "pointer" }}>{a.cta}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* PRESUPUESTO + INVITADOS */}
+        <div className="rs-2col" style={{ display: "grid", gridTemplateColumns: "340px 1fr", gap: 18, marginBottom: 18, alignItems: "stretch" }}>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ font: "600 16px Poppins", color: "#6b6b72", marginBottom: 10 }}>Presupuesto</div>
+            <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "20px 18px", display: "flex", flexDirection: "column", flex: 1, gap: 16, boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+                <div style={{ width: 40, height: 40, borderRadius: 12, flex: "none", background: "#FCE7F0", display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94" }}>
+                  <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18v12H3zM3 10h18" /><circle cx="12" cy="14" r="1.6" /></svg>
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ font: "500 11px Poppins", color: "#a0a0a8" }}>Estimado</div>
+                  <div style={{ font: "600 16px Poppins", color: "#3A3A42" }}>{fmt(estimado)}</div>
+                </div>
+              </div>
+              <div>
+                <div style={{ height: 8, borderRadius: 6, background: "#f2f2f4", overflow: "hidden" }}>
+                  <div style={{ height: "100%", width: `${presupPct.toFixed(0)}%`, borderRadius: 6, background: presupColor, transition: "width .9s cubic-bezier(.2,.7,.2,1)" }} />
+                </div>
+                <div style={{ display: "flex", justifyContent: "space-between", marginTop: 7 }}>
+                  <span style={{ font: "500 11px Poppins", color: "#a0a0a8" }}>Gastado</span>
+                  <span style={{ font: "600 16px Poppins", color: presupColor }}>{fmt(gastado)}</span>
+                </div>
+              </div>
+              <div style={{ display: "inline-flex", alignSelf: "flex-start", alignItems: "center", gap: 6, background: over ? "#FDF6E7" : "#EAF7F0", border: `1px solid ${over ? "#F2E2B8" : "#C3E8D5"}`, borderRadius: 999, padding: "5px 12px" }}>
+                {over
+                  ? <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#B4801F" strokeWidth={2.1} strokeLinecap="round" strokeLinejoin="round"><path d="M12 9v4M12 17h0" /><path d="M10.3 3.9L1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" /></svg>
+                  : <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#1E8F63" strokeWidth={2.3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>}
+                <span style={{ font: "600 11.5px Poppins", color: over ? "#B4801F" : "#1E8F63", whiteSpace: "nowrap" }}>{over ? `Superas el presupuesto en ${fmt(gastado - estimado)}` : `Te quedan ${fmt(Math.max(0, estimado - gastado))}`}</span>
+              </div>
+              <button onClick={() => router.push("/presupuesto")} style={dashBtn}>Añadir gastos</button>
+            </div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ font: "600 16px Poppins", color: "#6b6b72", marginBottom: 10 }}>Invitados</div>
+            <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "22px 18px", display: "flex", flexDirection: "column", flex: 1, boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
+              <div style={{ display: "flex", alignItems: "stretch", justifyContent: "center", gap: 10, flex: 1 }}>
+                {invStats.map((g, i) => (
+                  <div key={i} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", textAlign: "center", gap: 10 }}>
+                    <div style={{ position: "relative", width: 46, height: 46, flex: "none" }}>
+                      <div style={{ width: 46, height: 46, borderRadius: 14, background: g.soft, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={g.fg} strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="3.2" /><path d="M22 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.5a4 4 0 0 1 0 7" /></svg>
+                      </div>
+                      <div style={{ position: "absolute", right: -4, bottom: -4, width: 20, height: 20, borderRadius: "50%", background: g.fg, display: "flex", alignItems: "center", justifyContent: "center", border: "2.5px solid #fff" }}>{g.icon}</div>
+                    </div>
+                    <div style={{ font: "600 16px Poppins", color: "#3A3A42", lineHeight: 1 }}>{g.count}</div>
+                    <div style={{ font: "500 11.5px Poppins", color: "#8a8a90" }}>{g.label}</div>
+                  </div>
+                ))}
+              </div>
+              <button onClick={() => router.push("/invitados")} style={dashBtn}>Añadir Invitados</button>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};

--- a/apps/appEventos/components/Resumen/ResumenStudio.tsx
+++ b/apps/appEventos/components/Resumen/ResumenStudio.tsx
@@ -81,6 +81,30 @@ export const ResumenStudio: FC = () => {
     { count: `${cancelados} de ${total}`, label: "canceladas", soft: "#FBE4EF", fg: "#D83E7C", icon: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M6 6l12 12M18 6L6 18" /></svg> },
   ];
 
+  // Mesas por espacio (planSpace → tables; sentados por coincidencia de nombre_mesa)
+  const spaces: any[] = event?.planSpace || [];
+  const mesasList = spaces.map((sp: any) => {
+    const tables: any[] = sp?.tables || [];
+    const names = new Set(tables.map((t: any) => t?.title));
+    const capacity = tables.reduce((s: number, t: any) => s + (Number(t?.numberChair) || 0), 0);
+    const seatedHere = inv.filter((g) => g?.nombre_mesa && names.has(g.nombre_mesa)).length;
+    return { name: sp?.title || "Espacio", total: tables.length, seated: seatedHere, capacity };
+  });
+
+  // Lista de regalos (misma lógica que BlockListaRegalos)
+  const lista: any = event?.listaRegalos ?? null;
+  const regItems: any[] = Array.isArray(lista?.items) ? lista.items : Array.isArray(lista?.regalos) ? lista.regalos : Array.isArray(lista) ? lista : [];
+  const raised = regItems.reduce((s: number, it: any) => {
+    const c = Array.isArray(it?.contribuciones) ? it.contribuciones : [];
+    const cs = c.reduce((a: number, x: any) => a + (Number(x?.monto ?? x?.importe ?? 0) || 0), 0);
+    return s + (cs || (Number(it?.conseguido ?? 0) || 0));
+  }, 0);
+  const participantes = regItems.reduce((s: number, it: any) => s + (Array.isArray(it?.contribuciones) ? it.contribuciones.length : 0), 0);
+  const listaActiva = regItems.length > 0;
+
+  // Momentos
+  const albumes = Number((event as any)?.memoriesAlbumCount || 0);
+
   const dashBtn: React.CSSProperties = { alignSelf: "center", marginTop: "auto", height: 42, width: 160, padding: "0 18px", borderRadius: 11, background: "transparent", border: "1.5px dashed #F4A9C8", color: "#EF5B94", font: "600 12.5px Poppins", cursor: "pointer" };
 
   return (
@@ -240,6 +264,78 @@ export const ResumenStudio: FC = () => {
               </div>
               <button onClick={() => router.push("/invitados")} style={dashBtn}>Añadir Invitados</button>
             </div>
+          </div>
+        </div>
+
+        {/* BANNER INVITACIONES */}
+        <div style={{ borderRadius: 16, padding: "18px 24px", background: "linear-gradient(135deg,#EF5B94,#f588b3)", display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 22, boxShadow: "0 10px 24px rgba(239,91,148,.28)", flexWrap: "wrap", gap: 12 }}>
+          <div style={{ font: "600 16px Poppins", color: "#fff" }}>Invitaciones</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 26, flexWrap: "wrap" }}>
+            <div style={{ textAlign: "center" }}><span style={{ font: "600 13px Poppins", color: "#fff", opacity: .9 }}>enviadas </span><span style={{ font: "600 16px Poppins", color: "#fff" }}>{enviadas}</span></div>
+            <div style={{ textAlign: "center" }}><span style={{ font: "600 13px Poppins", color: "#fff", opacity: .9 }}>por enviar </span><span style={{ font: "600 16px Poppins", color: "#fff" }}>{sinEnviar}</span></div>
+            <div style={{ textAlign: "center" }}><span style={{ font: "600 13px Poppins", color: "#fff", opacity: .9 }}>confirmadas </span><span style={{ font: "600 16px Poppins", color: "#fff" }}>{confirmados}</span></div>
+            <button onClick={() => router.push("/invitaciones")} style={{ padding: "11px 18px", borderRadius: 10, background: "#fff", color: "#EF5B94", font: "600 12.5px Poppins", cursor: "pointer", border: "none" }}>Ver mis invitaciones</button>
+          </div>
+        </div>
+
+        {/* MESAS + LISTA DE REGALOS */}
+        <div className="rs-2col" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 18, marginBottom: 18, alignItems: "stretch" }}>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+              <div style={{ font: "600 16px Poppins", color: "#6b6b72" }}>Mesas</div>
+            </div>
+            <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "8px 18px 18px", flex: 1, display: "flex", flexDirection: "column", boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center" }}>
+                {mesasList.length === 0 && <div style={{ textAlign: "center", padding: "22px 0", font: "500 12px Poppins", color: "#a0a0a8" }}>Aún no has creado planos de mesas.</div>}
+                {mesasList.map((m, i) => (
+                  <div key={i} style={{ display: "flex", alignItems: "center", gap: 14, padding: "12px 0", borderBottom: `1px solid ${i < mesasList.length - 1 ? "#f0f0f2" : "transparent"}` }}>
+                    <div style={{ width: 44, height: 44, borderRadius: 12, flex: "none", background: "#FCE7F0", display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94" }}><svg width="22" height="22" viewBox="-2 -2 28 28" fill="none" stroke="currentColor" strokeWidth={1.7}><ellipse cx="12" cy="9" rx="8" ry="3" /><path d="M6 10v8M18 10v8" /></svg></div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{m.name}</div>
+                      <div style={{ font: "500 11px Poppins", color: "#a0a0a8", marginTop: 1 }}>{m.total} mesas</div>
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, background: "#FCE7F0", padding: "5px 11px", borderRadius: 20 }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="3.2" /></svg><span style={{ font: "600 12px Poppins", color: "#EF5B94" }}>{m.seated}{m.capacity ? ` de ${m.capacity}` : ""} sentados</span></div>
+                  </div>
+                ))}
+              </div>
+              <button onClick={() => router.push("/mesas")} style={dashBtn}>Ver mesas</button>
+            </div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+              <div style={{ font: "600 16px Poppins", color: "#6b6b72" }}>Lista de regalos</div>
+            </div>
+            <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: 18, display: "flex", flexDirection: "column", gap: 16, flex: 1, boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
+              <div style={{ display: "flex", gap: 12, flex: 1, alignItems: "center" }}>
+                <div style={{ flex: 1, background: "#faf9fb", borderRadius: 12, padding: "16px 14px", textAlign: "center" }}><div style={{ font: "600 16px Poppins", color: "#3A3A42" }}>{Math.round(raised).toLocaleString("es-ES")}€</div><div style={{ font: "500 10.5px Poppins", color: "#a0a0a8", marginTop: 2 }}>Recaudado</div></div>
+                <div style={{ flex: 1, background: "#faf9fb", borderRadius: 12, padding: "16px 14px", textAlign: "center" }}><div style={{ font: "600 16px Poppins", color: "#3A3A42" }}>{participantes}</div><div style={{ font: "500 10.5px Poppins", color: "#a0a0a8", marginTop: 2 }}>Participantes</div></div>
+              </div>
+              <button onClick={() => router.push("/lista-regalos")} style={dashBtn}>{listaActiva ? "Ver lista" : "Activar lista"}</button>
+            </div>
+          </div>
+        </div>
+
+        {/* ACCESOS RÁPIDOS */}
+        <div className="rs-hero" style={{ display: "grid", gridTemplateColumns: "44% 1fr", gap: 18, marginBottom: 16 }}>
+          <button onClick={() => router.push("/itinerario")} style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 9, padding: 13, borderRadius: 12, background: "#FCE7F0", color: "#EF5B94", font: "600 13px Poppins", border: "none", cursor: "pointer" }}><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><rect x="4" y="5" width="16" height="15" rx="2" /><path d="M4 10h16M8 3v4M16 3v4" /></svg>Ver itinerarios</button>
+          <div style={{ display: "flex", alignItems: "stretch", borderRadius: 12, overflow: "hidden", boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
+            <button title="Directorio de lugares (próximamente)" style={{ flex: "none", padding: "13px 20px", background: "#EF5B94", color: "#fff", font: "600 13px Poppins", border: "none", cursor: "default" }}>Lugar del evento</button>
+            <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 10, background: "#fff", padding: "12px 16px" }}>
+              <input type="text" placeholder="Buscar lugar en el directorio de Bodasdehoy…" style={{ flex: 1, border: "none", outline: "none", background: "transparent", font: "500 13px Poppins", color: "#3A3A42" }} />
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" /></svg>
+            </div>
+          </div>
+        </div>
+
+        {/* MOMENTOS */}
+        <div className="rs-2col" style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "18px 22px", display: "grid", gridTemplateColumns: "1fr 1fr", gap: 18, alignItems: "center", marginBottom: 22, boxShadow: "0 6px 20px rgba(0,0,0,.06)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+            <div style={{ width: 44, height: 44, borderRadius: 12, flex: "none", background: "#FCE7F0", display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94" }}><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7}><rect x="4" y="5" width="16" height="14" rx="2" /><circle cx="9" cy="10" r="1.6" /><path d="M5.5 18l4-4 2.5 2.5L16 13l2.5 3" /></svg></div>
+            <div style={{ flex: 1 }}><div style={{ font: "600 16px Poppins", color: "#6b6b72" }}>Momentos</div><div style={{ font: "500 11.5px Poppins", color: "#8a8a90", marginTop: 2 }}>Álbumes de fotos compartidos con tus invitados.</div></div>
+            <div style={{ textAlign: "center" }}><div style={{ font: "600 16px Poppins", color: "#EF5B94" }}>{albumes}</div><div style={{ font: "500 10.5px Poppins", color: "#a0a0a8" }}>álbumes</div></div>
+          </div>
+          <div style={{ display: "flex", justifyContent: "center", paddingLeft: 22 }}>
+            <button onClick={() => router.push("/momentos")} style={{ height: 42, width: 160, padding: "0 18px", borderRadius: 11, background: "transparent", border: "1.5px dashed #F4A9C8", color: "#EF5B94", font: "600 12.5px Poppins", cursor: "pointer" }}>{albumes > 0 ? "Ver álbumes" : "Crear álbum"}</button>
           </div>
         </div>
 

--- a/apps/appEventos/components/Resumen/ResumenStudio.tsx
+++ b/apps/appEventos/components/Resumen/ResumenStudio.tsx
@@ -6,6 +6,7 @@ import { ModalAddUserToEvent } from "../Utils/Compartir";
 import { defaultImagenes } from "../Home/Card";
 import { fetchApiBodas, queries } from "../../utils/Fetching";
 import { useToast } from "../../hooks/useToast";
+import { EntityNotesSection } from "../Notes/EntityNotesSection";
 
 /**
  * ResumenStudio — rediseño de la hoja de Resumen fiel al HTML "Resumen.dc.html".
@@ -47,7 +48,12 @@ export const ResumenStudio: FC = () => {
 
   const estimado = Number(event?.presupuesto_objeto?.coste_estimado || 0);
   const gastado = Number(event?.presupuesto_objeto?.coste_final || 0);
-  const cur = event?.presupuesto_objeto?.currency || "€";
+  const curSym = (c?: string) => {
+    const m: Record<string, string> = { EUR: "€", USD: "$", GBP: "£", MXN: "$", ARS: "$", COP: "$", CLP: "$", PEN: "S/", BRL: "R$", USB: "$" };
+    if (!c) return "€";
+    return m[c.toUpperCase()] || (c.length <= 2 ? c : "€");
+  };
+  const cur = curSym(event?.presupuesto_objeto?.currency);
   const over = gastado > estimado && estimado > 0;
   const fmt = (n: number) => `${Math.round(n).toLocaleString("es-ES")} ${cur}`;
   const presupPct = estimado > 0 ? Math.min((gastado / estimado) * 100, 100) : 0;
@@ -455,6 +461,12 @@ export const ResumenStudio: FC = () => {
             {closeX}
           </div>
         )}
+
+        {/* NOTAS INTERNAS */}
+        <div style={{ marginTop: 22 }}>
+          <div style={{ font: "600 16px Poppins", color: "#6b6b72", marginBottom: 14 }}>Notas internas</div>
+          <EntityNotesSection entityType="EVENTO" entityId={event._id} entityName={event.nombre || "Evento"} />
+        </div>
 
       </div>
 

--- a/apps/appEventos/components/Resumen/ResumenStudio.tsx
+++ b/apps/appEventos/components/Resumen/ResumenStudio.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/router";
 import { EventContextProvider, AuthContextProvider } from "../../context";
 import { ModalAddUserToEvent } from "../Utils/Compartir";
 import { defaultImagenes } from "../Home/Card";
+import { fetchApiBodas, queries } from "../../utils/Fetching";
+import { useToast } from "../../hooks/useToast";
 
 /**
  * ResumenStudio — rediseño de la hoja de Resumen fiel al HTML "Resumen.dc.html".
@@ -12,9 +14,27 @@ import { defaultImagenes } from "../Home/Card";
  */
 export const ResumenStudio: FC = () => {
   const router = useRouter();
-  const { event } = EventContextProvider() as any;
+  const { event, setEvent } = EventContextProvider() as any;
   const { user } = AuthContextProvider() as any;
+  const toast = useToast();
   const [openShare, setOpenShare] = useState(false);
+  const [picker, setPicker] = useState<null | "color" | "temporada" | "estilo" | "tematica">(null);
+  const [tematicaDraft, setTematicaDraft] = useState("");
+  const [editOpen, setEditOpen] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [editDate, setEditDate] = useState("");
+
+  // Persistencia de aspectos/evento — mismo patrón que BlockSobreMiEvento (eventUpdate)
+  const saveField = async (patch: Record<string, any>) => {
+    try {
+      const r: any = await fetchApiBodas({ query: queries.eventUpdate, variables: { idEvento: event._id, input: patch }, token: null });
+      if (r?.errors?.length) throw new Error();
+      setEvent({ ...event, ...patch });
+      toast("success", "Guardado con éxito");
+    } catch {
+      toast("error", "Ha ocurrido un error");
+    }
+  };
 
   const inv: any[] = event?.invitados_array || [];
   const total = inv.length;
@@ -105,6 +125,45 @@ export const ResumenStudio: FC = () => {
   // Momentos
   const albumes = Number((event as any)?.memoriesAlbumCount || 0);
 
+  // Sobre mi evento (aspectos) — mismos campos/valores que BlockSobreMiEvento
+  const colorVal = Array.isArray(event?.color) ? event.color[0] : event?.color;
+  const colorOpts = [
+    { name: "Amarillo", hex: "#F2C230" }, { name: "Celeste", hex: "#29C2E0" }, { name: "Rosado", hex: "#EF5B94" },
+    { name: "Rojo", hex: "#E23B2E" }, { name: "Morado", hex: "#8B3FD6" }, { name: "Beige", hex: "#E4D3A6" },
+    { name: "Dorado", hex: "#E0A32B" }, { name: "Plata", hex: "#A9B0BC" }, { name: "Naranja", hex: "#F07B29" }, { name: "verde", hex: "#4CA83D" },
+  ];
+  const colorHex = colorOpts.find((c) => c.name === colorVal)?.hex;
+  const seasonOpts: { name: string; color: string; paths: ReactNode }[] = [
+    { name: "Invierno", color: "#29C2E0", paths: <><path d="M12 2v20M3.34 7l17.32 10M3.34 17L20.66 7" /><path d="M12 5.6l-2.2-2.2M12 5.6l2.2-2.2M12 18.4l-2.2 2.2M12 18.4l2.2 2.2M6.8 9l-2.9-.2M6.8 9l-.2-2.9M17.2 15l2.9 .2M17.2 15l.2 2.9M6.8 15l-.2 2.9M6.8 15l-2.9 .2M17.2 9l.2-2.9M17.2 9l2.9-.2" /></> },
+    { name: "Primavera", color: "#4CA83D", paths: <><circle cx="12" cy="12" r="2.4" /><ellipse cx="12" cy="6" rx="2.5" ry="3.4" /><ellipse cx="12" cy="6" rx="2.5" ry="3.4" transform="rotate(60 12 12)" /><ellipse cx="12" cy="6" rx="2.5" ry="3.4" transform="rotate(120 12 12)" /><ellipse cx="12" cy="6" rx="2.5" ry="3.4" transform="rotate(180 12 12)" /><ellipse cx="12" cy="6" rx="2.5" ry="3.4" transform="rotate(240 12 12)" /><ellipse cx="12" cy="6" rx="2.5" ry="3.4" transform="rotate(300 12 12)" /></> },
+    { name: "Verano", color: "#F2A81E", paths: <><circle cx="12" cy="12" r="4.2" /><path d="M12 2.4v2.3M12 19.3v2.3M2.4 12h2.3M19.3 12h2.3M5.1 5.1l1.7 1.7M17.2 17.2l1.7 1.7M18.9 5.1l-1.7 1.7M6.8 17.2l-1.7 1.7" /></> },
+    { name: "Otoño", color: "#C77A2E", paths: <><path d="M12 2 L13.3 5.6 L16.6 4.5 L15.3 7.9 L19.2 7.6 L16.4 10.4 L20.2 11.9 L16 12.7 L17.9 16 L14.1 14.7 L13.8 18.6 L12 15.6 L10.2 18.6 L9.9 14.7 L6.1 16 L8 12.7 L3.8 11.9 L7.6 10.4 L4.8 7.6 L8.7 7.9 L7.4 4.5 L10.7 5.6 Z" /><path d="M12 15.6V22" /></> },
+  ];
+  const estiloOpts: { name: string; paths: ReactNode }[] = [
+    { name: "Aire libre", paths: <><circle cx="9" cy="8" r="4" /><path d="M9 12v9M3 21h18M15 21v-5h5v5" /></> },
+    { name: "Salón", paths: <><circle cx="12" cy="12" r="7" /><path d="M5 12h14M12 5v14M6.5 7.5c3.5 2.5 7.5 2.5 11 0M6.5 16.5c3.5-2.5 7.5-2.5 11 0" /></> },
+    { name: "Piscina", paths: <><path d="M12 4a7 7 0 0 1 7 7H5a7 7 0 0 1 7-7Z" /><path d="M12 4v9" /><path d="M4 21l5-5h8" /></> },
+    { name: "En casa", paths: <><path d="M6 21V4h12v17" /><path d="M9 8h2M13 8h2M9 12h2M13 12h2M9 16h2M13 16h2" /></> },
+    { name: "Salon historico", paths: <><path d="M3 21h18M5 21V10M9 21V10M15 21V10M19 21V10M3 10h18L12 3 3 10Z" /></> },
+  ];
+  const seasonIcon = (name?: string, size = 30) => { const s = seasonOpts.find((o) => o.name === name); return s ? <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={s.color} strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round">{s.paths}</svg> : null; };
+  const estiloIcon = (name?: string, size = 30) => { const s = estiloOpts.find((o) => o.name === name); return s ? <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="#7A7A82" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round">{s.paths}</svg> : null; };
+  const aspectVisual = (key: string) => {
+    if (key === "color") return <div style={{ width: 30, height: 30, borderRadius: "50%", background: colorHex || "#e6e6ea", border: "2px solid #fff", boxShadow: "0 0 0 1.5px #e6e6ea" }} />;
+    if (key === "temporada") return event?.temporada ? seasonIcon(event.temporada, 30) : <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="4" /><path d="M12 2v3M12 19v3M2 12h3M19 12h3" /></svg>;
+    if (key === "estilo") return event?.estilo ? estiloIcon(event.estilo, 30) : <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round"><path d="M3 21h18M5 21V9l7-5 7 5v12" /></svg>;
+    return <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke={event?.tematica ? "#EF5B94" : "#b3b3ba"} strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3l2.4 5.3 5.6.5-4.2 3.8 1.3 5.6L12 17l-5.1 2.5 1.3-5.6L4 10.3l5.6-.5z" /></svg>;
+  };
+  const aspects = [
+    { key: "color", name: "Color", value: colorVal || "Sin definir", has: !!colorVal },
+    { key: "temporada", name: "Temporada", value: event?.temporada || "Sin definir", has: !!event?.temporada },
+    { key: "estilo", name: "Estilo", value: event?.estilo || "Sin definir", has: !!event?.estilo },
+    { key: "tematica", name: "Temática", value: event?.tematica || "Sin definir", has: !!event?.tematica },
+  ];
+  const popover: React.CSSProperties = { background: "#fff", borderRadius: 14, boxShadow: "0 6px 22px rgba(0,0,0,.09)", padding: "24px 30px", marginBottom: 14, position: "relative", display: "flex", alignItems: "flex-start", flexWrap: "wrap", gap: "20px 30px", animation: "fadein .18s ease" };
+  const closeX = <button onClick={() => setPicker(null)} style={{ position: "absolute", top: 12, right: 16, width: 26, height: 26, color: "#8a8a90", fontSize: 16, background: "none", border: "none", cursor: "pointer" }}>✕</button>;
+  const openEdit = () => { setEditName(event?.nombre || ""); setEditDate(fechaValida ? fechaObj!.toISOString().slice(0, 10) : ""); setEditOpen(true); };
+
   const dashBtn: React.CSSProperties = { alignSelf: "center", marginTop: "auto", height: 42, width: 160, padding: "0 18px", borderRadius: 11, background: "transparent", border: "1.5px dashed #F4A9C8", color: "#EF5B94", font: "600 12.5px Poppins", cursor: "pointer" };
 
   return (
@@ -135,7 +194,7 @@ export const ResumenStudio: FC = () => {
               <div onClick={() => isOwner && setOpenShare(true)} title="Compartir" style={{ width: 32, height: 32, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94", cursor: isOwner ? "pointer" : "default" }}>
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><circle cx="18" cy="5" r="2.5" /><circle cx="6" cy="12" r="2.5" /><circle cx="18" cy="19" r="2.5" /><path d="M8.2 10.8l7.6-4.4M8.2 13.2l7.6 4.4" /></svg>
               </div>
-              <div title="Editar evento (próximamente)" style={{ width: 32, height: 32, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94", opacity: .5, cursor: "default" }}>
+              <div onClick={() => isOwner && openEdit()} title="Editar evento" style={{ width: 32, height: 32, borderRadius: 9, display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94", opacity: isOwner ? 1 : .5, cursor: isOwner ? "pointer" : "default" }}>
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8}><path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" /></svg>
               </div>
             </div>
@@ -220,7 +279,7 @@ export const ResumenStudio: FC = () => {
             <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "20px 18px", display: "flex", flexDirection: "column", flex: 1, gap: 16, boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
               <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
                 <div style={{ width: 40, height: 40, borderRadius: 12, flex: "none", background: "#FCE7F0", display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94" }}>
-                  <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18v12H3zM3 10h18" /><circle cx="12" cy="14" r="1.6" /></svg>
+                  <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><path d="M19 5c-1.5 0-2.8 1.4-3 2-3.5-1.5-11-.3-11 5 0 1.8 0 3 2 4.5V20h4v-2h3v2h4v-4c1-.5 1.7-1 2-2h2v-4h-2c0-1-.5-1.5-1-2V5z" /><path d="M2 9v1c0 1.1.9 2 2 2h1" /><path d="M16 11h0" /></svg>
                 </div>
                 <div style={{ flex: 1 }}>
                   <div style={{ font: "500 11px Poppins", color: "#a0a0a8" }}>Estimado</div>
@@ -317,10 +376,10 @@ export const ResumenStudio: FC = () => {
 
         {/* ACCESOS RÁPIDOS */}
         <div className="rs-hero" style={{ display: "grid", gridTemplateColumns: "44% 1fr", gap: 18, marginBottom: 16 }}>
-          <button onClick={() => router.push("/itinerario")} style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 9, padding: 13, borderRadius: 12, background: "#FCE7F0", color: "#EF5B94", font: "600 13px Poppins", border: "none", cursor: "pointer" }}><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><rect x="4" y="5" width="16" height="15" rx="2" /><path d="M4 10h16M8 3v4M16 3v4" /></svg>Ver itinerarios</button>
+          <button onClick={() => router.push("/itinerario")} style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 9, padding: "9px 13px", borderRadius: 12, background: "#FCE7F0", color: "#EF5B94", font: "600 13px Poppins", border: "none", cursor: "pointer" }}><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><rect x="4" y="5" width="16" height="15" rx="2" /><path d="M4 10h16M8 3v4M16 3v4" /></svg>Ver itinerarios</button>
           <div style={{ display: "flex", alignItems: "stretch", borderRadius: 12, overflow: "hidden", boxShadow: "0 4px 14px rgba(0,0,0,.06)" }}>
-            <button title="Directorio de lugares (próximamente)" style={{ flex: "none", padding: "13px 20px", background: "#EF5B94", color: "#fff", font: "600 13px Poppins", border: "none", cursor: "default" }}>Lugar del evento</button>
-            <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 10, background: "#fff", padding: "12px 16px" }}>
+            <button title="Directorio de lugares (próximamente)" style={{ flex: "none", padding: "9px 20px", background: "#EF5B94", color: "#fff", font: "600 13px Poppins", border: "none", cursor: "default" }}>Lugar del evento</button>
+            <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 10, background: "#fff", padding: "8px 16px" }}>
               <input type="text" placeholder="Buscar lugar en el directorio de Bodasdehoy…" style={{ flex: 1, border: "none", outline: "none", background: "transparent", font: "500 13px Poppins", color: "#3A3A42" }} />
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" /></svg>
             </div>
@@ -339,7 +398,85 @@ export const ResumenStudio: FC = () => {
           </div>
         </div>
 
+        {/* SOBRE MI EVENTO */}
+        <div style={{ font: "600 16px Poppins", color: "#6b6b72", marginBottom: 14 }}>Sobre mi evento</div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 30, marginBottom: 14, justifyItems: "center" }}>
+          {aspects.map((a) => (
+            <div key={a.key} onClick={() => { if (a.key === "tematica") setTematicaDraft(event?.tematica || ""); setPicker(picker === (a.key as any) ? null : (a.key as any)); }} style={{ width: "100%", aspectRatio: "1", maxWidth: 150, borderRadius: "50%", background: "#fff", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 6, textAlign: "center", boxShadow: "0 8px 20px rgba(0,0,0,.07)", cursor: "pointer" }}>
+              {aspectVisual(a.key)}
+              <div style={{ font: "500 12px Poppins", color: "#8a8a90" }}>{a.name}</div>
+              {a.has && <div style={{ font: "700 11.5px Poppins", color: "#6b6b72" }}>{a.value}</div>}
+            </div>
+          ))}
+        </div>
+
+        {picker === "color" && (
+          <div style={popover}>
+            {colorOpts.map((c) => (
+              <div key={c.name} onClick={() => { saveField({ color: [c.name] }); setPicker(null); }} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 7, cursor: "pointer", minWidth: 52 }}>
+                <div style={{ height: 46, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  <svg width="30" height="34" viewBox="0 0 24 25"><path d="M12 2 C12 2 4.5 11 4.5 16 a7.5 7.5 0 0 0 15 0 C19.5 11 12 2 12 2 Z" fill={c.hex} stroke={colorVal === c.name ? "#3A3A42" : "rgba(0,0,0,.14)"} strokeWidth={colorVal === c.name ? 1.6 : 1} /></svg>
+                </div>
+                <span style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{c.name}</span>
+              </div>
+            ))}
+            {closeX}
+          </div>
+        )}
+        {picker === "temporada" && (
+          <div style={{ ...popover, justifyContent: "space-around" }}>
+            {seasonOpts.map((s) => (
+              <div key={s.name} onClick={() => { saveField({ temporada: s.name }); setPicker(null); }} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 9, cursor: "pointer", minWidth: 72 }}>
+                <div style={{ height: 34, display: "flex", alignItems: "center", justifyContent: "center" }}>{seasonIcon(s.name, 30)}</div>
+                <span style={{ font: "500 13px Poppins", color: "#6b6b72" }}>{s.name}</span>
+              </div>
+            ))}
+            {closeX}
+          </div>
+        )}
+        {picker === "estilo" && (
+          <div style={{ ...popover, justifyContent: "space-around" }}>
+            {estiloOpts.map((s) => (
+              <div key={s.name} onClick={() => { saveField({ estilo: s.name }); setPicker(null); }} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 9, cursor: "pointer", minWidth: 72 }}>
+                <div style={{ height: 34, display: "flex", alignItems: "center", justifyContent: "center" }}>{estiloIcon(s.name, 30)}</div>
+                <span style={{ font: "500 13px Poppins", color: "#6b6b72" }}>{s.name}</span>
+              </div>
+            ))}
+            {closeX}
+          </div>
+        )}
+        {picker === "tematica" && (
+          <div style={{ ...popover, display: "block", padding: "22px 30px 24px" }}>
+            <div style={{ font: "600 13px Poppins", color: "#EF5B94", marginBottom: 10 }}>Temática del evento</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <input value={tematicaDraft} onChange={(e) => setTematicaDraft(e.target.value)} placeholder="Escribe la temática de tu evento…" style={{ flex: 1, border: "1.5px solid #E7E7EA", borderRadius: 10, padding: "11px 15px", font: "500 13px Poppins", color: "#3A3A42", outline: "none" }} />
+              <button onClick={() => { saveField({ tematica: tematicaDraft.trim() }); setPicker(null); }} style={{ flex: "none", display: "flex", alignItems: "center", justifyContent: "center", gap: 7, padding: "11px 20px", height: 44, background: "#EF5B94", borderRadius: 10, color: "#fff", font: "600 13px Poppins", border: "none", cursor: "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={2.6} strokeLinecap="round" strokeLinejoin="round"><path d="M5 12l5 5L20 7" /></svg>Guardar</button>
+            </div>
+            {closeX}
+          </div>
+        )}
+
       </div>
+
+      {/* MODAL EDITAR EVENTO */}
+      {editOpen && (
+        <div onClick={() => setEditOpen(false)} style={{ position: "fixed", inset: 0, background: "rgba(43,43,48,.45)", zIndex: 60, display: "flex", alignItems: "center", justifyContent: "center", padding: 20 }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ width: 460, maxWidth: "100%", background: "#fff", borderRadius: 18, boxShadow: "0 30px 70px rgba(0,0,0,.3)", padding: "24px 26px", animation: "fadein .2s ease" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
+              <div style={{ font: "700 17px Poppins", color: "#3A3A42" }}>Editar evento</div>
+              <button onClick={() => setEditOpen(false)} style={{ width: 28, height: 28, borderRadius: 8, color: "#a0a0a8", fontSize: 17, background: "none", border: "none", cursor: "pointer" }}>✕</button>
+            </div>
+            <div style={{ font: "600 13px Poppins", color: "#EF5B94", marginBottom: 8 }}>Nombre del evento</div>
+            <input value={editName} onChange={(e) => setEditName(e.target.value)} style={{ width: "100%", border: "1.5px solid #E7E7EA", borderRadius: 10, padding: "11px 15px", font: "500 13px Poppins", color: "#3A3A42", outline: "none", marginBottom: 16 }} />
+            <div style={{ font: "600 13px Poppins", color: "#EF5B94", marginBottom: 8 }}>Fecha del evento</div>
+            <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} style={{ width: "100%", border: "1.5px solid #E7E7EA", borderRadius: 10, padding: "11px 15px", font: "500 13px Poppins", color: "#3A3A42", outline: "none", marginBottom: 20 }} />
+            <div style={{ display: "flex", gap: 10 }}>
+              <button onClick={() => setEditOpen(false)} style={{ flex: "none", padding: "12px 20px", borderRadius: 10, background: "#f7f7f9", color: "#6b6b72", font: "600 13px Poppins", border: "none", cursor: "pointer" }}>Cancelar</button>
+              <button onClick={async () => { const patch: any = { nombre: editName.trim() }; if (editDate) patch.fecha = new Date(`${editDate}T12:00:00`).getTime(); await saveField(patch); setEditOpen(false); }} style={{ flex: 1, padding: 12, borderRadius: 10, background: "#EF5B94", color: "#fff", font: "600 13px Poppins", border: "none", cursor: "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)" }}>Guardar</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/appEventos/components/Resumen/ResumenStudio.tsx
+++ b/apps/appEventos/components/Resumen/ResumenStudio.tsx
@@ -24,6 +24,23 @@ export const ResumenStudio: FC = () => {
   const [editOpen, setEditOpen] = useState(false);
   const [editName, setEditName] = useState("");
   const [editDate, setEditDate] = useState("");
+  // Checklist "Toca para completar" — arranca reflejando el estado real del evento;
+  // al tocar alterna (mueve la barra de progreso). Toggle local (no persiste).
+  const [stepsDone, setStepsDone] = useState<boolean[]>(() => {
+    const iv: any[] = event?.invitados_array || [];
+    const seatedN = iv.filter((x) => x?.nombre_mesa && String(x.nombre_mesa).toLowerCase() !== "no asignado").length;
+    const est = Number(event?.presupuesto_objeto?.coste_estimado || 0);
+    const gas = Number(event?.presupuesto_objeto?.coste_final || 0);
+    const sent = iv.filter((x) => !!x?.invitacion).length;
+    return [
+      !!(event?.nombre && event?.fecha),
+      iv.length > 0,
+      est > 0 || gas > 0,
+      seatedN > 0,
+      sent > 0,
+      (event?.itinerarios_array?.length || 0) > 0,
+    ];
+  });
 
   // Persistencia de aspectos/evento — mismo patrón que BlockSobreMiEvento (eventUpdate)
   const saveField = async (patch: Record<string, any>) => {
@@ -67,19 +84,13 @@ export const ResumenStudio: FC = () => {
   const dias = fechaValida ? Math.max(0, Math.ceil((fechaObj!.getTime() - Date.now()) / 86400000)) : null;
   const tipoTxt = event?.tipo ? event.tipo.charAt(0).toUpperCase() + event.tipo.slice(1).toLowerCase() : "Evento";
 
-  // Checklist derivado del estado real del evento
-  const steps: { title: string; done: boolean; to: string | null }[] = [
-    { title: "Datos del evento", done: !!(event?.nombre && event?.fecha), to: null },
-    { title: "Lista de invitados", done: total > 0, to: "/invitados" },
-    { title: "Presupuesto", done: estimado > 0 || gastado > 0, to: "/presupuesto" },
-    { title: "Plano de mesas", done: seated > 0, to: "/mesas" },
-    { title: "Enviar invitaciones", done: enviadas > 0, to: "/invitaciones" },
-    { title: "Crear itinerario", done: (event?.itinerarios_array?.length || 0) > 0, to: "/itinerario" },
-  ];
-  const doneN = steps.filter((s) => s.done).length;
-  const totalSteps = steps.length;
+  // Checklist "Toca para completar" — usa el estado toggleable stepsDone (mueve la barra)
+  const stepTitles = ["Datos del evento", "Lista de invitados", "Presupuesto", "Plano de mesas", "Enviar invitaciones", "Crear itinerario"];
+  const steps = stepTitles.map((title, i) => ({ title, done: !!stepsDone[i] }));
+  const doneN = stepsDone.filter(Boolean).length;
+  const totalSteps = stepTitles.length;
   const pct = Math.round((doneN / totalSteps) * 100);
-  const firstPending = steps.findIndex((s) => !s.done);
+  const firstPending = stepsDone.findIndex((v) => !v);
   const estadoMsg = pct === 0 ? "¡Empieza tu evento!" : pct < 50 ? "¡Vamos comenzando!" : pct < 100 ? "¡Vas por buen camino!" : "¡A celebrar!";
   const ticks = [1, 2, 3, 4, 5].map((k) => ({ left: `${((k / totalSteps) * 100).toFixed(1)}%`, on: (k / totalSteps) * 100 <= pct }));
 
@@ -246,7 +257,7 @@ export const ResumenStudio: FC = () => {
               const bg = s.done ? "#f4f4f6" : active ? "#FDEEF4" : "#faf9fb";
               const border = s.done ? "#e4e4e8" : active ? "#EF5B94" : "#f0f0f2";
               return (
-                <div key={i} onClick={() => s.to && router.push(s.to)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 10px", borderRadius: 10, background: bg, border: `1.5px ${active ? "dashed" : "solid"} ${border}`, boxShadow: active ? "0 3px 12px rgba(239,91,148,.22)" : "none", cursor: s.to ? "pointer" : "default" }}>
+                <div key={i} onClick={() => setStepsDone((prev) => prev.map((v, idx) => (idx === i ? !v : v)))} style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 10px", borderRadius: 10, background: bg, border: `1.5px ${active ? "dashed" : "solid"} ${border}`, boxShadow: active ? "0 3px 12px rgba(239,91,148,.22)" : "none", cursor: "pointer" }}>
                   <div style={{ width: 20, height: 20, borderRadius: "50%", background: dotBg, display: "flex", alignItems: "center", justifyContent: "center", color: dotFg, font: "700 10px Poppins", flex: "none" }}>
                     {s.done ? <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth={3.5} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg> : i + 1}
                   </div>

--- a/apps/appEventos/components/Servicios/Utils/PermissionIndicator.tsx
+++ b/apps/appEventos/components/Servicios/Utils/PermissionIndicator.tsx
@@ -1,67 +1,51 @@
-import { FC } from "react"
+import { FC, ReactNode } from "react"
 import { useAllowed, useAllowedRouter } from "../../../hooks/useAllowed"
 import { AuthContextProvider, EventContextProvider } from "../../../context"
 import { useTranslation } from "react-i18next"
-import { useRouter, usePathname } from "next/navigation"
+import { usePathname } from "next/navigation"
 import { MdOutlineEdit, MdSecurity } from "react-icons/md"
 import { IoEyeOutline } from "react-icons/io5"
 import { FaCrown } from "react-icons/fa"
+
+/**
+ * Badge de rol del usuario en el evento — estilo píldora del diseño
+ * "Barra holder nueva" (Propietario dorado). Los 4 estados (Propietario /
+ * Ver y editar / Solo ver / Sin acceso) comparten la misma geometría.
+ */
+const Pill: FC<{ bg: string; color: string; icon: ReactNode; label: string }> = ({ bg, color, icon, label }) => (
+  <span style={{ display: "inline-flex", alignItems: "center", gap: 6, background: bg, color, font: "600 12px Poppins", padding: "6px 13px", borderRadius: 20, whiteSpace: "nowrap" }}>
+    {icon}{label}
+  </span>
+)
 
 export const PermissionIndicator: FC = () => {
   const { user } = AuthContextProvider()
   const { event } = EventContextProvider()
   const { t } = useTranslation()
-  const router = useRouter()
   const pathname = usePathname()
   const [isAllowed] = useAllowed()
   const [isAllowedRouter] = useAllowedRouter()
 
-  // Si es el dueño del evento
+  // Dueño del evento
   if (event?.usuario_id === user?.uid) {
-    return (
-      <div className="flex items-center space-x-1 px-2 py-1 bg-yellow-50 border border-yellow-200 rounded-md">
-        <FaCrown className="w-3 h-3 text-yellow-600" />
-        <span className="text-xs text-yellow-700 font-medium">{t("Propietario")}</span>
-      </div>
-    )
+    return <Pill bg="#FEF6D8" color="#B8860B" icon={<FaCrown style={{ width: 13, height: 13 }} />} label={t("Propietario")} />
   }
 
-  // Obtener permisos para la ruta actual
+  // Permisos para la ruta actual
   const getCurrentPath = () => {
     let path = pathname.split("/")[1].split("-")[0]
     if (path === "lista") path = "regalos"
     return path
   }
-
-  const currentPath = getCurrentPath()
+  getCurrentPath()
   const hasRouterAccess = isAllowedRouter()
   const hasEditAccess = isAllowed()
 
-  // Si no tiene acceso, no mostrar indicador
   if (!hasRouterAccess) {
-    return (
-      <div className="flex items-center space-x-1 px-2 py-1 bg-red-50 border border-red-200 rounded-md">
-        <MdSecurity className="w-3 h-3 text-red-600" />
-        <span className="text-xs text-red-700 font-medium">{t("Sin acceso")}</span>
-      </div>
-    )
+    return <Pill bg="#FBE9E9" color="#D9534F" icon={<MdSecurity style={{ width: 13, height: 13 }} />} label={t("Sin acceso")} />
   }
-
-  // Si tiene permisos de edición
   if (hasEditAccess) {
-    return (
-      <div className="flex items-center space-x-1 px-2 py-1 bg-green-50 border border-green-200 rounded-md">
-        <MdOutlineEdit className="w-3 h-3 text-green-600" />
-        <span className="text-xs text-green-700 font-medium">{t("Ver y editar")}</span>
-      </div>
-    )
+    return <Pill bg="#E4F5EE" color="#2FB37E" icon={<MdOutlineEdit style={{ width: 13, height: 13 }} />} label={t("Ver y editar")} />
   }
-
-  // Solo permisos de vista
-  return (
-    <div className="flex items-center space-x-1 px-2 py-1 bg-blue-50 border border-blue-200 rounded-md">
-      <IoEyeOutline className="w-3 h-3 text-blue-600" />
-      <span className="text-xs text-blue-700 font-medium">{t("Solo ver")}</span>
-    </div>
-  )
+  return <Pill bg="#EAF1F8" color="#5B7DA6" icon={<IoEyeOutline style={{ width: 13, height: 13 }} />} label={t("Solo ver")} />
 }

--- a/apps/appEventos/components/Utils/BlockTitle.tsx
+++ b/apps/appEventos/components/Utils/BlockTitle.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import Head from 'next/head'
 import { AuthContextProvider, EventContextProvider } from '../../context'
 import { defaultImagenes } from '../Home/Card'
 import { ModalAddUserToEvent, UsuariosCompartidos } from './Compartir'
@@ -11,7 +12,15 @@ import { useTranslation } from 'react-i18next'
 import { PermissionIndicator } from '../Servicios/Utils/PermissionIndicator'
 import ClickAwayListener from 'react-click-away-listener'
 
-
+/**
+ * BlockTitle — encabezado estándar de módulo. Rediseño estético fiel al HTML
+ * "Barra holder nueva" (radius 18, sombra suave, título 21px, badge de rol en
+ * píldora, chip de evento a la derecha, botón compartir con hover rosa).
+ * MISMOS datos y función: rol (PermissionIndicator), avatares/compartir
+ * (UsuariosCompartidos + ModalAddUserToEvent), extras por módulo (Drive/Mesas).
+ * La imagen del evento va a tamaño FIJO 40x40 (flex/shrink-0 + overflow) → nunca
+ * estira el header (cierra BUG-CW-N28 sin necesidad de altura fija).
+ */
 export const BlockTitle = ({ title }) => {
   const { t } = useTranslation()
   const { forCms, user } = AuthContextProvider()
@@ -20,89 +29,103 @@ export const BlockTitle = ({ title }) => {
   const [openModalDrive, setOpenModalDrive] = useState(false)
   const [showSeatingLink, setShowSeatingLink] = useState(false)
 
+  const isOwner = event?.usuario_id === user?.uid
+  const canShare = isOwner && user?.displayName !== "guest"
   const seatingUrl = event?._id
     ? `${typeof window !== 'undefined' ? window.location.origin : ''}/buscador-mesa/${event._id}`
     : ''
 
   return (
-    <div className={`w-full h-14 max-h-14 overflow-hidden bg-white rounded-xl shadow-lg ${forCms ? "hidden" : "flex"} items-center justify-between max-w-screen-lg mx-auto`}>
+    <div
+      style={{ background: "#fff", borderRadius: 18, boxShadow: "0 6px 20px rgba(0,0,0,.06)", padding: "16px 24px", fontFamily: "'Poppins',sans-serif" }}
+      className={`w-full ${forCms ? "hidden" : "flex"} items-center justify-between gap-5 max-w-screen-lg mx-auto`}
+    >
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+      </Head>
       <ModalAddUserToEvent openModal={openModal} setOpenModal={setOpenModal} event={event} />
-      <div className='flex md:flex-1 flex-col px-2 md:px-6 font-display'>
-        <div className="flex items-center space-x-2">
-          <span className="text-gray-500 text-[18px] leading-[20px] font-bold">{t(title)}</span>
+
+      {/* IZQUIERDA: título + badge de rol */}
+      <div className="flex flex-col min-w-0">
+        <div className="flex items-center gap-3.5 min-w-0">
+          <span style={{ font: "700 21px Poppins", color: "#4a4a52" }} className="truncate">{t(title)}</span>
           <PermissionIndicator />
         </div>
-        <div className='space-x-1'>
-          <span className='md:hidden capitalize text-primary text-[12px] leading-[12px]'>{event?.tipo}</span>
-          <span className='md:hidden capitalize text-gray-600 text-[12px] leading-[20px] font-medium'>{event?.nombre}</span>
+        {/* móvil: tipo + nombre (no perder info en pantallas chicas) */}
+        <div className="md:hidden mt-0.5 space-x-1">
+          <span style={{ color: "#EF5B94" }} className="capitalize text-[12px] leading-[12px]">{event?.tipo}</span>
+          <span className="capitalize text-gray-600 text-[12px] font-medium">{event?.nombre}</span>
         </div>
       </div>
-      <div className='flex-1 md:flex-none h-[100%] flex flex-row-reverse md:flex-row items-center gap-2 pr-2'>
-        {/* BUG-CW-N28 (informe QA 7ª ronda): h-[90%] sin max-h hacía que la imagen
-            de evento expandiera el contenedor a 402px en /presupuesto (vs 56px en
-            /mesas, donde la imagen cacheada era más pequeña). max-h-[50px] +
-            overflow-hidden en el wrapper aseguran banner SIEMPRE 56px. */}
-        <img
-          src={event?.imgEvento?.i320 ? `/api/proxy-image?url=${encodeURIComponent(`https://api-mcp.eventosorganizador.com/${event.imgEvento.i320}`)}` : defaultImagenes[event?.tipo?.toLowerCase()]}
-          className="h-[90%] max-h-[50px] object-cover object-top rounded-md border-1 border-gray-300 hidden md:block shrink-0"
-          alt={event?.nombre}
-          onError={(e) => { (e.target as HTMLImageElement).src = defaultImagenes[event?.tipo?.toLowerCase()] || defaultImagenes['otro']; }}
-        />
-        <div className='hidden md:flex flex-col font-display font-semibold text-md text-gray-500 px-2 md:pt-2 gap-2 min-w-0 max-w-[120px] lg:max-w-[180px]'>
-          <span className='text-sm translate-y-2 text-primary text-[12px] first-letter:capitalize'>{event?.tipo}</span>
-          <span className='uppercase truncate'>{event?.nombre}</span>
+
+      {/* DERECHA: avatares | divisor | evento | imagen | extras | compartir */}
+      <div className="flex items-center gap-4 shrink-0">
+        {/* avatares (datos reales + panel de permisos) */}
+        <div onClick={() => { isOwner && setOpenModal(!openModal) }} className="flex items-center">
+          <UsuariosCompartidos event={event} />
         </div>
-        <div className='flex items-center gap-1 shrink-0'>
-          <div className='flex items-center h-8'>
-            <div onClick={() => { event?.usuario_id === user?.uid && setOpenModal(!openModal) }} className="flex items-center h-8">
-              <UsuariosCompartidos event={event} />
-            </div>
-            <span
-              className={`flex items-center h-8 transition transform ${event?.usuario_id === user?.uid && user?.displayName !== "guest" ? "hover:scale-110 cursor-pointer text-primary" : "text-gray-300"}`}
-              onClick={() => { event?.usuario_id === user?.uid && user?.displayName !== "guest" && setOpenModal(!openModal) }}
-            >
-              <IoShareSocial className="w-6 h-6" />
-            </span>
+
+        {/* divisor */}
+        <div className="hidden md:block" style={{ width: 1, height: 30, background: "#eee" }} />
+
+        {/* evento (tipo + nombre) */}
+        <div className="hidden md:block text-right" style={{ lineHeight: 1.3 }}>
+          <div style={{ font: "600 10px Poppins", color: "#EF5B94", letterSpacing: ".6px" }} className="uppercase">{event?.tipo}</div>
+          <div style={{ font: "500 14px Poppins", color: "#3A3A42" }} className="uppercase truncate max-w-[120px] lg:max-w-[180px]">{event?.nombre}</div>
+        </div>
+
+        {/* imagen del evento — tamaño FIJO (no estira el header) */}
+        <div className="hidden md:block shrink-0" style={{ width: 40, height: 40, borderRadius: 10, overflow: "hidden", background: "#f2f2f4" }}>
+          <img
+            src={event?.imgEvento?.i320 ? `/api/proxy-image?url=${encodeURIComponent(`https://api-mcp.eventosorganizador.com/${event.imgEvento.i320}`)}` : defaultImagenes[event?.tipo?.toLowerCase()]}
+            alt={event?.nombre}
+            style={{ width: "100%", height: "100%", objectFit: "cover", objectPosition: "top" }}
+            onError={(e) => { (e.target as HTMLImageElement).src = defaultImagenes[event?.tipo?.toLowerCase()] || defaultImagenes['otro']; }}
+          />
+        </div>
+
+        {/* extra Presupuesto: Google Drive (WIP, comportamiento intacto) */}
+        {title === "Presupuesto" && (
+          <div onClick={() => "setOpenModalDrive(!openModalDrive)"} className="flex items-center justify-center cursor-pointer hover:bg-[#FCE7F0] rounded-[10px] transition" style={{ width: 38, height: 38, color: "#EF5B94" }}>
+            <DiGoogleDrive style={{ width: 22, height: 22 }} />
           </div>
-          {
-            title === "Presupuesto" ?
-              <div onClick={() => "setOpenModalDrive(!openModalDrive)"} className='cursor-pointer'>
-                <DiGoogleDrive className='w-[32px] h-[32px] text-primary' />
-              </div> :
-              null
-          }
-          {title === "Mesas y asientos" && event?._id && (
-            <div className='relative'>
-              <button
-                onClick={() => setShowSeatingLink(!showSeatingLink)}
-                title="Compartir buscador de mesa"
-                className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition text-primary"
-              >
-                <MdOutlineChair className="w-5 h-5" />
-              </button>
-              {showSeatingLink && (
-                <ClickAwayListener onClickAway={() => setShowSeatingLink(false)}>
-                  <div className="absolute right-0 top-10 bg-white shadow-lg rounded-lg p-4 w-[300px] z-50 border border-gray-100">
-                    <p className="text-xs text-gray-500 mb-2 font-medium">
-                      Link buscador de mesa para invitados (sin login)
-                    </p>
-                    <CopiarLink link={seatingUrl} />
-                  </div>
-                </ClickAwayListener>
-              )}
-            </div>
-          )}
-        </div>
+        )}
+
+        {/* extra Mesas: link del buscador de mesa */}
+        {title === "Mesas y asientos" && event?._id && (
+          <div className="relative">
+            <button onClick={() => setShowSeatingLink(!showSeatingLink)} title="Compartir buscador de mesa" className="flex items-center justify-center cursor-pointer hover:bg-[#FCE7F0] rounded-[10px] transition" style={{ width: 38, height: 38, color: "#EF5B94" }}>
+              <MdOutlineChair style={{ width: 20, height: 20 }} />
+            </button>
+            {showSeatingLink && (
+              <ClickAwayListener onClickAway={() => setShowSeatingLink(false)}>
+                <div className="absolute right-0 top-12 bg-white shadow-lg rounded-lg p-4 w-[300px] z-50 border border-gray-100">
+                  <p className="text-xs text-gray-500 mb-2 font-medium">Link buscador de mesa para invitados (sin login)</p>
+                  <CopiarLink link={seatingUrl} />
+                </div>
+              </ClickAwayListener>
+            )}
+          </div>
+        )}
+
+        {/* compartir */}
+        <span
+          onClick={() => { canShare && setOpenModal(!openModal) }}
+          className={`flex items-center justify-center rounded-[10px] transition ${canShare ? "cursor-pointer hover:bg-[#FCE7F0]" : ""}`}
+          style={{ width: 38, height: 38, color: canShare ? "#EF5B94" : "#d1d5db" }}
+        >
+          <IoShareSocial style={{ width: 16, height: 16 }} />
+        </span>
       </div>
-      {
-        openModalDrive ?
-          <Modal {...({ openIcon: openModalDrive, setOpenIcon: setOpenModalDrive, classe: "h-max w-[40%] flex items-center justify-center" } as any)}>
-            <div className='my-10 mx-32'>
-              <img alt="Work in progress" src='/WIP.png' />
-            </div>
-          </Modal>
-          : null
-      }
+
+      {openModalDrive ? (
+        <Modal {...({ openIcon: openModalDrive, setOpenIcon: setOpenModalDrive, classe: "h-max w-[40%] flex items-center justify-center" } as any)}>
+          <div className='my-10 mx-32'>
+            <img alt="Work in progress" src='/WIP.png' />
+          </div>
+        </Modal>
+      ) : null}
     </div>
   )
 }

--- a/apps/appEventos/components/Utils/Compartir/UsuariosCompartidos.tsx
+++ b/apps/appEventos/components/Utils/Compartir/UsuariosCompartidos.tsx
@@ -100,14 +100,14 @@ export const UsuariosCompartidos = ({ event }) => {
                     }}
                 >
                     {overflow > 0 && (
-                        <div className="bg-white rounded-full w-7 h-7 flex items-center justify-center text-center border border-gray-300 text-[13px] truncate font-semibold z-10">
+                        <div className="bg-[#f2f2f4] text-[#8a8a90] rounded-full w-8 h-8 flex items-center justify-center text-center border-2 border-white text-[11px] truncate font-bold z-10">
                             +{overflow}
                         </div>
                     )}
                     {visible.map((item, idx) => (
                         <div
                             key={idx}
-                            className={`${idx === 0 && overflow === 0 ? '' : '-ml-2'} bg-gray-300 rounded-full w-7 h-7 flex items-center justify-center border relative`}
+                            className={`${idx === 0 && overflow === 0 ? '' : '-ml-[9px]'} bg-gray-300 rounded-full w-8 h-8 flex items-center justify-center border-2 border-white relative`}
                         >
                             <ImageAvatar user={item} />
                             <div className={`h-2.5 w-2.5 ${getOnlineInfo(item?.onLine).status ? "bg-green" : "bg-none"} absolute rounded-full right-1 -bottom-1`} />
@@ -115,7 +115,7 @@ export const UsuariosCompartidos = ({ event }) => {
                     ))}
                 </button>
             ) : (
-                <div className="bg-gray-300 rounded-full w-7 h-7 flex items-center justify-center border relative">
+                <div className="bg-gray-300 rounded-full w-8 h-8 flex items-center justify-center border-2 border-white relative">
                     <ImageAvatar user={event?.detalles_usuario_id} />
                     <div className={`h-2.5 w-2.5 ${getOnlineInfo(event?.detalles_usuario_id?.onLine).status ? "bg-green" : "bg-none"} absolute rounded-full right-1 -bottom-1`} />
                 </div>

--- a/apps/appEventos/pages/invitaciones.tsx
+++ b/apps/appEventos/pages/invitaciones.tsx
@@ -188,8 +188,10 @@ const Invitaciones = () => {
       )
     }
     if (!event) return <EventLoadingOrError skeletonRows={3} />
-    // Rediseño UI (wizard 2 pasos) detrás de flag ?studio=1 — no altera la vista actual.
-    if (router.query.studio) return <InvitacionesStudio />
+    // Rediseño UI (wizard 2 pasos) = vista POR DEFECTO del módulo (aprobado por owner 9-ago).
+    // Salida de emergencia al módulo clásico con ?studio=legacy (rollback sin build; la vista
+    // antigua sigue en el código, no se borra → no se pierde funcionalidad).
+    if (router.query.studio !== "legacy") return <InvitacionesStudio />
     return (
       <DataTableGroupProvider>
         <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-full top-0 left-4" : "bg-base. w-full pt-2 md:py-0"}>

--- a/apps/appEventos/pages/invitaciones.tsx
+++ b/apps/appEventos/pages/invitaciones.tsx
@@ -16,6 +16,8 @@ import { useEventSyncWithUrl } from "../hooks/useEventSyncWithUrl"
 import { OptionsMenu } from "../components/Invitaciones/OptionsMenu";
 import { EnviadosComponent } from "../components/Invitaciones/EnviadosComponent";
 import { DiseñoComponent } from "../components/Invitaciones/DiseñoComponent";
+import { useRouter } from "next/router";
+import { InvitacionesStudio } from "../components/Invitaciones/InvitacionesStudio";
 import { Test, TitleComponent } from "../components/Invitaciones/Test";
 import { PlantillaTextos } from "../components/Invitaciones/PlantillaTextos";
 import { GoChevronDown } from "react-icons/go";
@@ -37,6 +39,7 @@ const CONFIG_PANEL_STORAGE_KEY = 'app-bodasdehoy-invitaciones-config';
 
 const Invitaciones = () => {
   const { t } = useTranslation();
+  const router = useRouter();
   const { user, verificationDone, forCms } = AuthContextProvider()
   const { event } = EventContextProvider();
   const [hoverRef, isHovered] = useHover();
@@ -185,6 +188,8 @@ const Invitaciones = () => {
       )
     }
     if (!event) return <EventLoadingOrError skeletonRows={3} />
+    // Rediseño UI (wizard 2 pasos) detrás de flag ?studio=1 — no altera la vista actual.
+    if (router.query.studio) return <InvitacionesStudio />
     return (
       <DataTableGroupProvider>
         <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-full top-0 left-4" : "bg-base. w-full pt-2 md:py-0"}>

--- a/apps/appEventos/pages/invitados.tsx
+++ b/apps/appEventos/pages/invitados.tsx
@@ -16,6 +16,7 @@ import { ModuleErrorBoundary } from "../components/ErrorBoundary";
 import FormCrearMenu from "../components/Forms/FormCrearMenu";
 import { useMounted } from "../hooks/useMounted";
 import { BlockTableroInvitados } from "../components/Invitados/BlockTableroInvitados";
+import { InvitadosStudio } from "../components/Invitados/InvitadosStudio";
 import { SelectModeView } from "../components/Utils/SelectModeView";
 import FormAcompañante from "../components/Forms/FormAcompañante";
 
@@ -101,6 +102,8 @@ const Invitados: FC = () => {
       )
     }
     if (!event) return <EventLoadingOrError skeletonRows={8} />
+    // Rediseño de la tabla de Invitados (Prototipo tablas v2) detrás de ?studio=1 — no altera la vista actual.
+    if (searchParams.get("studio")) return <InvitadosStudio />
     return (
       <>
         {shouldRenderChild && (

--- a/apps/appEventos/pages/invitados.tsx
+++ b/apps/appEventos/pages/invitados.tsx
@@ -102,8 +102,9 @@ const Invitados: FC = () => {
       )
     }
     if (!event) return <EventLoadingOrError skeletonRows={8} />
-    // Rediseño de la tabla de Invitados (Prototipo tablas v2) detrás de ?studio=1 — no altera la vista actual.
-    if (searchParams.get("studio")) return <InvitadosStudio />
+    // Rediseño de la tabla de Invitados (Prototipo tablas v2) = vista POR DEFECTO (aprobado por owner).
+    // Salida de emergencia a la tabla clásica con ?studio=legacy (rollback sin build; no se borra).
+    if (searchParams.get("studio") !== "legacy") return <InvitadosStudio />
     return (
       <>
         {shouldRenderChild && (

--- a/apps/appEventos/pages/resumen-evento.tsx
+++ b/apps/appEventos/pages/resumen-evento.tsx
@@ -18,13 +18,18 @@ import { BlockMomentos } from "../components/Resumen/BlockMomentos";
 import { ModuleErrorBoundary } from "../components/ErrorBoundary";
 import CopilotFilterBar from "../components/Utils/CopilotFilterBar";
 import { EntityNotesSection } from "../components/Notes/EntityNotesSection";
+import { useRouter } from "next/router";
+import { ResumenStudio } from "../components/Resumen/ResumenStudio";
 
 const Resumen = () => {
   const { event } = EventContextProvider()
+  const router = useRouter()
   useMounted()
   useEventSyncWithUrl()  // BUG-12: sincronizar event activo con ?event= de URL
 
   if (!event) return <EventLoadingOrError skeletonRows={6} />
+  // Rediseño de Resumen (Resumen.dc.html) detrás de ?studio=1 — no altera la vista actual.
+  if (router.query.studio) return <ResumenStudio />
   return (
     <>
       <section className="bg-base w-full md:py-10 px-2 md:px-0">

--- a/apps/appEventos/pages/resumen-evento.tsx
+++ b/apps/appEventos/pages/resumen-evento.tsx
@@ -28,8 +28,10 @@ const Resumen = () => {
   useEventSyncWithUrl()  // BUG-12: sincronizar event activo con ?event= de URL
 
   if (!event) return <EventLoadingOrError skeletonRows={6} />
-  // Rediseño de Resumen (Resumen.dc.html) detrás de ?studio=1 — no altera la vista actual.
-  if (router.query.studio) return <ResumenStudio />
+  // Rediseño de Resumen (Resumen.dc.html) = vista POR DEFECTO (aprobado por owner).
+  // Salida de emergencia al resumen clásico con ?studio=legacy (rollback sin build; los
+  // bloques antiguos siguen en el código, no se borran → no se pierde funcionalidad).
+  if (router.query.studio !== "legacy") return <ResumenStudio />
   return (
     <>
       <section className="bg-base w-full md:py-10 px-2 md:px-0">


### PR DESCRIPTION
Rediseño estético de 4 áreas de appEventos, **fiel a los HTML** entregados por el owner y con el **MISMO backend** (sin cambios de lógica). Todo aprobado por el owner y live por defecto en app-dev.

## Incluye
- **Invitaciones** — `InvitacionesStudio` (wizard Diseñar/Enviar). Mismo backend (update/createEmailTemplate, sendComunications). "Programar" deshabilitado.
- **Encabezado estándar de módulo** — `BlockTitle` rediseñado (aplica a los 8 módulos) + `PermissionIndicator` (píldora de rol) + avatares 32px.
- **Resumen** (`/resumen-evento`) — `ResumenStudio` (hero+cuenta atrás, checklist toggleable, alertas, presupuesto/invitados, mesas/regalos, momentos, sobre mi evento con aspectos vía eventUpdate, notas internas). Símbolo de moneda €.
- **Invitados** (`/invitados`) — `InvitadosStudio` (tabla agrupada, asistencia/menú inline vía editGuests, avatares por sexo, formularios reusados, compartir invitado, borrar grupo, exportar PDF).

## Notas
- Cada módulo tiene **rollback** a la vista clásica con `?studio=legacy` (el código antiguo no se borra).
- Sin cambios de backend. Piezas de backend nuevas señaladas y NO incluidas: renombrar grupo, importación de invitados (Excel/CSV), directorio de venues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)