### PR TITLE
feat(header): rediseño del encabezado + modales (perfil, notificaciones) por defecto

### DIFF
--- a/apps/appEventos/components/ChatSidebar/ChatToggleButton.tsx
+++ b/apps/appEventos/components/ChatSidebar/ChatToggleButton.tsx
@@ -10,10 +10,29 @@ import { IoChatbubbleEllipsesOutline, IoChatbubbleEllipses } from 'react-icons/i
 
 interface ChatToggleButtonProps {
   className?: string;
+  studio?: boolean;
 }
 
-const ChatToggleButton: FC<ChatToggleButtonProps> = ({ className = '' }) => {
+const ChatToggleButton: FC<ChatToggleButtonProps> = ({ className = '', studio = false }) => {
   const { isOpen, toggleSidebar } = useChatSidebar();
+
+  // Variante "studio" — píldora rosa fiel al HTML (Mis eventos.dc.html). Misma lógica (toggle).
+  if (studio) {
+    return (
+      <button
+        type="button"
+        data-testid="copilot-toggle"
+        aria-label={isOpen ? 'Cerrar Copilot' : 'Abrir Copilot'}
+        onClick={toggleSidebar}
+        title={isOpen ? 'Cerrar Copilot (⌘⇧C)' : 'Abrir Copilot (⌘⇧C)'}
+        style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#FDF1F6', borderRadius: 22, padding: '10px 18px', border: 'none', cursor: 'pointer' }}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="#EF5B94"><path d="M12 3l1.7 4.6L18 9l-4.3 1.4L12 15l-1.7-4.6L6 9l4.3-1.4L12 3z" /><path d="M18.5 14l.9 2.3 2.3.9-2.3.9-.9 2.3-.9-2.3-2.3-.9 2.3-.9.9-2.3z" opacity=".6" /></svg>
+        <span style={{ font: '600 13px Poppins', color: '#EF5B94' }}>Copilot</span>
+        <span style={{ width: 7, height: 7, borderRadius: '50%', background: isOpen ? '#EF5B94' : '#2FB37E' }} />
+      </button>
+    );
+  }
 
   return (
     <button

--- a/apps/appEventos/components/DefaultLayout/Navigation.tsx
+++ b/apps/appEventos/components/DefaultLayout/Navigation.tsx
@@ -184,7 +184,9 @@ const Navigation: FC = () => {
   // Flag global del rediseño de header (Mis eventos.dc.html): header nuevo solo con ?studio,
   // el actual por defecto. ?studio=legacy mantiene el clásico (coherente con los módulos).
   const studioParam = searchParams?.get("studio");
-  const studioHeader = !!studioParam && studioParam !== "legacy";
+  // Encabezado rediseñado = vista POR DEFECTO en todas las pantallas (aprobado por owner).
+  // Rollback a la barra clásica con ?studio=legacy.
+  const studioHeader = studioParam !== "legacy";
   const handleLogoClick = () => {
     const path = config?.pathDomain || '/';
     const isExternal = path.startsWith('http://') || path.startsWith('https://');

--- a/apps/appEventos/components/DefaultLayout/Navigation.tsx
+++ b/apps/appEventos/components/DefaultLayout/Navigation.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useEffect, useState, FC, useRef, cloneElement, isValidElement } from "react";
 import type { ImgHTMLAttributes, ReactElement } from "react";
-import { useRouter, usePathname } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { AuthContextProvider, EventContextProvider, EventsGroupContextProvider } from "../../context";
 import { Banner, IconLightBulb16, InvitacionesIcon, InvitadosIcon, ListaRegalosIcon, MesasIcon, MisEventosIcon, PresupuestoIcon, ResumenIcon } from "../icons";
 import { useToast } from "../../hooks/useToast";
@@ -24,6 +24,7 @@ const Navigation: FC = () => {
   const toast = useToast();
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [showSidebar, setShowSidebar] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [logoError, setLogoError] = useState(false);
@@ -180,6 +181,24 @@ const Navigation: FC = () => {
   }, []);
 
 
+  // Flag global del rediseño de header (Mis eventos.dc.html): header nuevo solo con ?studio,
+  // el actual por defecto. ?studio=legacy mantiene el clásico (coherente con los módulos).
+  const studioParam = searchParams?.get("studio");
+  const studioHeader = !!studioParam && studioParam !== "legacy";
+  const handleLogoClick = () => {
+    const path = config?.pathDomain || '/';
+    const isExternal = path.startsWith('http://') || path.startsWith('https://');
+    if (isExternal) {
+      try {
+        const parsed = new URL(path);
+        if (typeof window !== 'undefined' && parsed.origin === window.location.origin) {
+          router.push(parsed.pathname + parsed.search + parsed.hash || '/');
+        } else { router.push('/'); }
+      } catch { router.push('/'); }
+    } else { router.push(path); }
+    setIsActiveStateSwiper(0);
+  };
+
   return (
     <>
       {shouldRenderChild && user?.displayName !== 'guest' && (
@@ -193,6 +212,17 @@ const Navigation: FC = () => {
         className="f-top relative w-full bg-white"
         style={{ paddingLeft: copilotPushPx, transition: 'padding-left 0.2s ease' }}
       >
+        {studioHeader ? (
+          <div style={{ maxWidth: 1100, margin: "0 auto", height: 78, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 24px" }}>
+            <span onClick={handleLogoClick} className="cursor-pointer flex items-center h-[60px] shrink-0 overflow-visible" style={{ maxWidth: 208 }}>
+              {safeLogoNode ?? (<span className="px-3 py-1 rounded-lg bg-primary text-white font-title text-sm max-w-full truncate">{(typeof config?.headTitle === 'string' && config.headTitle.trim()) ? config.headTitle : (typeof config?.name === 'string' && config.name.trim()) ? config.name : 'App'}</span>)}
+            </span>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              {canSeeCopilot && <ChatToggleButton studio />}
+              <Profile studio state={isMounted} set={(act) => setIsMounted(act)} user={user} />
+            </div>
+          </div>
+        ) : (
         <div className="max-w-screen-lg h-16 px-5 lg:px-0 w-full flex justify-between items-center mx-auto inset-x-0  ">
           <span
             onClick={() => {
@@ -244,6 +274,7 @@ const Navigation: FC = () => {
             />
           </div>
         </div>
+        )}
 
         {/* segundo menu superior con las redirecciones funcionales de la app */}
         <div className={`${(urls.includes(url)) ? "hidden" : "block"}`}>

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -316,7 +316,9 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
         <ClickAwayListener onClickAway={() => dropdown && setDropwdon(false)}>
           <div
             data-testid="profile-menu-trigger"
-            className="bg-white items-center pr-2 flex relative cursor-pointer"
+            className={studio
+              ? "relative flex items-center gap-2.5 cursor-pointer rounded-[26px] py-[5px] pl-[5px] pr-3 hover:bg-[#F7F6F8] transition"
+              : "bg-white items-center pr-2 flex relative cursor-pointer"}
             onClick={() => setDropwdon(!dropdown)}>
             {dropdown && (
               <div data-testid="profile-menu-dropdown" className="bg-white rounded-lg w-80 h-max shadow-lg shadow-gray-400 absolute top-0 right-0 translate-y-[46px] translate-x-[20px] md:-translate-x-[0px]  overflow-hidden z-[60] title-display">
@@ -388,12 +390,42 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
                 · Desktop: texto "Iniciar sesión" junto al icono en ≥lg
             */}
             {isAuthenticatedUser ? (
-              <div className="flex items-center gap-2">
+              studio ? (
+                <>
+                  <div className="w-[38px] h-[38px] rounded-full overflow-hidden bg-[#EF5B94] flex-none">
+                    <ImageAvatar user={user} disabledTooltip />
+                  </div>
+                  <div className="hidden md:block" style={{ lineHeight: 1.2 }}>
+                    <div style={{ font: "600 12.5px Poppins", color: "#3A3A42", maxWidth: 150, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{user?.displayName || user?.email}</div>
+                    <div
+                      className="relative flex items-center gap-1 mt-[1px] w-max"
+                      style={{ font: "500 10.5px Poppins", color: "#8a8a90" }}
+                      onClick={(e) => { e.stopPropagation(); setShowFlags(!showFlags); }}
+                    >
+                      <img alt={optionSelect?.title ?? 'idioma'} src={`/flags-svg/${optionSelect?.flag}.svg`.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')} style={{ width: 16, height: 11, objectFit: "cover", borderRadius: 2 }} />
+                      <span>{optionSelect?.value === 'en' ? 'English' : 'Español'}</span>
+                      {showFlags && (
+                        <ClickAwayListener onClickAway={() => setShowFlags(false)}>
+                          <div className="bg-white w-max h-max absolute left-0 top-full mt-1 z-[70] border border-gray-200 rounded-lg flex flex-col shadow-md" onClick={(e) => e.stopPropagation()}>
+                            <ul className="w-full cursor-pointer text-gray-900 text-xs py-1">
+                              {idiomaArray.map((elem, idx) => (
+                                <li key={idx} onClick={(e) => { e.stopPropagation(); setOptionSelect(elem); setShowFlags(false); }} className="flex gap-1.5 items-center hover:bg-gray-100 px-3 py-1.5">
+                                  <img alt={elem.title ?? 'idioma'} src={`/flags-svg/${elem.flag}.svg`.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')} className="object-cover w-5 h-3.5 rounded-[2px]" />
+                                  <span className="text-gray-700">{elem.value === 'en' ? 'English' : 'Español'}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </ClickAwayListener>
+                      )}
+                    </div>
+                  </div>
+                </>
+              ) : (
                 <div className="w-10 h-10">
                   <ImageAvatar user={user} disabledTooltip />
                 </div>
-                {studio && <span className="hidden md:block" style={{ font: "600 12.5px Poppins", color: "#3A3A42", maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{user?.displayName || user?.email}</span>}
-              </div>
+              )
             ) : (
               <div
                 className="h-10 rounded-full bg-primary/10 border border-primary/20 flex items-center justify-center gap-1.5 px-2 lg:px-3 text-primary hover:bg-primary/15 transition"
@@ -404,23 +436,22 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
                 <span className="hidden lg:inline text-sm font-medium whitespace-nowrap">{t("signin")}</span>
               </div>
             )}
-            <ArrowDownBodasIcon className="w-5 h-5 rotate-90 transform text-black" />
+            {studio ? (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#8a8a90" strokeWidth={2.2}><path d="M6 9l6 6 6-6" /></svg>
+            ) : (
+              <ArrowDownBodasIcon className="w-5 h-5 rotate-90 transform text-black" />
+            )}
           </div>
         </ClickAwayListener>
-        <div onClick={() => { setShowFlags(!showFlags) }} className=" flex items-center cursor-pointer" >
-          {studio ? (
-            <div className="flex items-center gap-1.5 -ml-3" style={{ font: "500 11px Poppins", color: "#8a8a90" }}>
-              <span style={{ fontSize: 14, lineHeight: 1 }}>{optionSelect?.value === 'en' ? '\ud83c\uddec\ud83c\udde7' : '\ud83c\uddea\ud83c\uddf8'}</span>
-              <span className="hidden md:flex">{optionSelect?.value === 'en' ? 'English' : 'Espa\u00f1ol'}</span>
-            </div>
-          ) : (
+        {!studio && <div onClick={() => { setShowFlags(!showFlags) }} className=" flex items-center cursor-pointer" >
+          {
             optionSelect?.flag &&
             <div className="space-x-1 flex items-center justify-center text-sm -ml-4">
               <img alt={optionSelect?.title ?? 'idioma'} src={`/flags-svg/${optionSelect?.flag}.svg`.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')} width={22} className="border-[1px] border-gray-500" />
               <span className="hidden md:flex text-gray-600">{optionSelect?.title}</span>
             </div >
-          )}
-          <IoIosArrowDown className={studio ? "text-[#8a8a90]" : "text-gray-500"} />
+          }
+          <IoIosArrowDown className="text-gray-500" />
           {showFlags && <ClickAwayListener onClickAway={() => { setShowFlags(false) }}>
             <div className={`bg-white w-max h-max absolute translate-y-10 z-10 border-[1px] rounded-b-xl flex flex-col right-0 shadow-md`}>
               <ul className="w-full  cursor-pointer text-gray-900 text-xs py-1  ">
@@ -442,7 +473,7 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
             </div>
           </ClickAwayListener>
           }
-        </div>
+        </div>}
       </div>
       {/* Modal ObtenerFullAcceso eliminado — el botón ahora navega a /facturacion directamente */}
     </>

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -57,7 +57,7 @@ const clearDevBypass = () => {
   localStorage.removeItem('appEventos_activeEventId')
 }
 
-const Profile = ({ user, state, set, ...rest }) => {
+const Profile = ({ user, state, set, studio = false, ...rest }) => {
   const { t } = useTranslation()
   const router = useRouter()
   const pathname = usePathname()
@@ -301,7 +301,7 @@ const Profile = ({ user, state, set, ...rest }) => {
           <div className="items-center hidden md:flex gap-1 relative cursor-default">
             <div onClick={() => {
               !event ? toast("error", t("nohaveeventscreated")) : !isAllowedRouter("/servicios") ? ht() : router.push("/servicios")
-            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} bg-slate-100 w-8 h-8 rounded-full flex items-center justify-center hover:bg-primary/10 cursor-pointer transition`} >
+            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} ${studio ? "w-[42px] h-[42px] bg-[#F7F6F8] hover:bg-[#FCE7F0]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
               <GoTasklist className="text-primary w-5 h-5 scale-x-90" />
             </div>
           </div>
@@ -384,8 +384,11 @@ const Profile = ({ user, state, set, ...rest }) => {
                 · Desktop: texto "Iniciar sesión" junto al icono en ≥lg
             */}
             {isAuthenticatedUser ? (
-              <div className="w-10 h-10">
-                <ImageAvatar user={user} disabledTooltip />
+              <div className="flex items-center gap-2">
+                <div className="w-10 h-10">
+                  <ImageAvatar user={user} disabledTooltip />
+                </div>
+                {studio && <span className="hidden md:block" style={{ font: "600 12.5px Poppins", color: "#3A3A42", maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{user?.displayName || user?.email}</span>}
               </div>
             ) : (
               <div

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -402,15 +402,13 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
                       style={{ font: "500 10.5px Poppins", color: "#8a8a90" }}
                       onClick={(e) => { e.stopPropagation(); setShowFlags(!showFlags); }}
                     >
-                      <img alt={optionSelect?.title ?? 'idioma'} src={`/flags-svg/${optionSelect?.flag}.svg`.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')} style={{ width: 16, height: 11, objectFit: "cover", borderRadius: 2 }} />
                       <span>{optionSelect?.value === 'en' ? 'English' : 'Español'}</span>
                       {showFlags && (
                         <ClickAwayListener onClickAway={() => setShowFlags(false)}>
                           <div className="bg-white w-max h-max absolute left-0 top-full mt-1 z-[70] border border-gray-200 rounded-lg flex flex-col shadow-md" onClick={(e) => e.stopPropagation()}>
                             <ul className="w-full cursor-pointer text-gray-900 text-xs py-1">
                               {idiomaArray.map((elem, idx) => (
-                                <li key={idx} onClick={(e) => { e.stopPropagation(); setOptionSelect(elem); setShowFlags(false); }} className="flex gap-1.5 items-center hover:bg-gray-100 px-3 py-1.5">
-                                  <img alt={elem.title ?? 'idioma'} src={`/flags-svg/${elem.flag}.svg`.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')} className="object-cover w-5 h-3.5 rounded-[2px]" />
+                                <li key={idx} onClick={(e) => { e.stopPropagation(); setOptionSelect(elem); setShowFlags(false); }} className="px-4 py-1.5 hover:bg-gray-100">
                                   <span className="text-gray-700">{elem.value === 'en' ? 'English' : 'Español'}</span>
                                 </li>
                               ))}

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -301,13 +301,17 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
           <div className="items-center hidden md:flex gap-1 relative cursor-default">
             <div onClick={() => {
               !event ? toast("error", t("nohaveeventscreated")) : !isAllowedRouter("/servicios") ? ht() : router.push("/servicios")
-            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} ${studio ? "w-[42px] h-[42px] bg-[#F7F6F8] hover:bg-[#FCE7F0]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
-              <GoTasklist className="text-primary w-5 h-5 scale-x-90" />
+            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} ${studio ? "w-[42px] h-[42px] bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
+              {studio ? (
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round"><path d="M4.5 6.5l1 1 2-2M4.5 12l1 1 2-2M4.5 17.5l1 1 2-2" /><path d="M11 6.5h8.5M11 12h8.5M11 17.5h8.5" /></svg>
+              ) : (
+                <GoTasklist className="text-primary w-5 h-5 scale-x-90" />
+              )}
             </div>
           </div>
         }
         {isAuthenticatedUser &&
-          <Notifications />
+          <Notifications studio={studio} />
         }
         <ClickAwayListener onClickAway={() => dropdown && setDropwdon(false)}>
           <div
@@ -404,14 +408,19 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
           </div>
         </ClickAwayListener>
         <div onClick={() => { setShowFlags(!showFlags) }} className=" flex items-center cursor-pointer" >
-          {
+          {studio ? (
+            <div className="flex items-center gap-1.5 -ml-3" style={{ font: "500 11px Poppins", color: "#8a8a90" }}>
+              <span style={{ fontSize: 14, lineHeight: 1 }}>{optionSelect?.value === 'en' ? '\ud83c\uddec\ud83c\udde7' : '\ud83c\uddea\ud83c\uddf8'}</span>
+              <span className="hidden md:flex">{optionSelect?.value === 'en' ? 'English' : 'Espa\u00f1ol'}</span>
+            </div>
+          ) : (
             optionSelect?.flag &&
             <div className="space-x-1 flex items-center justify-center text-sm -ml-4">
               <img alt={optionSelect?.title ?? 'idioma'} src={`/flags-svg/${optionSelect?.flag}.svg`.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')} width={22} className="border-[1px] border-gray-500" />
               <span className="hidden md:flex text-gray-600">{optionSelect?.title}</span>
             </div >
-          }
-          <IoIosArrowDown className="text-gray-500" />
+          )}
+          <IoIosArrowDown className={studio ? "text-[#8a8a90]" : "text-gray-500"} />
           {showFlags && <ClickAwayListener onClickAway={() => { setShowFlags(false) }}>
             <div className={`bg-white w-max h-max absolute translate-y-10 z-10 border-[1px] rounded-b-xl flex flex-col right-0 shadow-md`}>
               <ul className="w-full  cursor-pointer text-gray-900 text-xs py-1  ">

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -320,7 +320,98 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
               ? "relative flex items-center gap-2.5 cursor-pointer rounded-[26px] py-[5px] pl-[5px] pr-3 hover:bg-[#F7F6F8] transition"
               : "bg-white items-center pr-2 flex relative cursor-pointer"}
             onClick={() => setDropwdon(!dropdown)}>
-            {dropdown && (
+            {dropdown && studio && (
+              <div
+                data-testid="profile-menu-dropdown"
+                className="absolute right-0 top-full mt-2.5 z-[60] w-[300px] bg-white rounded-[18px] border border-[#f0f0f2] overflow-hidden"
+                style={{ boxShadow: "0 24px 70px rgba(0,0,0,.16)" }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {/* Cabecera */}
+                <div className="px-6 pt-[22px] pb-[18px] text-center border-b border-[#f4f4f6]">
+                  <div className="relative w-14 h-14 mx-auto mb-2.5">
+                    <div className="w-14 h-14 rounded-full overflow-hidden bg-[#EF5B94]">
+                      {isAuthenticatedUser ? <ImageAvatar user={user} disabledTooltip /> : <div className="w-full h-full flex items-center justify-center"><UserIcon className="w-7 h-7 text-white" /></div>}
+                    </div>
+                    {isAuthenticatedUser && primaryRole && (
+                      <span className="absolute -bottom-0.5 -right-1.5 bg-[#FEF6D8] text-[#B8860B] px-2 py-[3px] rounded-[10px] border-[1.5px] border-white uppercase" style={{ font: "700 8.5px Poppins", letterSpacing: ".6px" }}>{isAdmin ? "ADMIN" : t(primaryRole)}</span>
+                    )}
+                  </div>
+                  <div style={{ font: "700 15px Poppins", color: "#3A3A42" }}>{isAuthenticatedUser ? (user?.displayName || user?.email || "—") : "Invitado"}</div>
+                  {isAuthenticatedUser && <div style={{ font: "400 12px Poppins", color: "#8a8a90" }}>{user?.email || "—"}</div>}
+                </div>
+
+                {/* Opciones */}
+                <div className="p-2.5">
+                  <div onClick={() => { setDropwdon(false); config?.pathPerfil ? router.push(config.pathPerfil) : router.push("/configuracion"); }} className="flex items-center gap-[11px] px-[13px] py-2.5 rounded-[11px] cursor-pointer hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.8} strokeLinecap="round"><circle cx="12" cy="8" r="3.4" /><path d="M5 20c1.2-3.2 3.8-5 7-5s5.8 1.8 7 5" /></svg>
+                    Mi perfil
+                  </div>
+                  <div onClick={() => { setDropwdon(false); router.push("/facturacion"); }} className="flex items-center gap-[11px] px-[13px] py-2.5 rounded-[11px] cursor-pointer hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.8} strokeLinecap="round"><rect x="3" y="6" width="18" height="13" rx="2" /><path d="M3 10h18" /></svg>
+                    Facturación
+                  </div>
+                  {/* Módulos (se conservan todas las acciones existentes) */}
+                  {optionsReduceCenter.map((item: Option, idx) => (
+                    <div key={`c-${idx}`} onClick={(e) => { setDropwdon(false); item.onClick?.(e); }} className="flex items-center gap-[11px] px-[13px] py-2.5 rounded-[11px] cursor-pointer hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
+                      <span className="w-4 h-4 flex items-center justify-center text-[#6b6b72]">{item.icon}</span>
+                      {t(item.title)}
+                    </div>
+                  ))}
+                  {optionsReduceEnd.filter((o: Option) => !["Mi perfil", "Cerrar Sesión"].includes(o.title)).map((item: Option, idx) => (
+                    <div key={`e-${idx}`} onClick={(e) => { setDropwdon(false); item.onClick?.(e); }} className="flex items-center gap-[11px] px-[13px] py-2.5 rounded-[11px] cursor-pointer hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
+                      <span className="w-4 h-4 flex items-center justify-center text-[#6b6b72]">{item.icon}</span>
+                      {t(item.title)}
+                    </div>
+                  ))}
+                  {/* Notificaciones push + toggle */}
+                  {isAuthenticatedUser && (
+                    <div className="flex items-center justify-between px-[13px] py-2.5 rounded-[11px] hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
+                      <div className="flex items-center gap-[11px]">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M18 9a6 6 0 1 0-12 0c0 6-2.5 7-2.5 7h17S18 15 18 9z" /><path d="M10 20a2.2 2.2 0 0 0 4 0" /></svg>
+                        Notificaciones push
+                      </div>
+                      <div
+                        onClick={(e) => { e.stopPropagation(); if (pushPermission !== 'granted') requestPushPermission(); }}
+                        className={`w-9 h-5 rounded-xl relative flex-none transition-colors ${pushPermission === 'granted' ? 'bg-[#2FB37E] cursor-default' : 'bg-[#d4d4da] cursor-pointer'}`}
+                        title={pushPermission === 'granted' ? 'Activadas' : 'Activar'}
+                      >
+                        <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-all ${pushPermission === 'granted' ? 'left-[18px]' : 'left-0.5'}`} style={{ boxShadow: "0 1px 4px rgba(0,0,0,.2)" }} />
+                      </div>
+                    </div>
+                  )}
+                  {/* Idioma */}
+                  <div onClick={(e) => { e.stopPropagation(); setShowFlags(!showFlags); }} className="flex items-center justify-between px-[13px] py-2.5 rounded-[11px] cursor-pointer hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
+                    <div className="flex items-center gap-[11px]">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b6b72" strokeWidth={1.8} strokeLinecap="round"><circle cx="12" cy="12" r="9" /><path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18" /></svg>
+                      Idioma
+                    </div>
+                    <span style={{ font: "500 12px Poppins", color: "#8a8a90" }}>{optionSelect?.value === 'en' ? 'English' : 'Español'} ›</span>
+                  </div>
+                  {showFlags && (
+                    <div className="mx-[13px] mb-1 rounded-[10px] border border-gray-100 overflow-hidden">
+                      {idiomaArray.map((elem, idx) => (
+                        <div key={idx} onClick={(e) => { e.stopPropagation(); setOptionSelect(elem); setShowFlags(false); }} className="px-4 py-2 cursor-pointer hover:bg-gray-100" style={{ font: "500 12px Poppins", color: elem.value === optionSelect?.value ? "#EF5B94" : "#3A3A42" }}>
+                          {elem.value === 'en' ? 'English' : 'Español'}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Footer */}
+                <div className="px-3.5 pt-3 pb-3.5 border-t border-[#f4f4f6] flex flex-col gap-2">
+                  {!!user?.uid && !["guest", "anonymous"].includes(user?.displayName) && (
+                    <button onClick={() => { setDropwdon(false); router.push("/facturacion"); }} className="py-[11px] rounded-[11px] text-white border-none cursor-pointer hover:bg-[#D83E7C]" style={{ background: "#EF5B94", font: "600 12.5px Poppins", boxShadow: "0 6px 16px rgba(239,91,148,.3)" }}>{t("Ver planes")}</button>
+                  )}
+                  <button onClick={(e) => { setDropwdon(false); const f = optionsEnd.find((o: Option) => o.title === "Cerrar Sesión")?.onClick; if (f) f(e); }} className="flex items-center justify-center gap-2 py-2 rounded-[10px] cursor-pointer border-none bg-transparent text-[#8a8a90] hover:bg-[#f5f5f7] hover:text-[#D83E7C]" style={{ font: "500 12.5px Poppins" }}>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" /></svg>
+                    Cerrar sesión
+                  </button>
+                </div>
+              </div>
+            )}
+            {dropdown && !studio && (
               <div data-testid="profile-menu-dropdown" className="bg-white rounded-lg w-80 h-max shadow-lg shadow-gray-400 absolute top-0 right-0 translate-y-[46px] translate-x-[20px] md:-translate-x-[0px]  overflow-hidden z-[60] title-display">
                 <div className="w-full border-b border-gray-100 pb-2">
                   <p className="text-gray-500 font-extralight uppercase tracking-wider	text-xs text-center  cursor-default">

--- a/apps/appEventos/components/Notifications.tsx
+++ b/apps/appEventos/components/Notifications.tsx
@@ -288,10 +288,32 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
         {/* Panel */}
         {showPanel && (
           <div
-            className="absolute bg-white rounded-lg w-96 shadow-lg shadow-gray-400 top-0 right-10 translate-x-1/2 translate-y-[46px] overflow-hidden z-[60]"
+            className={studio
+              ? "absolute right-0 top-full mt-3 w-[400px] bg-white rounded-[18px] border border-[#f0f0f2] overflow-hidden z-[60]"
+              : "absolute bg-white rounded-lg w-96 shadow-lg shadow-gray-400 top-0 right-10 translate-x-1/2 translate-y-[46px] overflow-hidden z-[60]"}
+            style={studio ? { boxShadow: "0 24px 70px rgba(0,0,0,.16)" } : undefined}
             onClick={e => e.stopPropagation()}
           >
             {/* Header */}
+            {studio ? (
+              <>
+                <div className="flex items-center gap-[9px] px-[22px] pt-[18px]">
+                  <span style={{ font: "700 15px Poppins", color: "#3A3A42" }}>{t("Notificaciones")}</span>
+                  {api2Total > 0 && <span style={{ background: "#FCE7F0", color: "#D83E7C", font: "700 10.5px Poppins", padding: "3px 9px", borderRadius: 12 }}>{api2Total}</span>}
+                </div>
+                <div className="flex gap-1 px-[22px] pt-[14px] pb-3 border-b border-[#f4f4f6]">
+                  <TabBtn studio active={view === 'legacy'} onClick={() => handleViewChange('legacy')} label={t("Actual")} badge={api2Notifs.length} />
+                  <TabBtn
+                    studio
+                    active={view === 'events-overview' || view === 'event-notifications' || view === 'all-pending'}
+                    onClick={() => handleViewChange('events-overview')}
+                    label={t("Pendientes")}
+                    badge={api2UnreadCount}
+                  />
+                  <TabBtn studio active={view === 'history'} onClick={() => handleViewChange('history')} label={t("Historial")} />
+                </div>
+              </>
+            ) : (
             <div className="border-b-2 border-gray-300 py-2 px-3">
               <div className="flex justify-between items-center mb-2">
                 <span className="text-gray-600 text-sm font-medium">
@@ -317,10 +339,12 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
                 <TabBtn active={view === 'history'} onClick={() => handleViewChange('history')} label={t("Historial")} />
               </div>
             </div>
+            )}
 
             {/* ========== VIEW: ACTUAL (últimas notificaciones via api2) ========== */}
             {view === 'legacy' && (
               <NotifList
+                studio={studio}
                 notifications={api2Notifs}
                 loading={api2Loading}
                 emptyText={t("No hay notificaciones")}
@@ -383,6 +407,7 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
                   </div>
                 </div>
                 <NotifList
+                  studio={studio}
                   notifications={api2Notifs}
                   loading={api2Loading}
                   emptyText={t("No hay notificaciones")}
@@ -434,7 +459,7 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
                     </li>
                   ));
                 })()}
-                {api2TotalPages > 1 && <li><Pagination page={api2Page} total={api2TotalPages} onPageChange={setApi2Page} t={t} /></li>}
+                {api2TotalPages > 1 && <li><Pagination studio={studio} page={api2Page} total={api2TotalPages} onPageChange={setApi2Page} t={t} /></li>}
               </ul>
             )}
           </div>
@@ -448,7 +473,17 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
 // Sub-components
 // ========================================
 
-function TabBtn({ active, onClick, label, badge }: { active: boolean; onClick: () => void; label: string; badge?: number }) {
+function TabBtn({ active, onClick, label, badge, studio }: { active: boolean; onClick: () => void; label: string; badge?: number; studio?: boolean }) {
+  if (studio) {
+    return (
+      <button onClick={onClick} className="flex items-center gap-1.5 rounded-[10px] cursor-pointer" style={{ padding: "8px 16px", font: "600 12px Poppins", background: active ? "#EF5B94" : "#f5f5f7", color: active ? "#fff" : "#6b6b72", border: "none" }}>
+        {label}
+        {!!badge && badge > 0 && (
+          <span style={{ font: "700 9.5px Poppins", padding: "2px 7px", borderRadius: 10, background: active ? "rgba(255,255,255,.25)" : "#e7e7ea", color: active ? "#fff" : "#6b6b72" }}>{badge > 99 ? '99+' : badge}</span>
+        )}
+      </button>
+    );
+  }
   return (
     <button onClick={onClick} className={`px-2 py-1 text-[10px] font-medium rounded transition-colors flex items-center gap-1 ${active ? 'bg-primary text-white' : 'text-gray-400 hover:bg-gray-100'}`}>
       {label}
@@ -459,20 +494,39 @@ function TabBtn({ active, onClick, label, badge }: { active: boolean; onClick: (
   );
 }
 
-function NotifList({ notifications, loading, emptyText, totalPages, page, onPageChange, t, router, onMarkRead }: {
+function NotifList({ notifications, loading, emptyText, totalPages, page, onPageChange, t, router, onMarkRead, studio }: {
   notifications: Api2Notification[]; loading: boolean; emptyText: string;
   totalPages: number; page: number; onPageChange: (p: number) => void;
-  t: (k: string) => string; router: any; onMarkRead?: (id: string) => void;
+  t: (k: string) => string; router: any; onMarkRead?: (id: string) => void; studio?: boolean;
 }) {
   return (
     <div>
-      <ul className="max-h-[340px] overflow-y-auto">
+      <ul className="overflow-y-auto" style={studio ? { maxHeight: 380, padding: "8px 10px" } : { maxHeight: 340 }}>
         {loading ? (
-          <li className="py-8 text-center text-gray-400 text-xs">{t("cargando")}...</li>
+          <li className={`py-8 text-center text-xs ${studio ? 'text-[#a0a0a8]' : 'text-gray-400'}`}>{t("cargando")}...</li>
         ) : notifications.length === 0 ? (
-          <li className="py-8 text-center text-gray-400 text-xs">{emptyText}</li>
+          <li className={`py-8 text-center text-xs ${studio ? 'text-[#a0a0a8]' : 'text-gray-400'}`}>{emptyText}</li>
         ) : notifications.map(n => {
           const eventName = n.resourceName || extractEventName(n.message);
+          if (studio) {
+            return (
+              <li key={n.id} className="flex items-start gap-3 p-3 rounded-xl cursor-pointer hover:bg-[#fdf7fa]"
+                  onClick={() => { if (!n.read && onMarkRead) onMarkRead(n.id); }}>
+                <div className="flex items-center justify-center flex-none mt-0.5" style={{ width: 34, height: 34, borderRadius: 11, background: "#FCE7F0", color: "#EF5B94" }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M21 12a8 8 0 0 1-8 8H4l2-3a8 8 0 1 1 15-5z" /></svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div style={{ font: "400 12.5px/1.55 Poppins", color: "#6b6b72", overflow: "hidden", display: "-webkit-box", WebkitLineClamp: 3, WebkitBoxOrient: "vertical" } as any}>
+                    <Interweave content={n.message} />
+                  </div>
+                  <div style={{ font: "400 11px Poppins", color: "#a0a0a8", marginTop: 4 }}>
+                    <RelativeTime date={new Date(n.createdAt).getTime()} />
+                  </div>
+                </div>
+                {!n.read && <span className="flex-none mt-1.5" style={{ width: 9, height: 9, borderRadius: "50%", background: "#2FB37E" }} />}
+              </li>
+            );
+          }
           return (
             <li key={n.id} className="flex gap-2 px-4 py-2.5 hover:bg-base border-b border-gray-50 cursor-pointer"
                 onClick={() => { if (!n.read && onMarkRead) onMarkRead(n.id); }}>
@@ -487,12 +541,21 @@ function NotifList({ notifications, loading, emptyText, totalPages, page, onPage
           );
         })}
       </ul>
-      {totalPages > 1 && <Pagination page={page} total={totalPages} onPageChange={onPageChange} t={t} />}
+      {totalPages > 1 && <Pagination studio={studio} page={page} total={totalPages} onPageChange={onPageChange} t={t} />}
     </div>
   );
 }
 
-function Pagination({ page, total, onPageChange, t }: { page: number; total: number; onPageChange: (p: number) => void; t: (k: string) => string }) {
+function Pagination({ page, total, onPageChange, t, studio }: { page: number; total: number; onPageChange: (p: number) => void; t: (k: string) => string; studio?: boolean }) {
+  if (studio) {
+    return (
+      <div className="flex justify-between items-center px-[22px] py-3 border-t border-[#f4f4f6]">
+        <button onClick={() => onPageChange(Math.max(1, page - 1))} disabled={page <= 1} style={{ font: "600 12px Poppins", color: page <= 1 ? "#c4c4cc" : "#EF5B94", background: "none", border: "none", cursor: page <= 1 ? "default" : "pointer" }}>← {t("Anterior")}</button>
+        <span style={{ font: "500 12px Poppins", color: "#8a8a90" }}>{page}/{total}</span>
+        <button onClick={() => onPageChange(Math.min(total, page + 1))} disabled={page >= total} style={{ font: "600 12px Poppins", color: page >= total ? "#c4c4cc" : "#EF5B94", background: "none", border: "none", cursor: page >= total ? "default" : "pointer" }}>{t("Siguiente")} →</button>
+      </div>
+    );
+  }
   return (
     <div className="flex justify-between items-center px-4 py-2 border-t bg-gray-50">
       <button onClick={() => onPageChange(Math.max(1, page - 1))} disabled={page <= 1} className="text-[10px] text-gray-500 disabled:opacity-30">← {t("Anterior")}</button>

--- a/apps/appEventos/components/Notifications.tsx
+++ b/apps/appEventos/components/Notifications.tsx
@@ -294,6 +294,7 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
             style={studio ? { boxShadow: "0 24px 70px rgba(0,0,0,.16)" } : undefined}
             onClick={e => e.stopPropagation()}
           >
+            {studio && <style dangerouslySetInnerHTML={{ __html: ".nf-noscroll{scrollbar-width:none;-ms-overflow-style:none;}.nf-noscroll::-webkit-scrollbar{display:none;width:0;height:0;}" }} />}
             {/* Header */}
             {studio ? (
               <>
@@ -359,7 +360,7 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
 
             {/* ========== VIEW: EVENTS OVERVIEW (sin evento seleccionado) ========== */}
             {view === 'events-overview' && (
-              <div className="max-h-[400px] overflow-y-auto">
+              <div className={`max-h-[400px] overflow-y-auto ${studio ? 'nf-noscroll' : ''}`}>
                 {/* Ver todas button */}
                 <button onClick={handleShowAll} className="w-full text-left px-4 py-2.5 text-xs font-medium text-primary hover:bg-pink-50 border-b border-gray-100 flex justify-between items-center">
                   <span>📋 {t("Ver todas las pendientes")}</span>
@@ -422,7 +423,7 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
 
             {/* ========== VIEW: HISTORY (grouped by event) ========== */}
             {view === 'history' && (
-              <ul className="max-h-[400px] overflow-y-auto">
+              <ul className={`max-h-[400px] overflow-y-auto ${studio ? 'nf-noscroll' : ''}`}>
                 {api2Loading ? (
                   <li className="py-8 text-center text-gray-400 text-xs">{t("cargando")}...</li>
                 ) : api2Notifs.length === 0 ? (
@@ -501,7 +502,7 @@ function NotifList({ notifications, loading, emptyText, totalPages, page, onPage
 }) {
   return (
     <div>
-      <ul className="overflow-y-auto" style={studio ? { maxHeight: 380, padding: "8px 10px" } : { maxHeight: 340 }}>
+      <ul className={studio ? "overflow-y-auto nf-noscroll" : "overflow-y-auto"} style={studio ? { maxHeight: 380, padding: "8px 10px" } : { maxHeight: 340 }}>
         {loading ? (
           <li className={`py-8 text-center text-xs ${studio ? 'text-[#a0a0a8]' : 'text-gray-400'}`}>{t("cargando")}...</li>
         ) : notifications.length === 0 ? (

--- a/apps/appEventos/components/Notifications.tsx
+++ b/apps/appEventos/components/Notifications.tsx
@@ -66,7 +66,7 @@ function extractEventName(message: string): string | null {
 // Component
 // ========================================
 
-export const Notifications = () => {
+export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => {
   const { t } = useTranslation()
   const { event: selectedEvent } = EventContextProvider()
   const { eventsGroup } = EventsGroupContextProvider();
@@ -262,13 +262,26 @@ export const Notifications = () => {
           aria-label={api2UnreadCount > 0 ? `Notificaciones, ${api2UnreadCount} sin leer` : "Notificaciones"}
           aria-expanded={showPanel}
           aria-haspopup="dialog"
-          className="bg-slate-100 w-10 h-10 rounded-full flex items-center justify-center hover:bg-zinc-200 cursor-pointer border-0 p-0 relative"
+          title={studio ? "Notificaciones" : undefined}
+          className={studio
+            ? "w-[42px] h-[42px] rounded-full flex items-center justify-center cursor-pointer border-0 p-0 relative bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94] transition"
+            : "bg-slate-100 w-10 h-10 rounded-full flex items-center justify-center hover:bg-zinc-200 cursor-pointer border-0 p-0 relative"}
         >
-          <RiNotification2Fill className="text-primary w-6 h-6 scale-x-90" />
+          {studio ? (
+            <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round" strokeLinejoin="round"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.7 21a2 2 0 0 1-3.4 0" /></svg>
+          ) : (
+            <RiNotification2Fill className="text-primary w-6 h-6 scale-x-90" />
+          )}
           {api2UnreadCount > 0 && (
-            <span className="absolute -top-2 -right-2 min-w-[24px] h-[24px] rounded-full bg-red-600 flex items-center justify-center shadow-md">
-              <span className="text-white text-[11px] font-bold leading-none">{api2UnreadCount > 99 ? '99+' : api2UnreadCount}</span>
-            </span>
+            studio ? (
+              <span className="absolute flex items-center justify-center" style={{ top: -3, right: -3, minWidth: 18, height: 18, borderRadius: 10, background: "#EF5B94", color: "#fff", font: "700 9.5px Poppins", padding: "0 4px", border: "2px solid #fff" }}>
+                {api2UnreadCount > 9 ? '9+' : api2UnreadCount}
+              </span>
+            ) : (
+              <span className="absolute -top-2 -right-2 min-w-[24px] h-[24px] rounded-full bg-red-600 flex items-center justify-center shadow-md">
+                <span className="text-white text-[11px] font-bold leading-none">{api2UnreadCount > 99 ? '99+' : api2UnreadCount}</span>
+              </span>
+            )
           )}
         </button>
 


### PR DESCRIPTION
## Rediseño del encabezado de appEventos (fiel al HTML), por defecto en todas las pantallas

Solo front/CSS — **mismo backend**, sin cambios de datos. Multi-tenant respetado (logo whitelabel intacto).

### Incluye
- **Barra 78px** (logo whitelabel + píldora Copilot + Tareas + Notificaciones + menú de cuenta).
- **Iconos exactos del HTML**: Tareas (checklist), Notificaciones (campana + badge), sin banderas en idioma (solo texto, por decisión del owner — el emoji se renderiza como "ES" en algunos SO).
- **Bloque usuario+idioma** en una sola píldora (avatar 38px + nombre/idioma apilados + chevron único).
- **Modal de cuenta** fiel al HTML (avatar 56px + badge rol + opciones + toggle push real + idioma + Ver planes + Cerrar sesión). Conserva TODAS las acciones (REGLA 0).
- **Panel de notificaciones** fiel al HTML (400px, tabs píldora Actual/Pendientes/Historial con contadores, items con icono rosa + punto verde, paginación). Reusa datos y lógica existentes.
- **Scroll invisible** en el panel.

### Activación
- Por defecto en **todas las pantallas** (Navigation es el header global).
- Rollback a la barra clásica con `?studio=legacy`.

### Verificación
- `tsc --noEmit` limpio en los archivos tocados.
- Build OK y verificado en app-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)