### PR TITLE
feat(nav): barra de módulos rediseñada + cabecera fija + fixes header

### DIFF
--- a/apps/appEventos/components/ChatSidebar/ChatToggleButton.tsx
+++ b/apps/appEventos/components/ChatSidebar/ChatToggleButton.tsx
@@ -25,7 +25,7 @@ const ChatToggleButton: FC<ChatToggleButtonProps> = ({ className = '', studio = 
         aria-label={isOpen ? 'Cerrar Copilot' : 'Abrir Copilot'}
         onClick={toggleSidebar}
         title={isOpen ? 'Cerrar Copilot (⌘⇧C)' : 'Abrir Copilot (⌘⇧C)'}
-        style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#FDF1F6', borderRadius: 22, padding: '10px 18px', border: 'none', cursor: 'pointer' }}
+        style={{ display: 'flex', alignItems: 'center', gap: 8, background: '#FDF1F6', borderRadius: 22, padding: '10px 18px', border: 'none', cursor: 'pointer', flexShrink: 0, whiteSpace: 'nowrap' }}
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="#EF5B94"><path d="M12 3l1.7 4.6L18 9l-4.3 1.4L12 15l-1.7-4.6L6 9l4.3-1.4L12 3z" /><path d="M18.5 14l.9 2.3 2.3.9-2.3.9-.9 2.3-.9-2.3-2.3-.9 2.3-.9.9-2.3z" opacity=".6" /></svg>
         <span style={{ font: '600 13px Poppins', color: '#EF5B94' }}>Copilot</span>

--- a/apps/appEventos/components/DefaultLayout/Container.tsx
+++ b/apps/appEventos/components/DefaultLayout/Container.tsx
@@ -1,4 +1,4 @@
-import { useRouter, usePathname } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { AuthContextProvider, LoadingContextProvider, useChatSidebar } from "../../context";
 import { EventsGroupContextProvider } from "../../context";
 import NavigationMobile from "./NavigationMobile";
@@ -25,6 +25,11 @@ const Container = (props) => {
   const { forCms } = AuthContextProvider();
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  // Header rediseñado (studio) = ON por defecto (rollback ?studio=legacy). Mide más alto que el
+  // clásico (78px + 74px = 152px vs 144px), así que reservamos ese espacio en desktop para que
+  // la cabecera quede fija arriba y no la arrastre el scroll del contenido.
+  const studioHeader = searchParams?.get("studio") !== "legacy";
   const { setLoading } = LoadingContextProvider();
   const chatSidebar = useChatSidebar();
 
@@ -139,7 +144,7 @@ const Container = (props) => {
       }
 
       <div
-        className={`w-full max-w-full min-w-0 ${pathname === "/" ? "" : "bg-base"} ${isFullHeight ? "h-[100vh]" : urls.includes(pathname) ? "" : forCms ? "h-[100vh]" : "h-[calc(100vh-144px)]"}`}
+        className={`w-full max-w-full min-w-0 ${pathname === "/" ? "" : "bg-base"} ${isFullHeight ? "h-[100vh]" : urls.includes(pathname) ? "" : forCms ? "h-[100vh]" : studioHeader ? "h-[calc(100vh-144px)] md:h-[calc(100vh-152px)]" : "h-[calc(100vh-144px)]"}`}
         style={{
           display: "grid",
           width: "100%",

--- a/apps/appEventos/components/DefaultLayout/Navigation.tsx
+++ b/apps/appEventos/components/DefaultLayout/Navigation.tsx
@@ -15,6 +15,21 @@ import { BsCalendarHeartFill, BsImages } from "react-icons/bs";
 import ChatToggleButton from "../ChatSidebar/ChatToggleButton";
 import { useChatSidebar, CHAT_SIDEBAR_MIN_WIDTH, CHAT_SIDEBAR_MAX_WIDTH, CHAT_SIDEBAR_DEFAULT_WIDTH } from "../../context/ChatSidebarContext";
 
+// Barra de módulos rediseñada (studio) — iconos EXACTOS del HTML "menumodulos".
+// fill=currentColor (color del item); los "huecos" (.mhole) se pintan con --hole (color del fondo).
+const STUDIO_ORDER = ["Mis eventos", "Resumen", "Invitados", "Mesas", "Presupuesto", "Invitaciones", "Itinerario", "Lista de regalos", "Momentos"];
+const STUDIO_ICONS: Record<string, JSX.Element> = {
+  "Mis eventos": (<svg viewBox="0 0 24 24"><path d="M9 2C6.2 2 4 4.4 4 7.4c0 2.9 2 5.3 4.4 5.6l-.6 1.5h2.4L9.6 13C12 12.7 14 10.3 14 7.4 14 4.4 11.8 2 9 2z" /><path opacity={0.55} d="M16.5 5c-1.9 0-3.5 1.7-3.5 3.9 0 2 1.3 3.7 3 4l-.4 1.1h1.8L17 12.9c1.7-.3 3-2 3-4C20 6.7 18.4 5 16.5 5z" /></svg>),
+  "Resumen": (<svg viewBox="0 0 24 24"><path d="M5.5 3A2.5 2.5 0 0 0 3 5.5v4A2.5 2.5 0 0 0 5.5 12h4A2.5 2.5 0 0 0 12 9.5v-4A2.5 2.5 0 0 0 9.5 3h-4z" /><path opacity={0.55} d="M15.5 3A2.5 2.5 0 0 0 13 5.5v2A2.5 2.5 0 0 0 15.5 10h3A2.5 2.5 0 0 0 21 7.5v-2A2.5 2.5 0 0 0 18.5 3h-3z" /><path d="M15.5 11A2.5 2.5 0 0 0 13 13.5v5a2.5 2.5 0 0 0 2.5 2.5h3a2.5 2.5 0 0 0 2.5-2.5v-5a2.5 2.5 0 0 0-2.5-2.5h-3z" /><path opacity={0.55} d="M5.5 13A2.5 2.5 0 0 0 3 15.5v3A2.5 2.5 0 0 0 5.5 21h4a2.5 2.5 0 0 0 2.5-2.5v-3A2.5 2.5 0 0 0 9.5 13h-4z" /></svg>),
+  "Invitados": (<svg viewBox="0 0 24 24"><circle cx="9" cy="8" r="3.6" /><path d="M3 19.2c0-3.3 2.7-5.7 6-5.7s6 2.4 6 5.7c0 .4-.3.8-.8.8H3.8a.8.8 0 0 1-.8-.8z" /><circle opacity={0.55} cx="16.8" cy="9" r="2.8" /><path opacity={0.55} d="M16.4 13.4c2.7.2 4.6 2.3 4.6 5 0 .3-.3.6-.6.6h-3.2c.2-.5.3-1 .3-1.6 0-1.5-.5-2.9-1.1-4z" /></svg>),
+  "Mesas": (<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4.2" /><circle opacity={0.55} cx="12" cy="4.5" r="1.7" /><circle opacity={0.55} cx="12" cy="19.5" r="1.7" /><circle opacity={0.55} cx="4.5" cy="12" r="1.7" /><circle opacity={0.55} cx="19.5" cy="12" r="1.7" /><circle opacity={0.55} cx="6.7" cy="6.7" r="1.5" /><circle opacity={0.55} cx="17.3" cy="6.7" r="1.5" /><circle opacity={0.55} cx="6.7" cy="17.3" r="1.5" /><circle opacity={0.55} cx="17.3" cy="17.3" r="1.5" /></svg>),
+  "Presupuesto": (<svg viewBox="0 0 24 24"><path d="M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h11a2.5 2.5 0 0 0 2.5-2.5v-15A2.5 2.5 0 0 0 17.5 2h-11zM7 5.5h10a1 1 0 0 1 1 1V8a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V6.5a1 1 0 0 1 1-1zM7.5 12a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6zm4.5 0a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6zm4.5 0a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6zm-9 4.5a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6zm4.5 0a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6zm4.5 0a1.3 1.3 0 1 1 0 2.6 1.3 1.3 0 0 1 0-2.6z" /></svg>),
+  "Invitaciones": (<svg viewBox="0 0 24 24"><path d="M3 8.8l8.4-5.2a1.2 1.2 0 0 1 1.2 0L21 8.8V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8.8z" /><path className="mhole" opacity={0.9} d="M12 15.6l-8.7-5.4v-.2L12 15l8.7-5v.2L12 15.6z" /><path className="mhole" d="M12 13.4c-.9-1-2.4-1.6-2.4-3 0-1 .7-1.7 1.5-1.7.4 0 .7.2.9.5.2-.3.5-.5.9-.5.8 0 1.5.7 1.5 1.7 0 1.4-1.5 2-2.4 3z" /></svg>),
+  "Itinerario": (<svg viewBox="0 0 24 24"><path d="M7 2.5a1 1 0 0 1 1 1V5h8V3.5a1 1 0 1 1 2 0V5h.5A2.5 2.5 0 0 1 21 7.5v11A2.5 2.5 0 0 1 18.5 21h-13A2.5 2.5 0 0 1 3 18.5v-11A2.5 2.5 0 0 1 5.5 5H6V3.5a1 1 0 0 1 1-1z" /><path className="mhole" d="M12 17.2c-1.4-1.4-3.6-2.4-3.6-4.4 0-1.4 1-2.4 2.2-2.4.6 0 1.1.3 1.4.8.3-.5.8-.8 1.4-.8 1.2 0 2.2 1 2.2 2.4 0 2-2.2 3-3.6 4.4z" /></svg>),
+  "Lista de regalos": (<svg viewBox="0 0 24 24"><path d="M3.5 8A1.5 1.5 0 0 1 5 6.5h14A1.5 1.5 0 0 1 20.5 8v2a1 1 0 0 1-1 1h-15a1 1 0 0 1-1-1V8z" /><path d="M5 12.5h6V21H6.5A1.5 1.5 0 0 1 5 19.5v-7zM13 12.5h6v7a1.5 1.5 0 0 1-1.5 1.5H13v-8.5z" /><path opacity={0.55} d="M12 6.5c-1.2-2.2-3-3.6-4.6-2.7C6 4.6 6.3 6.5 8 6.5h4zm0 0c1.2-2.2 3-3.6 4.6-2.7 1.4.8 1.1 2.7-.6 2.7H12z" /></svg>),
+  "Momentos": (<svg viewBox="0 0 24 24"><path d="M7 6.5A2.5 2.5 0 0 1 9.5 4h9A2.5 2.5 0 0 1 21 6.5v7A2.5 2.5 0 0 1 18.5 16h-9A2.5 2.5 0 0 1 7 13.5v-7z" /><path opacity={0.55} d="M4.5 7.5c-.8.3-1.5 1.2-1.5 2.2V18a3 3 0 0 0 3 3h8.3c1 0 1.9-.6 2.2-1.5H6.5a2 2 0 0 1-2-2V7.5z" /><circle className="mhole" cx="11" cy="8" r="1.3" /><path className="mhole" d="M8.5 14.5l2.6-3 1.9 2 1.6-1.6 3.4 2.6H8.5z" /></svg>),
+};
+
 const Navigation: FC = () => {
   const refBanner = useRef(null)
   const { t } = useTranslation();
@@ -280,6 +295,57 @@ const Navigation: FC = () => {
 
         {/* segundo menu superior con las redirecciones funcionales de la app */}
         <div className={`${(urls.includes(url)) ? "hidden" : "block"}`}>
+          {studioHeader ? (
+            <div className="hidden md:block">
+              <style dangerouslySetInnerHTML={{ __html: ".mbar-item svg{width:32px;height:32px;fill:currentColor}.mbar-item .mhole{fill:var(--hole)}" }} />
+              <div className="max-w-[1100px] mx-auto px-6">
+                <nav
+                  className="flex justify-center gap-2 rounded-b-[22px] px-[26px] pt-2 pb-[9px] transition-colors"
+                  style={{
+                    background: pathname === '/' ? 'linear-gradient(180deg,#F473A4,#EF5B94 55%,#E94F89)' : '#fff',
+                    boxShadow: pathname === '/' ? '0 14px 30px rgba(239,91,148,.35)' : '0 14px 30px rgba(0,0,0,.08)',
+                    ['--hole' as any]: pathname === '/' ? '#EF5B94' : '#fff',
+                  }}
+                >
+                  {Navbar
+                    .filter(item => !(item.hideForGuest && user?.displayName === 'guest'))
+                    .slice()
+                    .sort((a, b) => STUDIO_ORDER.indexOf(a.title) - STUDIO_ORDER.indexOf(b.title))
+                    .map((item, idx) => {
+                      const active = isActiveRoute(pathname, item.route);
+                      const pink = pathname === '/';
+                      const color = pink ? (active ? '#fff' : 'rgba(255,255,255,.75)') : (active ? '#EF5B94' : '#6b6b72');
+                      return (
+                        <button
+                          key={idx}
+                          type="button"
+                          title={!item.condicion ? navNoEventHint : undefined}
+                          onClick={() => {
+                            if (item.condicion) {
+                              if (!isAllowedRouter(item.route)) { ht() } else { router.push(item.route) }
+                            } else {
+                              if (!eventsGroupDone) {
+                                toast("warning", t("waitEventsListToast"))
+                              } else {
+                                const hasEvents = Array.isArray(eventsGroup) && eventsGroup.length > 0
+                                toast("error", t(hasEvents ? "selectEventFromHomeToast" : "youmustcreateevent"))
+                              }
+                              router.push("/")
+                            }
+                          }}
+                          className="mbar-item flex flex-col items-center gap-[5px] flex-1 min-w-0 py-[3px] cursor-pointer transition-transform hover:-translate-y-0.5"
+                          style={{ color, background: 'none', border: 'none', fontFamily: 'inherit' }}
+                        >
+                          {STUDIO_ICONS[item.title] ?? item.icon}
+                          <span style={{ font: `${active ? 600 : 500} 12px Poppins`, whiteSpace: 'nowrap' }}>{t(item.title)}</span>
+                          <i style={{ display: 'block', width: 26, height: 3, borderRadius: 3, background: active ? (pink ? '#fff' : '#EF5B94') : 'transparent' }} />
+                        </button>
+                      );
+                    })}
+                </nav>
+              </div>
+            </div>
+          ) : (
           <div className={`w-full h-20 hidden md:flex bg-base justify-center items-start`}>
             <div style={{ width, height }} className={`absolute top-16 z-10 px-16 flex justify-center transition-opacity duration-200 ${width > 0 ? 'opacity-100' : 'opacity-0'}`}>
               <Tooltip
@@ -338,6 +404,7 @@ const Navigation: FC = () => {
               />
             </div>
           </div >
+          )}
         </div>
       </header >
     </>

--- a/apps/appEventos/components/DefaultLayout/Navigation.tsx
+++ b/apps/appEventos/components/DefaultLayout/Navigation.tsx
@@ -18,7 +18,7 @@ import { useChatSidebar, CHAT_SIDEBAR_MIN_WIDTH, CHAT_SIDEBAR_MAX_WIDTH, CHAT_SI
 // Barra de módulos rediseñada (studio) — iconos EXACTOS del HTML "menumodulos".
 // fill=currentColor (color del item); los "huecos" (.mhole) se pintan con --hole (color del fondo).
 const STUDIO_ORDER = ["Mis eventos", "Resumen", "Invitados", "Mesas", "Presupuesto", "Invitaciones", "Itinerario", "Lista de regalos", "Momentos"];
-const STUDIO_ICONS: Record<string, JSX.Element> = {
+const STUDIO_ICONS: Record<string, ReactElement> = {
   "Mis eventos": (<svg viewBox="0 0 24 24"><path d="M9 2C6.2 2 4 4.4 4 7.4c0 2.9 2 5.3 4.4 5.6l-.6 1.5h2.4L9.6 13C12 12.7 14 10.3 14 7.4 14 4.4 11.8 2 9 2z" /><path opacity={0.55} d="M16.5 5c-1.9 0-3.5 1.7-3.5 3.9 0 2 1.3 3.7 3 4l-.4 1.1h1.8L17 12.9c1.7-.3 3-2 3-4C20 6.7 18.4 5 16.5 5z" /></svg>),
   "Resumen": (<svg viewBox="0 0 24 24"><path d="M5.5 3A2.5 2.5 0 0 0 3 5.5v4A2.5 2.5 0 0 0 5.5 12h4A2.5 2.5 0 0 0 12 9.5v-4A2.5 2.5 0 0 0 9.5 3h-4z" /><path opacity={0.55} d="M15.5 3A2.5 2.5 0 0 0 13 5.5v2A2.5 2.5 0 0 0 15.5 10h3A2.5 2.5 0 0 0 21 7.5v-2A2.5 2.5 0 0 0 18.5 3h-3z" /><path d="M15.5 11A2.5 2.5 0 0 0 13 13.5v5a2.5 2.5 0 0 0 2.5 2.5h3a2.5 2.5 0 0 0 2.5-2.5v-5a2.5 2.5 0 0 0-2.5-2.5h-3z" /><path opacity={0.55} d="M5.5 13A2.5 2.5 0 0 0 3 15.5v3A2.5 2.5 0 0 0 5.5 21h4a2.5 2.5 0 0 0 2.5-2.5v-3A2.5 2.5 0 0 0 9.5 13h-4z" /></svg>),
   "Invitados": (<svg viewBox="0 0 24 24"><circle cx="9" cy="8" r="3.6" /><path d="M3 19.2c0-3.3 2.7-5.7 6-5.7s6 2.4 6 5.7c0 .4-.3.8-.8.8H3.8a.8.8 0 0 1-.8-.8z" /><circle opacity={0.55} cx="16.8" cy="9" r="2.8" /><path opacity={0.55} d="M16.4 13.4c2.7.2 4.6 2.3 4.6 5 0 .3-.3.6-.6.6h-3.2c.2-.5.3-1 .3-1.6 0-1.5-.5-2.9-1.1-4z" /></svg>),
@@ -300,8 +300,9 @@ const Navigation: FC = () => {
               <style dangerouslySetInnerHTML={{ __html: ".mbar-item svg{width:32px;height:32px;fill:currentColor}.mbar-item .mhole{fill:var(--hole)}" }} />
               <div className="max-w-[1100px] mx-auto px-6">
                 <nav
-                  className="flex justify-center gap-2 rounded-b-[22px] px-[26px] pt-2 pb-[9px] transition-colors"
+                  className="flex items-center justify-center gap-2 rounded-b-[22px] px-[26px] transition-colors"
                   style={{
+                    height: 74,
                     background: pathname === '/' ? 'linear-gradient(180deg,#F473A4,#EF5B94 55%,#E94F89)' : '#fff',
                     boxShadow: pathname === '/' ? '0 14px 30px rgba(239,91,148,.35)' : '0 14px 30px rgba(0,0,0,.08)',
                     ['--hole' as any]: pathname === '/' ? '#EF5B94' : '#fff',

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -298,12 +298,12 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
     <>
       <div className="text-gray-100 flex space-x-4 relative" {...rest} >
         {isAuthenticatedUser &&
-          <div className="items-center hidden md:flex gap-1 relative cursor-default">
+          <div className="items-center hidden md:flex gap-1 relative cursor-default shrink-0">
             <div onClick={() => {
               !event ? toast("error", t("nohaveeventscreated")) : !isAllowedRouter("/servicios") ? ht() : router.push("/servicios")
-            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} ${studio ? "w-[42px] h-[42px] bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
+            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} ${studio ? "w-[42px] h-[42px] shrink-0 bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
               {studio ? (
-                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round"><path d="M4.5 6.5l1 1 2-2M4.5 12l1 1 2-2M4.5 17.5l1 1 2-2" /><path d="M11 6.5h8.5M11 12h8.5M11 17.5h8.5" /></svg>
+                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round" className="shrink-0"><path d="M4.5 6.5l1 1 2-2M4.5 12l1 1 2-2M4.5 17.5l1 1 2-2" /><path d="M11 6.5h8.5M11 12h8.5M11 17.5h8.5" /></svg>
               ) : (
                 <GoTasklist className="text-primary w-5 h-5 scale-x-90" />
               )}

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -358,7 +358,7 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
                       {t(item.title)}
                     </div>
                   ))}
-                  {optionsReduceEnd.filter((o: Option) => !["Mi perfil", "Cerrar Sesión"].includes(o.title)).map((item: Option, idx) => (
+                  {optionsReduceEnd.filter((o: Option) => !["Mi perfil", "Cerrar Sesión", "Facturacion"].includes(o.title)).map((item: Option, idx) => (
                     <div key={`e-${idx}`} onClick={(e) => { setDropwdon(false); item.onClick?.(e); }} className="flex items-center gap-[11px] px-[13px] py-2.5 rounded-[11px] cursor-pointer hover:bg-[#FCE7F0]" style={{ font: "500 13px Poppins", color: "#3A3A42" }}>
                       <span className="w-4 h-4 flex items-center justify-center text-[#6b6b72]">{item.icon}</span>
                       {t(item.title)}

--- a/apps/appEventos/components/DefaultLayout/Profile.tsx
+++ b/apps/appEventos/components/DefaultLayout/Profile.tsx
@@ -301,9 +301,9 @@ const Profile = ({ user, state, set, studio = false, ...rest }) => {
           <div className="items-center hidden md:flex gap-1 relative cursor-default shrink-0">
             <div onClick={() => {
               !event ? toast("error", t("nohaveeventscreated")) : !isAllowedRouter("/servicios") ? ht() : router.push("/servicios")
-            }} title={t("Servicios")} className={`${!event ? "opacity-40" : ""} ${studio ? "w-[42px] h-[42px] shrink-0 bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
+            }} title={t("Servicios")} style={studio ? { width: 42, height: 42, flexShrink: 0 } : undefined} className={`${!event ? "opacity-40" : ""} ${studio ? "bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94]" : "bg-slate-100 w-8 h-8 hover:bg-primary/10"} rounded-full flex items-center justify-center cursor-pointer transition`} >
               {studio ? (
-                <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round" className="shrink-0"><path d="M4.5 6.5l1 1 2-2M4.5 12l1 1 2-2M4.5 17.5l1 1 2-2" /><path d="M11 6.5h8.5M11 12h8.5M11 17.5h8.5" /></svg>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9} strokeLinecap="round" style={{ width: 19, height: 19, flexShrink: 0 }}><path d="M4.5 6.5l1 1 2-2M4.5 12l1 1 2-2M4.5 17.5l1 1 2-2" /><path d="M11 6.5h8.5M11 12h8.5M11 17.5h8.5" /></svg>
               ) : (
                 <GoTasklist className="text-primary w-5 h-5 scale-x-90" />
               )}

--- a/apps/appEventos/components/Notifications.tsx
+++ b/apps/appEventos/components/Notifications.tsx
@@ -264,7 +264,7 @@ export const Notifications = ({ studio = false }: { studio?: boolean } = {}) => 
           aria-haspopup="dialog"
           title={studio ? "Notificaciones" : undefined}
           className={studio
-            ? "w-[42px] h-[42px] rounded-full flex items-center justify-center cursor-pointer border-0 p-0 relative bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94] transition"
+            ? "w-[42px] h-[42px] shrink-0 rounded-full flex items-center justify-center cursor-pointer border-0 p-0 relative bg-[#F7F6F8] hover:bg-[#FCE7F0] text-[#6b6b72] hover:text-[#EF5B94] transition"
             : "bg-slate-100 w-10 h-10 rounded-full flex items-center justify-center hover:bg-zinc-200 cursor-pointer border-0 p-0 relative"}
         >
           {studio ? (


### PR DESCRIPTION
## Fase 2 — Barra de módulos rediseñada (fiel al HTML) + arreglos del encabezado

Solo front/CSS — **mismo backend**. Todo gated con `studioHeader` (rollback `?studio=legacy`); la barra/header clásicos quedan intactos.

### Barra de módulos (nueva)
- Iconos EXACTOS del HTML (fill=currentColor + huecos `.mhole` que se pintan del color del fondo).
- Dos estados: **rosa** (degradado) cuando "Mis eventos" activo → iconos/texto blancos + subrayado blanco; **blanca** en cualquier otro módulo → activo rosa, resto gris, subrayado rosa.
- Orden del HTML. Conserva rutas/`condicion`/toasts existentes.

### Arreglos del encabezado
- **Cabecera fija arriba**: altura determinista del header studio (78px + 74px = 152px) y `Container` reserva 152px en desktop, para que header + barra de módulos no los arrastre el scroll del contenido.
- **Iconos del top bar sin encogerse** (`shrink-0` + dimensiones inline en Tareas): ya no se achica al entrar a Presupuesto.
- **Modal de perfil**: "Facturación" aparece una sola vez (se excluye del mapeo, ya se renderiza fija).

### Verificación
- `tsc --noEmit` limpio en los archivos tocados.
- Build OK y verificado en app-dev (confirmado por el owner: cabecera, barra de módulos, modal de perfil y notificaciones OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)