### PR TITLE
♻️ refactor(bandeja): fuente única de clasificación de canal (DRY)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useConversations.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 
 import { buildHeaders } from '../utils/auth';
+import { classifyOtherChannel, isWhatsAppView } from '../utils/channelClassify';
 import { dedupeFetch } from '../utils/dedupeFetch';
 import { friendlyContactName, safePhoneOrEmpty } from '../utils/jid';
 import { useMessageStream } from './useMessageStream';
@@ -39,10 +40,6 @@ export interface Conversation {
   unreadCountForAgent?: number;
 }
 
-// A2-web: canales "otros" conocidos. Alineado 1:1 con useRecentConversations (feed).
-// Cualquier canal fuera de este set (o sin channel) se clasifica como "web" (cajón).
-const OTHER_CHANNELS = new Set(['instagram', 'telegram', 'email', 'web', 'facebook']);
-
 export function useConversations(channel: string | null) {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -78,7 +75,7 @@ export function useConversations(channel: string | null) {
       // pegar al endpoint WA y clasificarse como 'whatsapp'. Antes 'wa-xxx' caía al endpoint
       // de "otros" y filtraba c.channel==='wa-xxx' → SIEMPRE vacío → toda conv WA abierta
       // desde el detalle quedaba "solo lectura" falsamente (no solo las huérfanas).
-      const isWaView = channel === 'whatsapp' || channel?.startsWith('wa-') || !channel;
+      const isWaView = isWhatsAppView(channel);
       const fetchUrl = isWaView
         ? `${proxyBase}/whatsapp/conversations/${dev}`
         : `${proxyBase}/conversations?development=${dev}`;
@@ -98,12 +95,7 @@ export function useConversations(channel: string | null) {
           // Clasificación IDÉNTICA al feed (useRecentConversations): en vista WA todo es
           // 'whatsapp'; en vista "otros", desconocido/sin-channel → 'web' (cajón). Esto
           // hace que la conv sobreviva al abrirla (el filtro de abajo ya cuadra).
-          const rawKind = c.channel || c.platform || (isWaView ? 'whatsapp' : 'web');
-          const kind = isWaView
-            ? 'whatsapp'
-            : OTHER_CHANNELS.has(rawKind)
-              ? rawKind
-              : 'web';
+          const kind = isWaView ? 'whatsapp' : classifyOtherChannel(c.channel, c.platform);
           return {
             assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
             channel: kind as Conversation['channel'],

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useRecentConversations.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/hooks/useRecentConversations.ts
@@ -7,6 +7,7 @@ import { getWhatsAppChannels, getWhatsAppConversationsGQL } from '@/services/mcp
 
 import { useAuthCheck } from '@/hooks/useAuthCheck';
 import { buildHeaders } from '../utils/auth';
+import { classifyOtherChannel } from '../utils/channelClassify';
 import { dedupeFetch } from '../utils/dedupeFetch';
 import { friendlyContactName } from '../utils/jid';
 import { useMessageStream } from './useMessageStream';
@@ -153,7 +154,6 @@ export function useRecentConversations(max = 50, refreshKey = 0) {
           .catch(() => [] as RecentConversation[]);
 
         // Fetch other channels conversations (if backend supports them)
-        const otherChannels: ChannelKind[] = ['instagram', 'telegram', 'email', 'web', 'facebook'];
         const othersPromise = dedupeFetch(`/api/messages/conversations?development=${dev}`, {
           headers: buildHeaders(),
         })
@@ -162,15 +162,15 @@ export function useRecentConversations(max = 50, refreshKey = 0) {
             const data = await res.json();
             const rawList: any[] = Array.isArray(data) ? data : (data.conversations ?? []);
             return rawList.map((c: any) => {
-              const kind = (c.channel || c.platform || 'web') as ChannelKind;
-              const isKnown = otherChannels.includes(kind);
+              // Clasificación de canal — fuente ÚNICA compartida con useConversations (rail).
+              const ch = classifyOtherChannel(c.channel, c.platform);
               // N31 retirado 24-jun: api-ia commit 665097b normalizó lastMessage
               // a string + lastMessageAt + lastMessageFromMe. Ya no llega objeto.
               return {
                 assignedToUserId: c.assignedUserId ?? c.assigned_to ?? c.assignedTo ?? null,
-                channelParam: isKnown ? kind : 'web',
+                channelParam: ch,
                 conversationId: c.conversationId || c.id || '',
-                kind: isKnown ? kind : ('web' as const),
+                kind: ch,
                 lastMessage: c.lastMessage || '',
                 lastMessageAt: c.lastMessageAt || c.updatedAt || '',
                 lastInboundAt: c.lastInboundAt ?? c.last_inbound_at ?? undefined,

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/utils/channelClassify.ts
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/utils/channelClassify.ts
@@ -1,0 +1,40 @@
+import type { ChannelKind } from '../hooks/useRecentConversations';
+
+/**
+ * Fuente ÚNICA de la clasificación de canal de conversaciones.
+ *
+ * Antes esta lógica estaba DUPLICADA en `useConversations` (rail del detalle) y
+ * `useRecentConversations` (feed de /bandeja): misma lista de canales y mismo criterio
+ * copiados en dos sitios → podían divergir (p.ej. añadir un canal en uno y no en el otro,
+ * reintroduciendo el bug A2 de conteos/clasificación incoherentes). Aquí queda en un solo
+ * lugar para que ambos hooks NO puedan volver a divergir.
+ */
+
+/** Canales "otros" (no-WhatsApp) reconocidos. */
+export const KNOWN_OTHER_CHANNELS: readonly ChannelKind[] = [
+  'instagram',
+  'telegram',
+  'email',
+  'web',
+  'facebook',
+];
+
+const OTHER_SET = new Set<string>(KNOWN_OTHER_CHANNELS);
+
+/**
+ * ¿La vista corresponde a WhatsApp? Llega como kind `'whatsapp'`, como channelParam
+ * `'wa-{id}'` (URL del detalle) o como `null`/`undefined` (feed sin canal). Los tres pegan
+ * al endpoint WA y clasifican como `'whatsapp'`.
+ */
+export function isWhatsAppView(channel: string | null | undefined): boolean {
+  return channel === 'whatsapp' || !!channel?.startsWith('wa-') || !channel;
+}
+
+/**
+ * Clasifica el canal de una conversación en la vista "otros" (no-WA). Toma
+ * `channel`/`platform` del raw; desconocido o ausente → `'web'` (cajón por defecto).
+ */
+export function classifyOtherChannel(rawChannel?: unknown, rawPlatform?: unknown): ChannelKind {
+  const raw = String(rawChannel || rawPlatform || 'web');
+  return (OTHER_SET.has(raw) ? raw : 'web') as ChannelKind;
+}


### PR DESCRIPTION
## Fase 2 · future-proofing (no el refactor grande)

Tras auditar: **no hay bug de inconsistencia de datos** — `useConversations` (rail) y `useRecentConversations` (feed) ya pegan al mismo endpoint y clasifican igual (fix A2-web). Migrar todo a un store único sería riesgo sin payoff visible → **descartado**.

Lo que SÍ aportaba valor: la lista de canales + el criterio de clasificación estaban **duplicados** en ambos hooks → podían divergir y reintroducir el bug A2. Extraídos a una **fuente única** `bandeja/utils/channelClassify.ts`.

- `KNOWN_OTHER_CHANNELS`, `isWhatsAppView`, `classifyOtherChannel` — usados por ambos hooks.
- **Comportamiento idéntico** (test `ConversationList.view` pasa). Sin cambio visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)