### PR TITLE
💰 feat(presupuesto): rediseño completo studio (5 vistas) fiel a los HTML, mismo backend

### DIFF
--- a/apps/appEventos/components/Presupuesto/DashboardStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/DashboardStudio.tsx
@@ -1,0 +1,237 @@
+import { FC, useMemo, useState } from "react";
+import { EventContextProvider, AuthContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+import { fetchApiEventos, queries } from "../../utils/Fetching";
+import { getCurrency } from "../../utils/Funciones";
+import { useAllowed } from "../../hooks/useAllowed";
+import { useToast } from "../../hooks/useToast";
+
+const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
+const parseEs = (s: string) => { const n = parseFloat(String(s).replace(/[^\d.,]/g, "").replace(/\./g, "").replace(",", ".")); return Number.isNaN(n) ? 0 : n; };
+const WP = "wedding planer";
+const fmtFecha = (f: any) => { if (!f) return "—"; try { const d = new Date(f); return `${String(d.getDate()).padStart(2, "0")}/${String(d.getMonth() + 1).padStart(2, "0")}/${d.getFullYear()}`; } catch { return String(f); } };
+
+interface Props { categorias: any[]; }
+
+const DashboardStudio: FC<Props> = ({ categorias }) => {
+  const { t } = useTranslation();
+  const { event, setEvent } = EventContextProvider() as any;
+  const { user } = AuthContextProvider() as any;
+  const [isAllowed, ht] = useAllowed();
+  const toast = useToast();
+  const cur = event?.presupuesto_objeto?.currency;
+
+  const [tab, setTab] = useState<"main" | "hist">("main");
+  const [depOpen, setDepOpen] = useState(false);
+  const [depMonto, setDepMonto] = useState("");
+  const [depMetodo, setDepMetodo] = useState("");
+  const [depRef, setDepRef] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const cats = Array.isArray(categorias) ? categorias : [];
+  const deposits = event?.presupuesto_objeto?.weddingPlannerIngresos || [];
+
+  const data = useMemo(() => {
+    const allPagos: any[] = [];
+    cats.forEach((c) => (c.gastos_array || []).filter((g: any) => g?.estatus !== false).forEach((g: any) => (g.pagos_array || []).filter((p: any) => p?.estado === "pagado").forEach((p: any) => allPagos.push({ ...p, catName: c.nombre, gastoName: g.nombre }))));
+    const directos = allPagos.filter((p) => p.pagado_por !== WP);
+    const wpPagos = allPagos.filter((p) => p.pagado_por === WP);
+    const recibido = deposits.reduce((a: number, d: any) => a + (Number(d.monto) || 0), 0);
+    const totalDirectos = directos.reduce((a, p) => a + (Number(p.importe) || 0), 0);
+    const totalWP = wpPagos.reduce((a, p) => a + (Number(p.importe) || 0), 0);
+    const presupuestoTotal = cats.reduce((a, c) => a + (c.coste_final || 0), 0);
+    const totalPagado = event?.presupuesto_objeto?.pagado || 0;
+    const utilizado = totalWP;
+    const disponible = recibido - utilizado;
+    return { allPagos, directos, wpPagos, recibido, totalDirectos, totalWP, presupuestoTotal, totalPagado, utilizado, disponible };
+  }, [cats, deposits, event?.presupuesto_objeto?.pagado]);
+
+  const pctDisp = data.recibido > 0 ? Math.round((data.disponible / data.recibido) * 100) : 0;
+  const pctPag = data.presupuestoTotal > 0 ? Math.round((data.totalPagado / data.presupuestoTotal) * 100) : 0;
+
+  const kpis = [
+    { label: t("Total recibido"), val: data.recibido, sub: t("Del presupuesto total"), tone: "#2FB37E", bg: "#E4F5EE" },
+    { label: t("Fondos disponibles"), val: data.disponible, sub: `${pctDisp}% ${t("del total")}`, tone: "#3A3A42", bg: "#faf9fb" },
+    { label: t("Total utilizado"), val: data.utilizado, sub: `${t("En")} ${data.wpPagos.length} ${t("pagos")}`, tone: "#B4801F", bg: "#FBF0DA" },
+    { label: t("Pagos directos"), val: data.totalDirectos, sub: `${data.directos.length} ${t("pagos")}`, tone: "#EF5B94", bg: "#FCE7F0" },
+    { label: t("Presupuesto total"), val: data.presupuestoTotal, sub: t("Todos los gastos"), tone: "#D83E7C", bg: "#FBE4EF" },
+  ];
+  const finStats = [
+    { label: t("Presupuesto total"), val: data.presupuestoTotal, sub: t("Todos los gastos incluidos"), tone: "#3A3A42", bg: "#faf9fb" },
+    { label: t("Total pagado"), val: data.totalPagado, sub: `${pctPag}% ${t("completado")}`, tone: "#1E8F63", bg: "#E4F5EE" },
+    { label: t("Pagos directos"), val: data.totalDirectos, sub: t("Fuera de la plataforma"), tone: "#B4801F", bg: "#FBF0DA" },
+    { label: t("Por Wedding Planner"), val: data.totalWP, sub: t("Total pagado"), tone: "#D83E7C", bg: "#FBE4EF" },
+  ];
+
+  const applyPO = (result: any) => { const po = result?.evento?.presupuesto_objeto; if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po })); };
+
+  const submitDep = async () => {
+    if (!isAllowed()) { ht(); return; }
+    const monto = parseEs(depMonto);
+    if (!monto || saving) return;
+    setSaving(true);
+    try {
+      const result: any = await fetchApiEventos({
+        query: queries.addWeddingPlannerIngreso,
+        variables: { evento_id: event._id, ingreso: { fecha: new Date(), monto, metodo: depMetodo, referencia: depRef, registrado_por: user?.displayName || user?.email || "" } },
+      });
+      applyPO(result);
+      toast("success", t("Depósito registrado"));
+      setDepOpen(false); setDepMonto(""); setDepMetodo(""); setDepRef("");
+    } catch { toast("error", t("Ha ocurrido un error")); } finally { setSaving(false); }
+  };
+
+  const delDep = async (dep: any) => {
+    if (!isAllowed()) { ht(); return; }
+    try { applyPO(await fetchApiEventos({ query: queries.deleteWeddingPlannerIngreso, variables: { evento_id: event._id, ingreso_id: dep._id } })); toast("success", t("Depósito eliminado")); }
+    catch { toast("error", t("Ha ocurrido un error")); }
+  };
+
+  const card: any = { background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)" };
+  const canConfirm = !!depMonto.trim() && !saving;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16, fontFamily: "'Poppins',sans-serif" }}>
+      <style dangerouslySetInnerHTML={{ __html: ".ds-in:focus{border-color:#EF5B94!important;}.ds-ghost:hover{border-color:#EF5B94!important;color:#EF5B94!important;}" }} />
+
+      {/* Cabecera */}
+      <div style={{ ...card, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, padding: "20px 22px", flexWrap: "wrap" }}>
+        <div><div style={{ font: "700 17px Poppins", color: "#3A3A42" }}>{t("Gestión financiera")}</div><div style={{ font: "500 12px Poppins", color: "#a0a0a8", marginTop: 2 }}>{t("Depósitos, pagos directos y pagos por Wedding Planner")}</div></div>
+        <div style={{ textAlign: "right" }}><div style={{ font: "700 11px Poppins", color: "#EF5B94", letterSpacing: 1 }}>{t("EVENTO")}</div><div style={{ font: "700 14px Poppins", color: "#3A3A42" }}>{event?.nombre}</div></div>
+      </div>
+
+      {/* 5 KPI */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(5,1fr)", gap: 12 }}>
+        {kpis.map((d, i) => (
+          <div key={i} style={{ ...card, padding: 16 }}>
+            <div style={{ display: "inline-flex", alignItems: "center", borderRadius: 999, padding: "4px 11px", font: "700 9.5px Poppins", letterSpacing: ".4px", textTransform: "uppercase", background: d.bg, color: d.tone, whiteSpace: "nowrap" }}>{d.label}</div>
+            <div style={{ font: "700 19px Poppins", color: d.tone, marginTop: 11, whiteSpace: "nowrap" }}>{getCurrency(d.val, cur)}</div>
+            <div style={{ font: "500 11px Poppins", color: "#a0a0a8", marginTop: 3 }}>{d.sub}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Registrar nuevo depósito */}
+      <div>
+        <button onClick={() => { if (!isAllowed()) { ht(); return; } setDepOpen((v) => !v); }} style={{ display: "inline-flex", alignItems: "center", gap: 8, padding: "11px 20px", borderRadius: 10, background: "#EF5B94", border: "none", color: "#fff", font: "600 13px Poppins", cursor: "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)" }}><span style={{ fontSize: 16, lineHeight: 1 }}>＋</span>{t("Registrar nuevo depósito")}</button>
+      </div>
+      {depOpen && (
+        <div style={{ ...card, padding: "20px 22px" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1.4fr", gap: 14 }}>
+            <div><div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Monto del depósito")}</div><input className="ds-in" value={depMonto} onChange={(e) => setDepMonto(e.target.value)} placeholder="0,00" style={{ width: "100%", padding: "11px 14px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 13.5px Poppins", color: "#3A3A42", outline: "none" }} /></div>
+            <div><div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Método de pago")}</div><select className="ds-in" value={depMetodo} onChange={(e) => setDepMetodo(e.target.value)} style={{ width: "100%", padding: "11px 14px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 13.5px Poppins", color: "#3A3A42", outline: "none", background: "#fff" }}><option value="">{t("Seleccionar método")}</option><option>{t("Efectivo")}</option><option>{t("Transferencia")}</option><option>{t("Tarjeta")}</option><option>{t("Ingreso en cuenta")}</option></select></div>
+            <div><div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Referencia")}</div><input className="ds-in" value={depRef} onChange={(e) => setDepRef(e.target.value)} placeholder={t("Número de referencia o descripción") as string} style={{ width: "100%", padding: "11px 14px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 13.5px Poppins", color: "#3A3A42", outline: "none" }} /></div>
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
+            <button onClick={() => setDepOpen(false)} style={{ padding: "10px 18px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12.5px Poppins", cursor: "pointer" }}>{t("Cancelar")}</button>
+            <button onClick={submitDep} disabled={!canConfirm} style={{ display: "inline-flex", alignItems: "center", gap: 7, padding: "10px 18px", borderRadius: 10, background: canConfirm ? "#EF5B94" : "#f3c4d8", border: "none", color: "#fff", font: "600 12.5px Poppins", cursor: canConfirm ? "pointer" : "default" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>{t("Confirmar depósito")}</button>
+          </div>
+        </div>
+      )}
+
+      {/* Pestañas internas */}
+      <div style={{ display: "flex", gap: 22, borderBottom: "1.5px solid #ececef", padding: "0 4px" }}>
+        {[{ k: "main", l: t("Dashboard principal") }, { k: "hist", l: t("Historial de depósitos") }].map((tb) => {
+          const on = tab === tb.k;
+          return <button key={tb.k} onClick={() => setTab(tb.k as any)} style={{ background: "none", border: "none", cursor: "pointer", padding: "10px 2px 12px", font: "600 13px Poppins", whiteSpace: "nowrap", marginBottom: "-1.5px", color: on ? "#EF5B94" : "#8a8a90", borderBottom: `2.5px solid ${on ? "#EF5B94" : "transparent"}` }}>{tb.l}</button>;
+        })}
+      </div>
+
+      {tab === "main" ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, alignItems: "start" }}>
+            {/* Pagos directos */}
+            <div style={{ ...card, overflow: "hidden" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, padding: "16px 20px", borderBottom: "1px solid #f2f2f4" }}>
+                <div style={{ font: "700 14.5px Poppins", color: "#3A3A42" }}>{t("Pagos directos")}</div>
+                <div style={{ textAlign: "right" }}><div style={{ font: "500 10.5px Poppins", color: "#a0a0a8" }}>{t("Total en pagos directos")}</div><div style={{ font: "700 15px Poppins", color: "#EF5B94" }}>{getCurrency(data.totalDirectos, cur)}</div></div>
+              </div>
+              {data.directos.length === 0 && <div style={{ padding: "40px 20px", textAlign: "center", font: "500 12px Poppins", color: "#a0a0a8" }}>{t("No hay pagos directos")}</div>}
+              {data.directos.map((p: any, i: number) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: 12, padding: "13px 20px", borderBottom: "1px solid #f6f6f8" }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.gastoName}</div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 3, font: "500 11.5px Poppins", color: "#a0a0a8", flexWrap: "wrap" }}>
+                      <span>{fmtFecha(p.fecha_pago)}</span>
+                      <span style={{ background: "#faf9fb", border: "1px solid #ececef", borderRadius: 999, padding: "2px 9px", font: "600 10.5px Poppins", color: "#6b6b72" }}>{cap1(p.catName)}</span>
+                      {p.pagado_por && <span>{t("Por")}: {p.pagado_por}</span>}
+                    </div>
+                  </div>
+                  <div style={{ textAlign: "right", flex: "none" }}>
+                    <div style={{ font: "700 13.5px Poppins", color: "#3A3A42" }}>{getCurrency(p.importe || 0, cur)}</div>
+                    <span style={{ display: "inline-flex", alignItems: "center", gap: 5, background: "#E4F5EE", color: "#2FB37E", borderRadius: 999, padding: "3px 10px", font: "600 10.5px Poppins", marginTop: 4 }}><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#2FB37E" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg>{t("Pagado")}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {/* Pagos por Wedding Planner */}
+            <div style={{ ...card, overflow: "hidden" }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, padding: "16px 20px", borderBottom: "1px solid #f2f2f4" }}>
+                <div style={{ font: "700 14.5px Poppins", color: "#3A3A42" }}>{t("Pagos por Wedding Planner")}</div>
+                <div style={{ textAlign: "right" }}><div style={{ font: "500 10.5px Poppins", color: "#a0a0a8" }}>{t("Total pagado")}</div><div style={{ font: "700 15px Poppins", color: "#3A3A42" }}>{getCurrency(data.totalWP, cur)}</div></div>
+              </div>
+              {data.wpPagos.length === 0 ? (
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "52px 24px", textAlign: "center" }}>
+                  <div style={{ width: 46, height: 46, borderRadius: "50%", background: "#faf9fb", display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", marginBottom: 12 }}><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l1.5-5h15L21 9M3 9v11h18V9M3 9h18M9 13h6" /></svg></div>
+                  <div style={{ font: "600 13.5px Poppins", color: "#6b6b72" }}>{t("No hay pagos realizados")}</div>
+                  <div style={{ font: "500 12px Poppins", color: "#a0a0a8", marginTop: 3 }}>{t("Los pagos por Wedding Planner aparecerán aquí")}</div>
+                </div>
+              ) : data.wpPagos.map((p: any, i: number) => (
+                <div key={i} style={{ display: "flex", alignItems: "center", gap: 12, padding: "13px 20px", borderBottom: "1px solid #f6f6f8" }}>
+                  <div style={{ flex: 1, minWidth: 0 }}><div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.gastoName}</div><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8", marginTop: 3 }}>{fmtFecha(p.fecha_pago)} · {cap1(p.catName)}</div></div>
+                  <div style={{ font: "700 13.5px Poppins", color: "#3A3A42" }}>{getCurrency(p.importe || 0, cur)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+          {/* Resumen financiero detallado */}
+          <div style={{ ...card, padding: "20px 22px" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, flexWrap: "wrap", marginBottom: 16 }}>
+              <div style={{ font: "700 15px Poppins", color: "#3A3A42" }}>{t("Resumen financiero detallado")}</div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button className="ds-ghost" style={{ display: "inline-flex", alignItems: "center", gap: 7, padding: "9px 14px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M9 13h6M9 17h6" /></svg>{t("Generar reporte")}</button>
+                <button className="ds-ghost" style={{ display: "inline-flex", alignItems: "center", gap: 7, padding: "9px 14px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v12M7 10l5 5 5-5" /><path d="M5 21h14" /></svg>{t("Exportar Excel")}</button>
+              </div>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 12, marginBottom: 20 }}>
+              {finStats.map((f, i) => (
+                <div key={i} style={{ background: f.bg, borderRadius: 14, padding: "15px 16px" }}>
+                  <div style={{ font: "600 11px Poppins", color: f.tone }}>{f.label}</div>
+                  <div style={{ font: "700 18px Poppins", color: f.tone, marginTop: 6 }}>{getCurrency(f.val, cur)}</div>
+                  <div style={{ font: "500 10.5px Poppins", color: "#a0a0a8", marginTop: 2 }}>{f.sub}</div>
+                </div>
+              ))}
+            </div>
+            <div style={{ font: "600 13px Poppins", color: "#3A3A42", marginBottom: 10 }}>{t("Distribución por categorías")}</div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "8px 16px" }}>
+              {cats.map((c) => (
+                <div key={c._id} style={{ display: "flex", alignItems: "center", gap: 10, background: "#faf9fb", borderRadius: 10, padding: "10px 14px" }}>
+                  <div style={{ flex: 1, font: "500 12.5px Poppins", color: "#5a5a62", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{cap1(c.nombre)}</div>
+                  <div style={{ font: "700 12.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap" }}>{getCurrency(c.coste_final || 0, cur)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div style={{ ...card, overflow: "hidden" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "140px 1fr 160px 140px 40px", gap: 8, padding: "14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
+            <div>{t("Fecha")}</div><div>{t("Concepto")}</div><div style={{ textAlign: "right" }}>{t("Importe")}</div><div>{t("Registrado por")}</div><div />
+          </div>
+          {deposits.length === 0 && <div style={{ padding: "40px 22px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{t("Aún no hay depósitos registrados")}</div>}
+          {deposits.map((d: any, i: number) => (
+            <div key={d._id || i} style={{ display: "grid", gridTemplateColumns: "140px 1fr 160px 140px 40px", gap: 8, alignItems: "center", padding: "13px 22px", borderBottom: "1px solid #f6f6f8" }}>
+              <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{fmtFecha(d.fecha)}</div>
+              <div style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{d.referencia || d.concepto || t("Depósito")}</div>
+              <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#2FB37E" }}>{getCurrency(Number(d.monto) || 0, cur)}</div>
+              <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{d.registrado_por || d.por || "—"}</div>
+              <div style={{ display: "flex", justifyContent: "center" }}><button title={t("Eliminar")} onClick={() => delDep(d)} style={{ width: 28, height: 28, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg></button></div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DashboardStudio;

--- a/apps/appEventos/components/Presupuesto/DetalleCategoriaStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/DetalleCategoriaStudio.tsx
@@ -5,9 +5,8 @@ import { fetchApiEventos, queries } from "../../utils/Fetching";
 import { getCurrency } from "../../utils/Funciones";
 import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
-import { EntityNotesSection } from "../Notes/EntityNotesSection";
-import ModalLeft from "../Utils/ModalLeft";
-import FormAddPago from "../Forms/FormAddPago";
+import StudioNotesSection from "./StudioNotesSection";
+import ModalAddPagoStudio from "./ModalAddPagoStudio";
 
 // Nombre de categoría: iniciar con mayúscula (solo primera letra).
 const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
@@ -88,11 +87,9 @@ const DetalleCategoriaStudio: FC<Props> = ({ categoriaId, onClose }) => {
         .dc-link:hover{color:#D83E7C!important;}
       `}} />
 
-      {/* Modal Añadir pago (reusa el form existente) */}
+      {/* Modal Añadir pago (fiel al HTML) */}
       {pagoGasto && (
-        <ModalLeft state={!!pagoGasto} set={() => setPagoGasto(null)}>
-          <FormAddPago GastoID={pagoGasto} cate={categoria._id} setGastoID={() => setPagoGasto(null)} />
-        </ModalLeft>
+        <ModalAddPagoStudio categoriaId={categoria._id} gastoId={pagoGasto} onClose={() => setPagoGasto(null)} />
       )}
 
       {/* TARJETA DETALLE */}
@@ -149,9 +146,9 @@ const DetalleCategoriaStudio: FC<Props> = ({ categoriaId, onClose }) => {
         </div>
       </div>
 
-      {/* NOTAS INTERNAS (colapsable, backend real) */}
+      {/* NOTAS INTERNAS (colapsable, fiel al HTML, backend real) */}
       {categoria._id && (
-        <EntityNotesSection entityType="ENTITY" entityId={categoria._id} entityName={categoria?.nombre || "Categoría"} />
+        <StudioNotesSection entityId={categoria._id} entityName={categoria?.nombre || "Categoría"} />
       )}
     </>
   );

--- a/apps/appEventos/components/Presupuesto/DetalleCategoriaStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/DetalleCategoriaStudio.tsx
@@ -1,0 +1,160 @@
+import { FC, useState } from "react";
+import { EventContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+import { fetchApiEventos, queries } from "../../utils/Fetching";
+import { getCurrency } from "../../utils/Funciones";
+import { useAllowed } from "../../hooks/useAllowed";
+import { useToast } from "../../hooks/useToast";
+import { EntityNotesSection } from "../Notes/EntityNotesSection";
+import ModalLeft from "../Utils/ModalLeft";
+import FormAddPago from "../Forms/FormAddPago";
+
+// Nombre de categoría: iniciar con mayúscula (solo primera letra).
+const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
+
+interface Props {
+  categoriaId: string;
+  onClose: () => void;
+}
+
+const DetalleCategoriaStudio: FC<Props> = ({ categoriaId, onClose }) => {
+  const { t } = useTranslation();
+  const { event, setEvent } = EventContextProvider() as any;
+  const [isAllowed, ht] = useAllowed();
+  const toast = useToast();
+  const [pagoGasto, setPagoGasto] = useState<string | null>(null);
+
+  const cur = event?.presupuesto_objeto?.currency;
+  const categoria = event?.presupuesto_objeto?.categorias_array?.find((c: any) => c._id === categoriaId);
+  const gastos: any[] = (categoria?.gastos_array || []).filter((g: any) => g?.estatus !== false);
+
+  if (!categoria) return null;
+
+  const catTot = categoria.coste_final || 0;
+  const catPag = categoria.pagado || 0;
+  const catPen = catTot - catPag;
+
+  const applyPO = (result: any, fallback?: (prev: any) => any) => {
+    const po = result?.evento?.presupuesto_objeto;
+    if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po }));
+    else if (fallback) setEvent(fallback);
+  };
+
+  const addServicio = async () => {
+    if (!isAllowed()) { ht(); return; }
+    try {
+      const result: any = await fetchApiEventos({
+        query: queries.nuevoGasto,
+        variables: { evento_id: event._id, categoria_id: categoria._id, nombre: t("Nueva partida de gasto") },
+      });
+      if (result?.success === false && result?.errors?.length) { toast("error", t("Ha ocurrido un error")); return; }
+      applyPO(result);
+    } catch (e) { toast("error", t("Ha ocurrido un error")); }
+  };
+
+  const deleteGasto = async (gasto: any) => {
+    if (!isAllowed()) { ht(); return; }
+    try {
+      const result: any = await fetchApiEventos({
+        query: queries.borrarGasto,
+        variables: { evento_id: event._id, categoria_id: categoria._id, gasto_id: gasto._id },
+      });
+      applyPO(result, (prev: any) => ({
+        ...prev,
+        presupuesto_objeto: {
+          ...prev.presupuesto_objeto,
+          categorias_array: prev.presupuesto_objeto.categorias_array.map((c: any) => c._id !== categoria._id ? c : { ...c, gastos_array: (c.gastos_array || []).filter((g: any) => g._id !== gasto._id) }),
+        },
+      }));
+      toast("success", t("Partida eliminada"));
+    } catch (e) { toast("error", t("Ha ocurrido un error")); }
+  };
+
+  const openPago = (gasto: any) => {
+    if (!isAllowed()) { ht(); return; }
+    setPagoGasto(gasto._id);
+  };
+
+  const COL = "minmax(110px,1.3fr) 74px 72px 74px 58px";
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: `
+        .dc-row:hover{background:#faf9fb;}
+        .dc-pag:hover{background:#E4F5EE;text-decoration:underline;}
+        .dc-add:hover{background:#E4F5EE!important;color:#1E8F63!important;}
+        .dc-del:hover{background:#FBE4EF!important;color:#D83E7C!important;}
+        .dc-close:hover{background:#faf9fb!important;color:#3A3A42!important;}
+        .dc-link:hover{color:#D83E7C!important;}
+      `}} />
+
+      {/* Modal Añadir pago (reusa el form existente) */}
+      {pagoGasto && (
+        <ModalLeft state={!!pagoGasto} set={() => setPagoGasto(null)}>
+          <FormAddPago GastoID={pagoGasto} cate={categoria._id} setGastoID={() => setPagoGasto(null)} />
+        </ModalLeft>
+      )}
+
+      {/* TARJETA DETALLE */}
+      <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden", marginBottom: 18, fontFamily: "'Poppins',sans-serif" }}>
+        {/* Cabecera */}
+        <div style={{ position: "relative", padding: "18px 20px 14px", borderBottom: "1px solid #f2f2f4" }}>
+          <div style={{ textAlign: "center", font: "700 16px Poppins", color: "#EF5B94" }}>{cap1(categoria.nombre)}</div>
+          <button className="dc-close" title={t("Cerrar")} onClick={onClose} style={{ position: "absolute", top: 14, right: 14, width: 30, height: 30, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+        </div>
+
+        {/* Encabezado columnas con totales */}
+        <div style={{ display: "grid", gridTemplateColumns: COL, gap: 6, padding: "11px 16px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".4px", textTransform: "uppercase" }}>
+          <div>{t("Partida de gasto")}</div>
+          <div style={{ textAlign: "right" }}>{t("Coste total")}<div style={{ font: "600 10.5px Poppins", color: "#a0a0a8", textTransform: "none", letterSpacing: 0 }}>{getCurrency(catTot, cur)}</div></div>
+          <div style={{ textAlign: "right" }}>{t("Pagado")}<div style={{ font: "600 10.5px Poppins", color: "#a0a0a8", textTransform: "none", letterSpacing: 0 }}>{getCurrency(catPag, cur)}</div></div>
+          <div style={{ textAlign: "right" }}>{t("Por pagar")}<div style={{ font: "600 10.5px Poppins", color: "#a0a0a8", textTransform: "none", letterSpacing: 0 }}>{getCurrency(catPen, cur)}</div></div>
+          <div />
+        </div>
+
+        {/* Filas de partidas */}
+        {gastos.length === 0 && (
+          <div style={{ padding: "26px 16px", textAlign: "center", font: "500 12px Poppins", color: "#a0a0a8" }}>{t("Aún no hay partidas de gasto")}</div>
+        )}
+        {gastos.map((g: any) => {
+          const tot = g.coste_final || 0;
+          const pag = g.pagado || 0;
+          const pen = tot - pag;
+          return (
+            <div key={g._id} className="dc-row" style={{ display: "grid", gridTemplateColumns: COL, gap: 6, alignItems: "center", padding: "12px 16px", borderBottom: "1px solid #f4f4f6" }}>
+              <div style={{ font: "500 12.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={g.nombre}>{g.nombre}</div>
+              <div style={{ textAlign: "right", font: "600 12px Poppins", color: "#3A3A42" }}>{getCurrency(tot, cur)}</div>
+              <div className="dc-pag" title={t("Añadir pago")} onClick={() => openPago(g)} style={{ textAlign: "right", font: "600 12px Poppins", color: "#2FB37E", cursor: "pointer", borderRadius: 6, padding: "2px 4px", margin: "-2px -4px" }}>{getCurrency(pag, cur)}</div>
+              <div style={{ textAlign: "right", font: "600 12px Poppins", color: pen === 0 ? "#8a8a90" : "#D83E7C" }}>{getCurrency(pen, cur)}</div>
+              <div style={{ display: "flex", alignItems: "center", gap: 4, justifyContent: "flex-end" }}>
+                <button className="dc-add" title={t("Añadir pago")} onClick={() => openPago(g)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer", font: "700 14px Poppins", lineHeight: 1 }}>＋</button>
+                <button className="dc-del" title={t("Eliminar partida")} onClick={() => deleteGasto(g)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg></button>
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Añadir servicio */}
+        <div style={{ padding: "12px 20px", borderBottom: "1px solid #f2f2f4" }}>
+          <button className="dc-link" onClick={addServicio} style={{ display: "inline-flex", alignItems: "center", gap: 7, background: "none", border: "none", cursor: "pointer", font: "600 12.5px Poppins", color: "#EF5B94", padding: 0, whiteSpace: "nowrap" }}><span style={{ width: 18, height: 18, borderRadius: "50%", background: "#FCE7F0", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 13, lineHeight: 1 }}>＋</span>{t("Añadir servicio")}</button>
+        </div>
+
+        {/* Total */}
+        <div style={{ display: "grid", gridTemplateColumns: COL, gap: 6, alignItems: "center", padding: "13px 16px", background: "#EF5B94" }}>
+          <div style={{ font: "700 13px Poppins", color: "#fff" }}>{t("Total")}</div>
+          <div style={{ textAlign: "right", font: "700 12px Poppins", color: "#fff" }}>{getCurrency(catTot, cur)}</div>
+          <div style={{ textAlign: "right", font: "700 12px Poppins", color: "#fff" }}>{getCurrency(catPag, cur)}</div>
+          <div style={{ textAlign: "right", font: "700 12px Poppins", color: "#fff" }}>{getCurrency(catPen, cur)}</div>
+          <div />
+        </div>
+      </div>
+
+      {/* NOTAS INTERNAS (colapsable, backend real) */}
+      {categoria._id && (
+        <EntityNotesSection entityType="ENTITY" entityId={categoria._id} entityName={categoria?.nombre || "Categoría"} />
+      )}
+    </>
+  );
+};
+
+export default DetalleCategoriaStudio;

--- a/apps/appEventos/components/Presupuesto/ExportExcelPresupuesto.tsx
+++ b/apps/appEventos/components/Presupuesto/ExportExcelPresupuesto.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useToast } from '../../hooks/useToast';
 import { BsDownload } from 'react-icons/bs';
 
-const ExportExcelPresupuesto = ({ className = "" }: { className?: string }) => {
+const ExportExcelPresupuesto = ({ className = "", studio = false }: { className?: string; studio?: boolean }) => {
   const { event } = EventContextProvider();
   const { t } = useTranslation();
   const toast = useToast();
@@ -385,13 +385,27 @@ const ExportExcelPresupuesto = ({ className = "" }: { className?: string }) => {
     }
   };
 
+  if (studio) {
+    return (
+      <button
+        onClick={exportToExcel}
+        title="Exportar presupuesto a Excel"
+        className="ps-btn2"
+        style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 14px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer", whiteSpace: "nowrap" }}
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M12 15V3M7 8l5-5 5 5M4 21h16" /></svg>
+        {t("export")}
+      </button>
+    );
+  }
+
   return (
     <button
       onClick={exportToExcel}
       className={`capitalize text-gray-500 cursor-pointer flex justify-center items-center border border-primary rounded-md px-3 text-xs text-primary ${className}`}
       title="Exportar presupuesto a Excel"
     >
-      
+
       {t("export")}
     </button>
   );

--- a/apps/appEventos/components/Presupuesto/ModalAddPagoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/ModalAddPagoStudio.tsx
@@ -1,0 +1,204 @@
+import { FC, useState, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useEffect } from "react";
+import { EventContextProvider, AuthContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+import { fetchApiEventos, fetchApiBodas, queries } from "../../utils/Fetching";
+import { getCurrency } from "../../utils/Funciones";
+import { useAllowed } from "../../hooks/useAllowed";
+import { useToast } from "../../hooks/useToast";
+
+const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
+const parseEs = (s: string) => {
+  const n = parseFloat(String(s).replace(/[^\d.,]/g, "").replace(/\./g, "").replace(",", "."));
+  return Number.isNaN(n) ? 0 : n;
+};
+
+interface Props { categoriaId: string; gastoId: string; onClose: () => void; }
+
+const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose }) => {
+  const { t } = useTranslation();
+  const { event, setEvent } = EventContextProvider() as any;
+  const { config } = AuthContextProvider() as any;
+  const [isAllowed, ht] = useAllowed();
+  const toast = useToast();
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const [tab, setTab] = useState<"pago" | "prox">("pago");
+  const [importe, setImporte] = useState("");
+  const [fecha, setFecha] = useState(() => new Date().toISOString().slice(0, 10));
+  const [detOpen, setDetOpen] = useState(false);
+  const [medioPago, setMedioPago] = useState("");
+  const [pagadoPor, setPagadoPor] = useState("");
+  const [wp, setWp] = useState(false);
+  const [concepto, setConcepto] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const cur = event?.presupuesto_objeto?.currency;
+  const categoria = event?.presupuesto_objeto?.categorias_array?.find((c: any) => c._id === categoriaId);
+  const gasto = categoria?.gastos_array?.find((g: any) => g._id === gastoId);
+  const costeFinal = gasto?.coste_final || 0;
+  const pagado = gasto?.pagado || 0;
+  const porPagar = costeFinal - pagado;
+  const esPago = tab === "pago";
+
+  const save = async () => {
+    if (!isAllowed()) { ht(); return; }
+    const imp = parseEs(importe);
+    if (!imp) { toast("error", t("Importe requerido")); return; }
+    if (!fecha) { toast("error", t("Selecciona una fecha")); return; }
+    if (saving) return;
+    setSaving(true);
+    try {
+      let soporte: any = null;
+      if (esPago && file) {
+        try {
+          const up: any = await fetchApiBodas({
+            query: queries.singleUpload,
+            variables: { file, development: config?.development || "bodasdehoy", eventId: event?._id, category: "payment" },
+            type: "formData",
+          });
+          const url = up?.file?.publicUrls?.optimized400w ?? up?.file?.publicUrls?.optimized800w ?? up?.file?.publicUrls?.original ?? null;
+          if (url) soporte = { image_url: url, medium_url: url, thumb_url: url };
+        } catch { toast("error", t("Error al subir la imagen")); }
+      }
+      const pago = {
+        importe: imp,
+        estado: esPago ? "pagado" : "pendiente",
+        fecha_pago: esPago ? fecha : "",
+        fecha_vencimiento: esPago ? "" : fecha,
+        pagado_por: esPago ? (wp ? "wedding planer" : pagadoPor) : "",
+        medio_pago: esPago ? medioPago : "",
+        concepto,
+        soporte,
+      };
+      const result: any = await fetchApiEventos({
+        query: queries.nuevoPago,
+        variables: { evento_id: event._id, categoria_id: categoriaId, gasto_id: gastoId, pagos_array: [pago] },
+      });
+      if (result?.success === false && result?.errors?.length) { toast("error", t("Ha ocurrido un error")); setSaving(false); return; }
+      const po = result?.evento?.presupuesto_objeto;
+      if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po }));
+      toast("success", esPago ? t("Pago registrado") : t("Próximo pago programado"));
+      onClose();
+    } catch (e) {
+      toast("error", t("Ha ocurrido un error"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!mounted || typeof document === "undefined" || !gasto) return null;
+
+  const chips = [
+    { l: t("Coste final"), v: getCurrency(costeFinal, cur), bg: "#faf9fb", bd: "#f0f0f2", fg: "#3A3A42", lc: "#a0a0a8" },
+    { l: t("Pagado"), v: getCurrency(pagado, cur), bg: "#E4F5EE", bd: "#B7E3CE", fg: "#1E8F63", lc: "#1E8F63" },
+    { l: t("Por pagar"), v: getCurrency(porPagar, cur), bg: "#FBE4EF", bd: "#F6C4DB", fg: "#D83E7C", lc: "#D83E7C" },
+  ];
+
+  const Toggle: FC<{ on: boolean }> = ({ on }) => (
+    <span style={{ width: 26, height: 14, borderRadius: 999, background: on ? "#EF5B94" : "#d8d8dd", position: "relative", display: "inline-block", transition: "background .15s", flex: "none" }}>
+      <span style={{ position: "absolute", top: 2, left: on ? 14 : 2, width: 10, height: 10, borderRadius: "50%", background: "#fff", transition: "left .15s" }} />
+    </span>
+  );
+
+  return createPortal(
+    <div onClick={onClose} style={{ position: "fixed", inset: 0, background: "rgba(30,30,40,.38)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9999, padding: 20, fontFamily: "'Poppins',sans-serif" }}>
+      <style dangerouslySetInnerHTML={{ __html: ".ap-in:focus{border-color:#EF5B94!important;}.ap-close:hover{background:#faf9fb!important;color:#3A3A42!important;}.ap-pill:hover{background:#FBE4EF!important;}.ap-link:hover{color:#D83E7C!important;}.ap-cta:hover{background:#D83E7C!important;}.ap-drop:hover{border-color:#EF5B94!important;color:#EF5B94!important;background:#FEF7FA!important;}" }} />
+      <div onClick={(e) => e.stopPropagation()} style={{ background: "#fff", borderRadius: 16, boxShadow: "0 20px 50px rgba(0,0,0,.2)", width: "min(540px,92vw)", maxHeight: "86vh", overflow: "auto", padding: "24px 26px", animation: "grow .25s ease" }}>
+        {/* Cabecera */}
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ font: "600 11.5px Poppins", color: "#a0a0a8", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{cap1(categoria?.nombre)} · {gasto?.nombre}</div>
+            <div style={{ font: "700 18px Poppins", color: "#3A3A42", marginTop: 2 }}>{esPago ? t("Añadir pago") : t("Añadir próximo pago")}</div>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start", flex: "none", marginTop: 2 }}>
+            <button onClick={() => setTab("pago")} style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "none", border: "none", cursor: "pointer", padding: 0, font: "600 12px Poppins", color: esPago ? "#3A3A42" : "#a0a0a8", whiteSpace: "nowrap" }}><Toggle on={esPago} />{t("Añadir pago")}</button>
+            <button onClick={() => setTab("prox")} style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "none", border: "none", cursor: "pointer", padding: 0, font: "600 12px Poppins", color: !esPago ? "#3A3A42" : "#a0a0a8", whiteSpace: "nowrap" }}><Toggle on={!esPago} />{t("Añadir próximo pago")}</button>
+          </div>
+          <button className="ap-close" title={t("Cerrar")} onClick={onClose} style={{ width: 30, height: 30, flex: "none", borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+        </div>
+
+        {/* Resumen chips */}
+        <div style={{ display: "flex", gap: 10, marginTop: 16 }}>
+          {chips.map((c, i) => (
+            <div key={i} style={{ flex: 1, background: c.bg, border: `1px solid ${c.bd}`, borderRadius: 12, padding: "10px 14px" }}>
+              <div style={{ font: "600 11px Poppins", color: c.lc }}>{c.l}</div>
+              <div style={{ font: "700 14px Poppins", color: c.fg, marginTop: 2 }}>{c.v}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Importe + fecha */}
+        <div style={{ display: "grid", gridTemplateColumns: "1.3fr 1fr", gap: 12, marginTop: 16 }}>
+          <div>
+            <div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Importe")}</div>
+            <input className="ap-in" autoFocus value={importe} onChange={(e) => setImporte(e.target.value)} placeholder="0,00 €" style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "700 16px Poppins", color: "#3A3A42", outline: "none" }} />
+            {porPagar > 0 && (
+              <button className="ap-pill" onClick={() => setImporte(String(porPagar))} style={{ marginTop: 8, display: "inline-flex", alignItems: "center", gap: 6, background: "#FCE7F0", border: "none", borderRadius: 999, padding: "6px 14px", font: "600 11.5px Poppins", color: "#D83E7C", cursor: "pointer", whiteSpace: "nowrap" }}>{t("Pagar todo lo pendiente")} ({getCurrency(porPagar, cur)})</button>
+            )}
+          </div>
+          <div>
+            <div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{esPago ? t("Fecha de pago") : t("Fecha de futuro pago")}</div>
+            <input className="ap-in" type="date" value={fecha} onChange={(e) => setFecha(e.target.value)} style={{ width: "100%", padding: "12px 12px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+          </div>
+        </div>
+
+        {/* Detalles opcionales */}
+        <button className="ap-link" onClick={() => setDetOpen((v) => !v)} style={{ marginTop: 16, display: "inline-flex", alignItems: "center", gap: 7, background: "none", border: "none", cursor: "pointer", font: "600 12.5px Poppins", color: "#EF5B94", padding: 0, whiteSpace: "nowrap" }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ transform: detOpen ? "rotate(90deg)" : "none", transition: "transform .18s" }}><path d="M9 6l6 6-6 6" /></svg>
+          {t("Añadir detalles (opcional)")}
+        </button>
+        {detOpen && (
+          <div>
+            {esPago && (
+              <div style={{ marginTop: 14 }}>
+                <div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Modo de pago")}</div>
+                <input className="ap-in" value={medioPago} onChange={(e) => setMedioPago(e.target.value)} placeholder={t("Transferencia, tarjeta, efectivo…") as string} style={{ width: "100%", padding: "10px 12px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+              </div>
+            )}
+            {esPago && (
+              <div style={{ marginTop: 14 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
+                  <span style={{ font: "600 12px Poppins", color: "#6b6b72" }}>{t("Pagado por")}</span>
+                  <label onClick={() => setWp((v) => !v)} style={{ display: "inline-flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+                    <span style={{ width: 18, height: 18, borderRadius: 6, display: "inline-flex", alignItems: "center", justifyContent: "center", background: wp ? "#EF5B94" : "#fff", border: `1.5px solid ${wp ? "#EF5B94" : "#d8d8dd"}`, color: "#fff", fontSize: 11 }}>{wp ? "✓" : ""}</span>
+                    <span style={{ font: "500 12px Poppins", color: "#6b6b72" }}>{t("Wedding Planner")}</span>
+                  </label>
+                </div>
+                {!wp && <input className="ap-in" value={pagadoPor} onChange={(e) => setPagadoPor(e.target.value)} placeholder={t("Nombre de quien paga") as string} style={{ width: "100%", padding: "10px 12px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />}
+              </div>
+            )}
+            <div style={{ marginTop: 14 }}>
+              <div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Concepto del pago")}</div>
+              <input className="ap-in" value={concepto} onChange={(e) => setConcepto(e.target.value)} placeholder={t("Ej. Reserva, primer plazo…") as string} style={{ width: "100%", padding: "10px 12px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+            </div>
+            {esPago && (
+              <div style={{ marginTop: 16 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+                  <span style={{ font: "600 12px Poppins", color: "#6b6b72" }}>{t("Cargar documento")}</span>
+                  <span style={{ font: "600 10px Poppins", color: "#1E8F63", background: "#E4F5EE", borderRadius: 999, padding: "2px 8px" }}>PRO</span>
+                </div>
+                <input ref={fileRef} type="file" accept="image/*,application/pdf" style={{ display: "none" }} onChange={(e) => setFile(e.target.files?.[0] || null)} />
+                <div className="ap-drop" onClick={() => fileRef.current?.click()} style={{ border: "1.5px dashed #d8d8dd", borderRadius: 12, padding: 18, display: "flex", alignItems: "center", justifyContent: "center", gap: 8, color: file ? "#EF5B94" : "#a0a0a8", font: "500 12px Poppins", cursor: "pointer", textAlign: "center" }}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 15V3M7 8l5-5 5 5M4 21h16" /></svg>
+                  {file ? file.name : t("Arrastra o haz clic para subir el justificante")}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* CTA */}
+        <button className="ap-cta" onClick={save} disabled={saving} style={{ width: "100%", marginTop: 20, padding: 13, borderRadius: 10, background: "#EF5B94", color: "#fff", border: "none", font: "600 13.5px Poppins", cursor: saving ? "default" : "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)", opacity: saving ? 0.7 : 1 }}>{esPago ? t("Añadir pago") : t("Añadir próximo pago")}</button>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ModalAddPagoStudio;

--- a/apps/appEventos/components/Presupuesto/ModalAddPagoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/ModalAddPagoStudio.tsx
@@ -14,27 +14,28 @@ const parseEs = (s: string) => {
   return Number.isNaN(n) ? 0 : n;
 };
 
-interface Props { categoriaId: string; gastoId: string; onClose: () => void; }
+interface Props { categoriaId: string; gastoId: string; onClose: () => void; pago?: any; }
 
-const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose }) => {
+const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose, pago }) => {
   const { t } = useTranslation();
   const { event, setEvent } = EventContextProvider() as any;
   const { config } = AuthContextProvider() as any;
   const [isAllowed, ht] = useAllowed();
   const toast = useToast();
   const fileRef = useRef<HTMLInputElement>(null);
+  const editing = !!pago;
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
-  const [tab, setTab] = useState<"pago" | "prox">("pago");
-  const [importe, setImporte] = useState("");
-  const [fecha, setFecha] = useState(() => new Date().toISOString().slice(0, 10));
-  const [detOpen, setDetOpen] = useState(false);
-  const [medioPago, setMedioPago] = useState("");
-  const [pagadoPor, setPagadoPor] = useState("");
-  const [wp, setWp] = useState(false);
-  const [concepto, setConcepto] = useState("");
+  const [tab, setTab] = useState<"pago" | "prox">(pago?.estado === "pendiente" ? "prox" : "pago");
+  const [importe, setImporte] = useState(pago ? String(pago.importe ?? "") : "");
+  const [fecha, setFecha] = useState(() => pago ? (pago.fecha_pago || pago.fecha_vencimiento || new Date().toISOString().slice(0, 10)) : new Date().toISOString().slice(0, 10));
+  const [detOpen, setDetOpen] = useState(!!pago);
+  const [medioPago, setMedioPago] = useState(pago?.medio_pago || "");
+  const [pagadoPor, setPagadoPor] = useState(pago?.pagado_por && pago.pagado_por !== "wedding planer" ? pago.pagado_por : "");
+  const [wp, setWp] = useState(pago?.pagado_por === "wedding planer");
+  const [concepto, setConcepto] = useState(pago?.concepto || "");
   const [file, setFile] = useState<File | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -66,7 +67,8 @@ const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose }) => {
           if (url) soporte = { image_url: url, medium_url: url, thumb_url: url };
         } catch { toast("error", t("Error al subir la imagen")); }
       }
-      const pago = {
+      const pagoObj = {
+        ...(editing ? pago : {}),
         importe: imp,
         estado: esPago ? "pagado" : "pendiente",
         fecha_pago: esPago ? fecha : "",
@@ -74,16 +76,15 @@ const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose }) => {
         pagado_por: esPago ? (wp ? "wedding planer" : pagadoPor) : "",
         medio_pago: esPago ? medioPago : "",
         concepto,
-        soporte,
+        ...(soporte ? { soporte } : {}),
       };
-      const result: any = await fetchApiEventos({
-        query: queries.nuevoPago,
-        variables: { evento_id: event._id, categoria_id: categoriaId, gasto_id: gastoId, pagos_array: [pago] },
-      });
+      const result: any = editing
+        ? await fetchApiEventos({ query: queries.editPago, variables: { evento_id: event._id, categoria_id: categoriaId, gasto_id: gastoId, pago_id: pago._id, pagos_array: [pagoObj] } })
+        : await fetchApiEventos({ query: queries.nuevoPago, variables: { evento_id: event._id, categoria_id: categoriaId, gasto_id: gastoId, pagos_array: [pagoObj] } });
       if (result?.success === false && result?.errors?.length) { toast("error", t("Ha ocurrido un error")); setSaving(false); return; }
       const po = result?.evento?.presupuesto_objeto;
       if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po }));
-      toast("success", esPago ? t("Pago registrado") : t("Próximo pago programado"));
+      toast("success", editing ? t("Pago actualizado") : esPago ? t("Pago registrado") : t("Próximo pago programado"));
       onClose();
     } catch (e) {
       toast("error", t("Ha ocurrido un error"));
@@ -114,7 +115,7 @@ const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose }) => {
         <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ font: "600 11.5px Poppins", color: "#a0a0a8", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{cap1(categoria?.nombre)} · {gasto?.nombre}</div>
-            <div style={{ font: "700 18px Poppins", color: "#3A3A42", marginTop: 2 }}>{esPago ? t("Añadir pago") : t("Añadir próximo pago")}</div>
+            <div style={{ font: "700 18px Poppins", color: "#3A3A42", marginTop: 2 }}>{editing ? t("Editar pago") : esPago ? t("Añadir pago") : t("Añadir próximo pago")}</div>
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start", flex: "none", marginTop: 2 }}>
             <button onClick={() => setTab("pago")} style={{ display: "inline-flex", alignItems: "center", gap: 8, background: "none", border: "none", cursor: "pointer", padding: 0, font: "600 12px Poppins", color: esPago ? "#3A3A42" : "#a0a0a8", whiteSpace: "nowrap" }}><Toggle on={esPago} />{t("Añadir pago")}</button>
@@ -194,7 +195,7 @@ const ModalAddPagoStudio: FC<Props> = ({ categoriaId, gastoId, onClose }) => {
         )}
 
         {/* CTA */}
-        <button className="ap-cta" onClick={save} disabled={saving} style={{ width: "100%", marginTop: 20, padding: 13, borderRadius: 10, background: "#EF5B94", color: "#fff", border: "none", font: "600 13.5px Poppins", cursor: saving ? "default" : "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)", opacity: saving ? 0.7 : 1 }}>{esPago ? t("Añadir pago") : t("Añadir próximo pago")}</button>
+        <button className="ap-cta" onClick={save} disabled={saving} style={{ width: "100%", marginTop: 20, padding: 13, borderRadius: 10, background: "#EF5B94", color: "#fff", border: "none", font: "600 13.5px Poppins", cursor: saving ? "default" : "pointer", boxShadow: "0 6px 16px rgba(239,91,148,.3)", opacity: saving ? 0.7 : 1 }}>{editing ? t("Guardar cambios") : esPago ? t("Añadir pago") : t("Añadir próximo pago")}</button>
       </div>
     </div>,
     document.body

--- a/apps/appEventos/components/Presupuesto/PagosStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PagosStudio.tsx
@@ -1,0 +1,120 @@
+import { FC, useState } from "react";
+import { EventContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+import { fetchApiEventos, queries } from "../../utils/Fetching";
+import { getCurrency } from "../../utils/Funciones";
+import { useAllowed } from "../../hooks/useAllowed";
+import { useToast } from "../../hooks/useToast";
+import ClickAwayListener from "react-click-away-listener";
+import ModalAddPagoStudio from "./ModalAddPagoStudio";
+
+const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
+const COLS = "2.4fr 112px 105px 100px 18px 1.1fr 1.1fr 40px";
+
+interface Props { categorias: any[]; estado: "pagado" | "pendiente"; }
+
+const PagosStudio: FC<Props> = ({ categorias, estado }) => {
+  const { t } = useTranslation();
+  const { event, setEvent } = EventContextProvider() as any;
+  const [isAllowed, ht] = useAllowed();
+  const toast = useToast();
+  const cur = event?.presupuesto_objeto?.currency;
+
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const [menuAt, setMenuAt] = useState<string | null>(null);
+  const [modalTarget, setModalTarget] = useState<{ cat: string; gasto: string; pago: any } | null>(null);
+
+  const cats = Array.isArray(categorias) ? categorias : [];
+  const isOpen = (id: string) => open[id] !== false;
+
+  // Agrupar pagos por categoría (cada fila = un pago del estado pedido).
+  const grupos = cats.map((c) => {
+    const rows: any[] = [];
+    (c.gastos_array || []).filter((g: any) => g?.estatus !== false).forEach((g: any) => {
+      (g.pagos_array || []).filter((p: any) => p?.estado === estado).forEach((p: any) => rows.push({ gasto: g, pago: p }));
+    });
+    return { c, rows };
+  }).filter((x) => x.rows.length > 0);
+
+  const applyPO = (result: any) => { const po = result?.evento?.presupuesto_objeto; if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po })); };
+
+  const delPago = async (cat: any, gasto: any, pago: any) => {
+    if (!isAllowed()) { ht(); return; }
+    try { applyPO(await fetchApiEventos({ query: queries.deletepayment, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id, pago_id: pago._id } })); toast("success", t("Pago eliminado")); }
+    catch { toast("error", t("Ha ocurrido un error")); }
+  };
+
+  const chip = estado === "pagado"
+    ? { bg: "#E4F5EE", fg: "#2FB37E", label: t("Pagado"), icon: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#2FB37E" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg> }
+    : { bg: "#FBF0DA", fg: "#B4801F", label: t("Pendiente"), icon: <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#B4801F" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9" /><path d="M12 8v4l3 2" /></svg> };
+
+  return (
+    <div>
+      <style dangerouslySetInnerHTML={{ __html: `
+        .pg-row:hover{background:#faf9fb;}
+        .pg-ghead:hover{background:#f4f3f6!important;}
+        .pg-dots:hover{background:#faf9fb!important;color:#6b6b72!important;}
+        .pg-menu button:hover{background:#FCE7F0;color:#D83E7C;}
+        .pg-menu .pg-del:hover{background:#FBE4EF;}
+        .pg-scrollx{overflow-x:auto;scrollbar-width:none;-ms-overflow-style:none;}
+        .pg-scrollx::-webkit-scrollbar{display:none;}
+      `}} />
+
+      {modalTarget && <ModalAddPagoStudio categoriaId={modalTarget.cat} gastoId={modalTarget.gasto} pago={modalTarget.pago} onClose={() => setModalTarget(null)} />}
+
+      <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+        <div className="pg-scrollx">
+          <div style={{ minWidth: 820 }}>
+            <div style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, padding: "14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
+              <div>{t("Registro")}</div><div>{t("Estado")}</div><div>{estado === "pagado" ? t("Fecha de pago") : t("Fecha de vencimiento")}</div><div style={{ textAlign: "right" }}>{t("Importe")}</div><div /><div>{t("Modo de pago")}</div><div>{t("Concepto")}</div><div />
+            </div>
+
+            {grupos.length === 0 && (
+              <div style={{ padding: "40px 22px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{estado === "pagado" ? t("Aún no hay pagos registrados") : t("No hay pagos pendientes")}</div>
+            )}
+
+            {grupos.map(({ c, rows }) => {
+              const abierto = isOpen(c._id);
+              return (
+                <div key={c._id}>
+                  <div className="pg-ghead" onClick={() => setOpen((o) => ({ ...o, [c._id]: !abierto }))} style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 22px", background: "#faf9fb", borderBottom: "1px solid #f6f6f8", cursor: "pointer" }}>
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8a8a90" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ transform: abierto ? "none" : "rotate(-90deg)", transition: "transform .15s" }}><path d="M6 9l6 6 6-6" /></svg>
+                    <span style={{ font: "500 14px Poppins", color: "#5a5a62" }}>{cap1(c.nombre)}</span>
+                    <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", minWidth: 20, height: 20, padding: "0 6px", borderRadius: 999, background: "#ecebef", color: "#8a8a90", font: "700 11px Poppins" }}>{rows.length}</span>
+                  </div>
+                  {abierto && rows.map(({ gasto, pago }: any) => {
+                    const key = c._id + "|" + gasto._id + "|" + pago._id;
+                    return (
+                      <div key={key} className="pg-row" onClick={() => setModalTarget({ cat: c._id, gasto: gasto._id, pago: null })} style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, alignItems: "center", padding: "12px 22px", borderBottom: "1px solid #f6f6f8", cursor: "pointer" }}>
+                        <div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={gasto.nombre}>{gasto.nombre}</div>
+                        <div><span style={{ display: "inline-flex", alignItems: "center", gap: 6, background: chip.bg, color: chip.fg, borderRadius: 999, padding: "5px 12px", font: "600 11.5px Poppins", whiteSpace: "nowrap" }}>{chip.icon}{chip.label}</span></div>
+                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{estado === "pagado" ? (pago.fecha_pago || "—") : (pago.fecha_vencimiento || pago.fecha_pago || "—")}</div>
+                        <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(pago.importe || 0, cur)}</div>
+                        <div />
+                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.medio_pago}>{pago.medio_pago || "—"}</div>
+                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.concepto}>{pago.concepto || "—"}</div>
+                        <div style={{ position: "relative", display: "flex", justifyContent: "center" }} onClick={(e) => e.stopPropagation()}>
+                          <button className="pg-dots" onClick={(e) => { e.stopPropagation(); setMenuAt(menuAt === key ? null : key); }} style={{ width: 28, height: 28, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.8" /><circle cx="12" cy="12" r="1.8" /><circle cx="12" cy="19" r="1.8" /></svg></button>
+                          {menuAt === key && (
+                            <ClickAwayListener onClickAway={() => setMenuAt(null)}>
+                              <div className="pg-menu" style={{ position: "absolute", top: -6, right: "calc(100% + 6px)", zIndex: 45, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 12, boxShadow: "0 14px 36px rgba(0,0,0,.16)", padding: 8, width: 150, textAlign: "left" }}>
+                                <button onClick={() => { setMenuAt(null); if (!isAllowed()) { ht(); return; } setModalTarget({ cat: c._id, gasto: gasto._id, pago }); }} style={{ display: "flex", alignItems: "center", gap: 9, width: "100%", padding: "8px 10px", borderRadius: 8, background: "none", border: "none", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42", textAlign: "left" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" /></svg>{t("Editar")}</button>
+                                <button className="pg-del" onClick={() => { setMenuAt(null); delPago(c, gasto, pago); }} style={{ display: "flex", alignItems: "center", gap: 9, width: "100%", padding: "8px 10px", borderRadius: 8, background: "none", border: "none", cursor: "pointer", font: "500 12.5px Poppins", color: "#D83E7C", textAlign: "left" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg>{t("Eliminar")}</button>
+                              </div>
+                            </ClickAwayListener>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PagosStudio;

--- a/apps/appEventos/components/Presupuesto/PagosStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PagosStudio.tsx
@@ -9,7 +9,10 @@ import ClickAwayListener from "react-click-away-listener";
 import ModalAddPagoStudio from "./ModalAddPagoStudio";
 
 const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
-const COLS = "2.4fr 112px 105px 100px 18px 1.1fr 1.1fr 40px";
+// Pago (pagado): Registro·Estado·Fecha de pago·Importe·(sep)·Modo de pago·Concepto·⋮
+const COLS_PAGADO = "2.4fr 112px 105px 100px 18px 1.1fr 1.1fr 40px";
+// Pagos pendientes: Registro·Estado·Fecha futuro pago·Concepto·⋮
+const COLS_PEND = "1.2fr 130px 150px 1.6fr 40px";
 
 interface Props { categorias: any[]; estado: "pagado" | "pendiente"; }
 
@@ -26,6 +29,9 @@ const PagosStudio: FC<Props> = ({ categorias, estado }) => {
 
   const cats = Array.isArray(categorias) ? categorias : [];
   const isOpen = (id: string) => open[id] !== false;
+  const isPagado = estado === "pagado";
+  const COLS = isPagado ? COLS_PAGADO : COLS_PEND;
+  const minW = isPagado ? 820 : 620;
 
   // Agrupar pagos por categoría (cada fila = un pago del estado pedido).
   const grupos = cats.map((c) => {
@@ -64,9 +70,11 @@ const PagosStudio: FC<Props> = ({ categorias, estado }) => {
 
       <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
         <div className="pg-scrollx">
-          <div style={{ minWidth: 820 }}>
+          <div style={{ minWidth: minW }}>
             <div style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, padding: "14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
-              <div>{t("Registro")}</div><div>{t("Estado")}</div><div>{estado === "pagado" ? t("Fecha de pago") : t("Fecha de vencimiento")}</div><div style={{ textAlign: "right" }}>{t("Importe")}</div><div /><div>{t("Modo de pago")}</div><div>{t("Concepto")}</div><div />
+              {isPagado
+                ? <><div>{t("Registro")}</div><div>{t("Estado")}</div><div>{t("Fecha de pago")}</div><div style={{ textAlign: "right" }}>{t("Importe")}</div><div /><div>{t("Modo de pago")}</div><div>{t("Concepto")}</div><div /></>
+                : <><div>{t("Registro")}</div><div>{t("Estado")}</div><div>{t("Fecha futuro pago")}</div><div>{t("Concepto")}</div><div /></>}
             </div>
 
             {grupos.length === 0 && (
@@ -88,11 +96,20 @@ const PagosStudio: FC<Props> = ({ categorias, estado }) => {
                       <div key={key} className="pg-row" onClick={() => setModalTarget({ cat: c._id, gasto: gasto._id, pago: null })} style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, alignItems: "center", padding: "12px 22px", borderBottom: "1px solid #f6f6f8", cursor: "pointer" }}>
                         <div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={gasto.nombre}>{gasto.nombre}</div>
                         <div><span style={{ display: "inline-flex", alignItems: "center", gap: 6, background: chip.bg, color: chip.fg, borderRadius: 999, padding: "5px 12px", font: "600 11.5px Poppins", whiteSpace: "nowrap" }}>{chip.icon}{chip.label}</span></div>
-                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{estado === "pagado" ? (pago.fecha_pago || "—") : (pago.fecha_vencimiento || pago.fecha_pago || "—")}</div>
-                        <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(pago.importe || 0, cur)}</div>
-                        <div />
-                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.medio_pago}>{pago.medio_pago || "—"}</div>
-                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.concepto}>{pago.concepto || "—"}</div>
+                        {isPagado ? (
+                          <>
+                            <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{pago.fecha_pago || "—"}</div>
+                            <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(pago.importe || 0, cur)}</div>
+                            <div />
+                            <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.medio_pago}>{pago.medio_pago || "—"}</div>
+                            <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.concepto}>{pago.concepto || "—"}</div>
+                          </>
+                        ) : (
+                          <>
+                            <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{pago.fecha_vencimiento || pago.fecha_pago || "—"}</div>
+                            <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={pago.concepto}>{pago.concepto || "—"}</div>
+                          </>
+                        )}
                         <div style={{ position: "relative", display: "flex", justifyContent: "center" }} onClick={(e) => e.stopPropagation()}>
                           <button className="pg-dots" onClick={(e) => { e.stopPropagation(); setMenuAt(menuAt === key ? null : key); }} style={{ width: 28, height: 28, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.8" /><circle cx="12" cy="12" r="1.8" /><circle cx="12" cy="19" r="1.8" /></svg></button>
                           {menuAt === key && (

--- a/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
@@ -7,8 +7,6 @@ import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
 import ClickAwayListener from "react-click-away-listener";
 import ModalAddPagoStudio from "./ModalAddPagoStudio";
-import { EventInfoModal } from "./PresupuestoV2/modals/EventInfoModal";
-import { ColumnsConfigModal } from "./PresupuestoV2/modals/ColumnsConfigModal";
 
 const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
 const parseEs = (s: string) => { const n = parseFloat(String(s).replace(/[^\d.,]/g, "").replace(/\./g, "").replace(",", ".")); return Number.isNaN(n) ? 0 : n; };
@@ -36,6 +34,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
   const onFilterChange = (type: any, value: any) => setFilters((f: any) => ({ ...f, [type]: value }));
   const onClearFilters = () => setFilters(EMPTY_FILTERS);
   const [viewLevel, setViewLevel] = useState(3);
+  const [guestMode, setGuestMode] = useState<"conf" | "est">("conf");
   const [editRow, setEditRow] = useState<string | null>(null);
   const [editVals, setEditVals] = useState<{ nombre: string; coste_estimado: string; coste_final: string }>({ nombre: "", coste_estimado: "", coste_final: "" });
 
@@ -112,7 +111,22 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
   const cellStyle = (align: string): any => ({ textAlign: align === "left" ? "left" : align, minWidth: 0 });
   const editInput: any = { width: "100%", padding: "5px 7px", borderRadius: 7, border: "1.5px solid #EF5B94", font: "500 12px Poppins", color: "#3A3A42", outline: "none", boxSizing: "border-box" };
   const filtersActive = filters.categories.length > 0 || filters.paymentStatus !== "all";
-  const formatNumber = (v: number) => getCurrency(v, cur);
+
+  // Info evento
+  const confAdults = (Array.isArray(event?.invitados_array) ? event.invitados_array : []).filter((i: any) => !i.edad || i.edad >= 18 || i.tipo === "adulto").length;
+  const confChildren = (Array.isArray(event?.invitados_array) ? event.invitados_array : []).filter((i: any) => (i.edad && i.edad < 18) || i.tipo === "niño").length;
+  const estAdults = event?.presupuesto_objeto?.totalStimatedGuests?.adults || 0;
+  const estChildren = event?.presupuesto_objeto?.totalStimatedGuests?.children || 0;
+  const guests = guestMode === "conf"
+    ? { n: confAdults + confChildren, ad: confAdults, kid: confChildren, label: t("Invitados confirmados") }
+    : { n: estAdults + estChildren, ad: estAdults, kid: estChildren, label: t("Invitados estimados") };
+  const pct = totals.tot > 0 ? Math.round((totals.pag / totals.tot) * 100) : 0;
+  const totalGastos = cats.reduce((a, c) => a + ((c.gastos_array?.length) || 0), 0);
+  const COLUMNAS = [
+    { k: "gasto", l: t("Partida de gasto") }, { k: "unidad", l: t("Unidad") }, { k: "cantidad", l: t("Cantidad") },
+    { k: "valor_unitario", l: t("Valor unitario") }, { k: "coste_final", l: t("Coste total") }, { k: "coste_estimado", l: t("Coste estimado") },
+    { k: "pagado", l: t("Pagado") }, { k: "pendiente_pagar", l: t("Pendiente") }, { k: "options", l: t("Acciones") },
+  ];
 
   return (
     <div style={{ position: "relative" }}>
@@ -316,11 +330,83 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         );
       })()}
       {panel === "info" && (
-        <EventInfoModal event={event} currency={cur} categorias_array={cats} totalStimatedGuests={event?.presupuesto_objeto?.totalStimatedGuests ?? { adults: 0, children: 0 }} totals={tableTotals} formatNumber={formatNumber} onClose={() => setPanel(null)} />
+        <div style={{ position: "absolute", top: 48, left: 12, zIndex: 50, width: 340, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+          <div style={{ display: "flex", alignItems: "center", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
+            <div style={{ font: "700 15px Poppins", color: "#3A3A42", flex: 1 }}>{t("Información del evento")}</div>
+            <button className="pd-x" onClick={() => setPanel(null)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+          </div>
+          <div style={{ padding: "16px 18px", display: "flex", flexDirection: "column", gap: 16 }}>
+            {/* Resumen de invitados */}
+            <div>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10, gap: 10 }}>
+                <div style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{t("Resumen de invitados")}</div>
+                <div style={{ display: "flex", background: "#faf9fb", border: "1px solid #ececef", borderRadius: 10, padding: 3 }}>
+                  {[{ k: "conf", l: t("Confirmados") }, { k: "est", l: t("Estimados") }].map((m) => {
+                    const on = guestMode === m.k;
+                    return <button key={m.k} onClick={() => setGuestMode(m.k as any)} style={{ padding: "5px 12px", borderRadius: 8, border: "none", cursor: "pointer", font: "600 11.5px Poppins", background: on ? "#fff" : "transparent", color: on ? "#EF5B94" : "#8a8a90", boxShadow: on ? "0 2px 6px rgba(0,0,0,.08)" : "none" }}>{m.l}</button>;
+                  })}
+                </div>
+              </div>
+              <div style={{ border: "1.5px solid #ececef", borderRadius: 12, padding: 16, textAlign: "center" }}>
+                <div style={{ font: "700 26px Poppins", color: "#EF5B94" }}>{guests.n}</div>
+                <div style={{ font: "700 10px Poppins", color: "#8a8a90", letterSpacing: ".8px", textTransform: "uppercase", marginTop: 2 }}>{guests.label}</div>
+                <div style={{ display: "flex", justifyContent: "center", gap: 34, marginTop: 12 }}>
+                  <div><div style={{ font: "600 16px Poppins", color: "#3A3A42" }}>{guests.ad}</div><div style={{ font: "500 11px Poppins", color: "#a0a0a8" }}>{t("Adultos")}</div></div>
+                  <div style={{ width: 1, background: "#ececef" }} />
+                  <div><div style={{ font: "600 16px Poppins", color: "#3A3A42" }}>{guests.kid}</div><div style={{ font: "500 11px Poppins", color: "#a0a0a8" }}>{t("Niños")}</div></div>
+                </div>
+              </div>
+            </div>
+            {/* Detalles del evento */}
+            <div>
+              <div style={{ font: "600 13px Poppins", color: "#3A3A42", marginBottom: 8 }}>{t("Detalles del evento")}</div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 7, font: "500 12.5px Poppins" }}>
+                {[
+                  { l: t("Nombre"), v: event?.nombre || "—" },
+                  { l: t("Moneda"), v: (cur || "eur").toUpperCase() },
+                  { l: t("Categorías"), v: String(cats.length) },
+                  { l: t("Total gastos"), v: String(totalGastos) },
+                ].map((r, i) => (
+                  <div key={i} style={{ display: "flex", justifyContent: "space-between" }}><span style={{ color: "#a0a0a8" }}>{r.l}</span><span style={{ color: "#3A3A42", fontWeight: 600 }}>{r.v}</span></div>
+                ))}
+              </div>
+            </div>
+            {/* Progreso del presupuesto */}
+            <div>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 7 }}>
+                <div style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{t("Progreso del presupuesto")}</div>
+                <div style={{ font: "700 13px Poppins", color: "#3A3A42" }}>{pct}%</div>
+              </div>
+              <div style={{ height: 8, borderRadius: 8, background: "#f0f0f2", overflow: "hidden" }}><div style={{ height: "100%", width: `${Math.min(pct, 100)}%`, background: "#EF5B94", borderRadius: 8 }} /></div>
+              <div style={{ display: "flex", justifyContent: "space-between", marginTop: 7, font: "600 11.5px Poppins" }}>
+                <span style={{ color: "#2FB37E" }}>{t("Pagado")}: {getCurrency(totals.pag, cur)}</span>
+                <span style={{ color: "#D83E7C" }}>{t("Pendiente")}: {getCurrency(totals.pen, cur)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
-      {panel === "columnas" && (
-        <ColumnsConfigModal columnConfig={columnConfig} toggleColumnVisibility={toggleColumnVisibility} onClose={() => setPanel(null)} />
-      )}
+      {panel === "columnas" && (() => {
+        const allChecked = COLUMNAS.every((c) => columnConfig[c.k]?.visible !== false);
+        return (
+          <div style={{ position: "absolute", top: 48, right: 12, zIndex: 50, width: 280, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+            <div style={{ display: "flex", alignItems: "center", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
+              <div style={{ font: "700 15px Poppins", color: "#3A3A42", flex: 1 }}>{t("Columnas")}</div>
+              <button className="pd-x" onClick={() => setPanel(null)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+            </div>
+            <label className="pd-cat" style={{ display: "flex", alignItems: "center", gap: 11, padding: "12px 18px", borderBottom: "1px solid #f2f2f4", cursor: "pointer", font: "600 13px Poppins", color: "#3A3A42" }}>
+              <input type="checkbox" checked={allChecked} onChange={(e) => setColumnConfig((cc: any) => { const next = { ...cc }; COLUMNAS.forEach((c) => (next[c.k] = { visible: e.target.checked })); return next; })} style={{ accentColor: "#EF5B94", width: 16, height: 16 }} />{t("Seleccionar todo")}
+            </label>
+            <div className="pd-scrollx" style={{ maxHeight: 400, overflowY: "auto", padding: "4px 0" }}>
+              {COLUMNAS.map((c) => (
+                <label key={c.k} className="pd-cat" style={{ display: "flex", alignItems: "center", gap: 11, padding: "10px 18px", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42" }}>
+                  <input type="checkbox" checked={columnConfig[c.k]?.visible !== false} onChange={() => toggleColumnVisibility(c.k)} style={{ accentColor: "#EF5B94", width: 16, height: 16 }} />{c.l}
+                </label>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 };

--- a/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
@@ -7,7 +7,6 @@ import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
 import ClickAwayListener from "react-click-away-listener";
 import ModalAddPagoStudio from "./ModalAddPagoStudio";
-import { FiltersModal } from "./PresupuestoV2/modals/FiltersModal";
 import { EventInfoModal } from "./PresupuestoV2/modals/EventInfoModal";
 import { ColumnsConfigModal } from "./PresupuestoV2/modals/ColumnsConfigModal";
 
@@ -45,15 +44,15 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
 
   // Columnas (algunas ocultables desde "Columnas")
   const ALL_COLS = [
-    { key: "partida", label: t("Partida de gasto"), w: "minmax(230px,2.2fr)", always: true, align: "left" },
-    { key: "unidad", label: t("Unidad"), w: "80px", align: "center" },
-    { key: "cantidad", label: t("Cantidad"), w: "86px", align: "center" },
-    { key: "valor", label: t("Valor unit."), w: "106px", align: "center" },
-    { key: "coste", label: t("Coste total"), w: "116px", always: true, align: "center" },
-    { key: "estimado", label: t("Estimado"), w: "110px", align: "center" },
-    { key: "pagado", label: t("Pagado"), w: "104px", always: true, align: "center" },
-    { key: "pendiente", label: t("Pendiente"), w: "114px", always: true, align: "center" },
-    { key: "menu", label: "", w: "44px", always: true, align: "center" },
+    { key: "partida", label: t("Partida de gasto"), w: "minmax(180px,2.2fr)", always: true, align: "left" },
+    { key: "unidad", label: t("Unidad"), w: "60px", align: "center" },
+    { key: "cantidad", label: t("Cantidad"), w: "68px", align: "center" },
+    { key: "valor", label: t("Valor unit."), w: "92px", align: "center" },
+    { key: "coste", label: t("Coste total"), w: "100px", always: true, align: "center" },
+    { key: "estimado", label: t("Estimado"), w: "96px", align: "center" },
+    { key: "pagado", label: t("Pagado"), w: "90px", always: true, align: "center" },
+    { key: "pendiente", label: t("Pendiente"), w: "100px", always: true, align: "center" },
+    { key: "menu", label: "", w: "38px", always: true, align: "center" },
   ];
   const COLMAP: any = { partida: "gasto", unidad: "unidad", cantidad: "cantidad", valor: "valor_unitario", coste: "coste_final", estimado: "coste_estimado", pagado: "pagado", pendiente: "pendiente_pagar", menu: "options" };
   const visibleCols = ALL_COLS.filter((c) => columnConfig[COLMAP[c.key]]?.visible !== false);
@@ -65,13 +64,14 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
     return { tot, pag, est, pen: tot - pag, nCat: cats.length, nPart: nP };
   }, [cats]);
   const tableTotals = { estimado: totals.est, total: totals.tot, pagado: totals.pag };
-  const noFilters = filters.categories.length === 0 && filters.paymentStatus === "all";
+  const rmin = parseEs(filters.amountRange.min), rmax = parseEs(filters.amountRange.max);
+  const noFilters = filters.categories.length === 0 && filters.paymentStatus === "all" && filters.visibilityStatus === "all" && !filters.amountRange.min && !filters.amountRange.max;
 
   const ql = q.trim().toLowerCase();
   const filtered = cats.map((c) => {
     if (filters.categories.length && !filters.categories.includes(c._id)) return { c, gastos: [] as any[] };
     const catMatch = String(c.nombre || "").toLowerCase().includes(ql);
-    let gastos = (c.gastos_array || []).filter((g: any) => g?.estatus !== false);
+    let gastos = (c.gastos_array || []).filter((g: any) => filters.visibilityStatus === "hidden" ? g?.estatus === false : g?.estatus !== false);
     gastos = gastos.filter((g: any) => {
       const ct = g.coste_final || 0, pag = g.pagado || 0, pen = ct - pag;
       if (filters.paymentStatus === "paid") return ct > 0 && pen <= 0;
@@ -79,6 +79,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
       if (filters.paymentStatus === "partial") return pag > 0 && pen > 0;
       return true;
     });
+    gastos = gastos.filter((g: any) => { const ct = g.coste_final || 0; if (filters.amountRange.min && ct < rmin) return false; if (filters.amountRange.max && ct > rmax) return false; return true; });
     gastos = gastos.filter((g: any) => !ql || catMatch || String(g.nombre || "").toLowerCase().includes(ql));
     return { c, gastos };
   }).filter((x) => x.gastos.length > 0 || (!ql && noFilters));
@@ -127,6 +128,10 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         .pd-scrollx::-webkit-scrollbar{display:none;}
         .pd-pop label:hover{background:#faf9fb;}
         .pd-search:focus,.pd-search:focus-visible{outline:none!important;box-shadow:none!important;border:none!important;}
+        .pd-fsel:focus,.pd-fin:focus{border-color:#EF5B94!important;}
+        .pd-cat:hover{background:#faf9fb;}
+        .pd-limpiar:hover{color:#D83E7C!important;}
+        .pd-x:hover{background:#faf9fb!important;color:#3A3A42!important;}
       `}} />
 
       {pagoTarget && <ModalAddPagoStudio categoriaId={pagoTarget.cat} gastoId={pagoTarget.gasto} onClose={() => setPagoTarget(null)} />}
@@ -160,8 +165,8 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
 
         {/* Tabla */}
         <div className="pd-scrollx">
-          <div style={{ minWidth: 880 }}>
-            <div style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: 8, padding: "14px 30px 14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
+          <div style={{ minWidth: 820 }}>
+            <div style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: 8, padding: "14px 20px 14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
               {visibleCols.map((c) => <div key={c.key} style={{ textAlign: c.align === "left" ? "left" : c.align } as any}>{c.label}</div>)}
             </div>
 
@@ -229,7 +234,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
                       ),
                     };
                     return (
-                      <div key={g._id} className="pd-row" style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: 8, alignItems: "center", padding: "11px 30px 11px 22px", borderBottom: "1px solid #f4f4f6" }}>
+                      <div key={g._id} className="pd-row" style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: 8, alignItems: "center", padding: "11px 20px 11px 22px", borderBottom: "1px solid #f4f4f6" }}>
                         {visibleCols.map((col) => <div key={col.key} style={cellStyle(col.align)}>{render[col.key]}</div>)}
                       </div>
                     );
@@ -242,9 +247,74 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
       </div>
 
       {/* Modales (fuera del overflow del card; se posicionan absolute top-12 left-3) */}
-      {panel === "filtros" && (
-        <FiltersModal filters={filters} onFilterChange={onFilterChange} onClose={() => setPanel(null)} onClearFilters={onClearFilters} categorias_array={cats} viewLevel={viewLevel} setViewLevel={setViewLevel} />
-      )}
+      {panel === "filtros" && (() => {
+        const selFsel: any = { width: "100%", padding: "9px 12px", border: "1.5px solid #E7E7EA", borderRadius: 10, font: "500 12.5px Poppins", color: "#3A3A42", background: "#fff", outline: "none" };
+        const helpTxt: any = { font: "500 11px Poppins", color: "#a0a0a8", marginTop: 5 };
+        const lblTxt: any = { font: "600 13px Poppins", color: "#3A3A42", marginBottom: 7 };
+        const allChecked = cats.length > 0 && filters.categories.length === cats.length;
+        return (
+          <div style={{ position: "absolute", top: 48, left: 12, zIndex: 50, width: 320, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+            <div style={{ display: "flex", alignItems: "center", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
+              <div style={{ font: "700 15px Poppins", color: "#3A3A42", flex: 1 }}>{t("Filtros")}</div>
+              <button className="pd-limpiar" onClick={() => { onClearFilters(); setViewLevel(3); }} style={{ font: "600 12.5px Poppins", color: "#EF5B94", background: "none", border: "none", cursor: "pointer", padding: "4px 8px" }}>{t("Limpiar")}</button>
+              <button className="pd-x" onClick={() => setPanel(null)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+            </div>
+            <div className="pd-scrollx" style={{ maxHeight: 420, overflowY: "auto", padding: "16px 18px", display: "flex", flexDirection: "column", gap: 16 }}>
+              {/* Vista de detalle */}
+              <div>
+                <div style={lblTxt}>{t("Vista de detalle")}</div>
+                <select className="pd-fsel" value={viewLevel} onChange={(e) => setViewLevel(Number(e.target.value))} style={selFsel}>
+                  <option value={3}>{t("Detalle completo")}</option><option value={1}>{t("Solo categorías")}</option><option value={2}>{t("Categorías y gastos")}</option>
+                </select>
+                <div style={helpTxt}>{viewLevel === 1 ? t("Mostrar únicamente las categorías principales") : viewLevel === 2 ? t("Mostrar categorías y sus gastos asociados") : t("Mostrar todos los elementos: categorías, gastos e ítems")}</div>
+              </div>
+              {/* Filtrar por categorías */}
+              <div>
+                <div style={lblTxt}>{t("Filtrar por categorías")} ({filters.categories.length} {t("seleccionadas")})</div>
+                <div className="pd-scrollx" style={{ border: "1.5px solid #E7E7EA", borderRadius: 10, maxHeight: 150, overflowY: "auto" }}>
+                  <label style={{ display: "flex", alignItems: "center", gap: 9, padding: "9px 12px", borderBottom: "1px solid #f4f4f6", cursor: "pointer", font: "600 12.5px Poppins", color: "#EF5B94" }}>
+                    <input type="checkbox" checked={allChecked} onChange={(e) => onFilterChange("categories", e.target.checked ? cats.map((c) => c._id) : [])} style={{ accentColor: "#EF5B94", width: 15, height: 15 }} />{t("Seleccionar todas")}
+                  </label>
+                  {cats.map((c) => {
+                    const checked = filters.categories.includes(c._id);
+                    return (
+                      <label key={c._id} className="pd-cat" style={{ display: "flex", alignItems: "center", gap: 9, padding: "8px 12px", borderBottom: "1px solid #f8f8fa", cursor: "pointer", font: "500 12.5px Poppins", color: "#6b6b72" }}>
+                        <input type="checkbox" checked={checked} onChange={(e) => onFilterChange("categories", e.target.checked ? [...filters.categories, c._id] : filters.categories.filter((id: string) => id !== c._id))} style={{ accentColor: "#EF5B94", width: 15, height: 15 }} />{cap1(c.nombre)}
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+              {/* Estado de pago */}
+              <div>
+                <div style={lblTxt}>{t("Estado de pago")}</div>
+                <select className="pd-fsel" value={filters.paymentStatus} onChange={(e) => onFilterChange("paymentStatus", e.target.value)} style={selFsel}>
+                  <option value="all">{t("Todos los estados")}</option><option value="paid">{t("Pagado")}</option><option value="pending">{t("Pendiente")}</option><option value="partial">{t("Pago parcial")}</option>
+                </select>
+                <div style={helpTxt}>{t("Mostrar elementos con cualquier estado de pago")}</div>
+              </div>
+              {/* Estado de visibilidad */}
+              <div>
+                <div style={lblTxt}>{t("Estado de visibilidad")}</div>
+                <select className="pd-fsel" value={filters.visibilityStatus} onChange={(e) => onFilterChange("visibilityStatus", e.target.value)} style={selFsel}>
+                  <option value="all">{t("Todos (visibles y ocultos)")}</option><option value="visible">{t("Solo visibles")}</option><option value="hidden">{t("Solo ocultos")}</option>
+                </select>
+                <div style={helpTxt}>{t("Mostrar todos los elementos sin filtrar por visibilidad")}</div>
+              </div>
+              {/* Rango de montos */}
+              <div>
+                <div style={lblTxt}>{t("Rango de montos (coste total)")}</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <input className="pd-fin" type="text" value={filters.amountRange.min} onChange={(e) => onFilterChange("amountRange", { ...filters.amountRange, min: e.target.value })} placeholder={t("Mínimo") as string} style={{ flex: 1, minWidth: 0, padding: "9px 12px", border: "1.5px solid #E7E7EA", borderRadius: 10, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+                  <span style={{ font: "500 12px Poppins", color: "#a0a0a8" }}>{t("a")}</span>
+                  <input className="pd-fin" type="text" value={filters.amountRange.max} onChange={(e) => onFilterChange("amountRange", { ...filters.amountRange, max: e.target.value })} placeholder={t("Máximo") as string} style={{ flex: 1, minWidth: 0, padding: "9px 12px", border: "1.5px solid #E7E7EA", borderRadius: 10, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+                </div>
+                <div style={helpTxt}>{t("Ingresa valores para filtrar por rango de montos")}</div>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
       {panel === "info" && (
         <EventInfoModal event={event} currency={cur} categorias_array={cats} totalStimatedGuests={event?.presupuesto_objeto?.totalStimatedGuests ?? { adults: 0, children: 0 }} totals={tableTotals} formatNumber={formatNumber} onClose={() => setPanel(null)} />
       )}

--- a/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
@@ -1,0 +1,176 @@
+import { FC, useMemo, useState } from "react";
+import { EventContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+import { fetchApiEventos, queries } from "../../utils/Fetching";
+import { getCurrency } from "../../utils/Funciones";
+import { useAllowed } from "../../hooks/useAllowed";
+import { useToast } from "../../hooks/useToast";
+import ClickAwayListener from "react-click-away-listener";
+import ModalAddPagoStudio from "./ModalAddPagoStudio";
+
+const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
+const COLS = "minmax(230px,2.2fr) 70px 76px 96px 110px 110px 100px 110px 44px";
+
+interface Props { categorias: any[]; onAddCategoria: () => void; }
+
+const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) => {
+  const { t } = useTranslation();
+  const { event, setEvent } = EventContextProvider() as any;
+  const [isAllowed, ht] = useAllowed();
+  const toast = useToast();
+  const cur = event?.presupuesto_objeto?.currency;
+
+  const [q, setQ] = useState("");
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const [menuAt, setMenuAt] = useState<string | null>(null);
+  const [pagoTarget, setPagoTarget] = useState<{ cat: string; gasto: string } | null>(null);
+
+  const cats = Array.isArray(categorias) ? categorias : [];
+  const isOpen = (id: string) => open[id] !== false; // default abierto
+
+  const totals = useMemo(() => {
+    let tot = 0, pag = 0;
+    cats.forEach((c) => (c.gastos_array || []).filter((g: any) => g?.estatus !== false).forEach((g: any) => { tot += g.coste_final || 0; pag += g.pagado || 0; }));
+    return { tot, pag, pen: tot - pag };
+  }, [cats]);
+
+  const ql = q.trim().toLowerCase();
+  const filtered = cats.map((c) => {
+    const catMatch = String(c.nombre || "").toLowerCase().includes(ql);
+    const gastos = (c.gastos_array || []).filter((g: any) => g?.estatus !== false).filter((g: any) => !ql || catMatch || String(g.nombre || "").toLowerCase().includes(ql));
+    return { c, gastos };
+  }).filter((x) => !ql || String(x.c.nombre || "").toLowerCase().includes(ql) || x.gastos.length > 0);
+
+  const allOpen = cats.every((c) => isOpen(c._id));
+  const toggleAll = () => { const next: Record<string, boolean> = {}; cats.forEach((c) => (next[c._id] = !allOpen)); setOpen(next); };
+
+  const applyPO = (result: any) => { const po = result?.evento?.presupuesto_objeto; if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po })); };
+
+  const addPartida = async (cat: any) => {
+    if (!isAllowed()) { ht(); return; }
+    try { applyPO(await fetchApiEventos({ query: queries.nuevoGasto, variables: { evento_id: event._id, categoria_id: cat._id, nombre: t("Nueva partida de gasto") } })); }
+    catch { toast("error", t("Ha ocurrido un error")); }
+  };
+  const addItem = async (cat: any, gasto: any) => {
+    if (!isAllowed()) { ht(); return; }
+    try { applyPO(await fetchApiEventos({ query: queries.nuevoItemGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id, itemGasto: { nombre: t("Nuevo item"), cantidad: 1, unidad: "unidad", valor_unitario: 0, total: 0 } } })); }
+    catch { toast("error", t("Ha ocurrido un error")); }
+  };
+  const delGasto = async (cat: any, gasto: any) => {
+    if (!isAllowed()) { ht(); return; }
+    try { applyPO(await fetchApiEventos({ query: queries.borrarGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id } })); toast("success", t("Partida eliminada")); }
+    catch { toast("error", t("Ha ocurrido un error")); }
+  };
+
+  return (
+    <div>
+      <style dangerouslySetInnerHTML={{ __html: `
+        .pd-tool:hover{color:#EF5B94!important;}
+        .pd-row:hover{background:#faf9fb;}
+        .pd-ghead:hover{background:#f4f3f6!important;}
+        .pd-dots:hover{background:#faf9fb!important;color:#6b6b72!important;}
+        .pd-menu button:hover{background:#FCE7F0;color:#D83E7C;}
+        .pd-menu .pd-del:hover{background:#FBE4EF;}
+        .pd-collapse:hover{color:#EF5B94!important;background:#faf9fb!important;}
+        .pd-scrollx{overflow-x:auto;scrollbar-width:none;-ms-overflow-style:none;}
+        .pd-scrollx::-webkit-scrollbar{display:none;}
+      `}} />
+
+      {pagoTarget && <ModalAddPagoStudio categoriaId={pagoTarget.cat} gastoId={pagoTarget.gasto} onClose={() => setPagoTarget(null)} />}
+
+      <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+        {/* Toolbar */}
+        <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "14px 18px", borderBottom: "1px solid #f2f2f4", flexWrap: "wrap" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 180, maxWidth: 300, border: "1.5px solid #E7E7EA", borderRadius: 999, padding: "9px 15px", color: "#a0a0a8" }}>
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></svg>
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={t("Buscar…") as string} style={{ border: "none", background: "none", flex: 1, minWidth: 0, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 28, marginLeft: "auto" }}>
+            <div style={{ textAlign: "right", whiteSpace: "nowrap" }}><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>{t("Total")}</div><div style={{ font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(totals.tot, cur)}</div></div>
+            <div style={{ textAlign: "right", whiteSpace: "nowrap" }}><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>{t("Pagado")}</div><div style={{ font: "700 13px Poppins", color: "#2FB37E" }}>{getCurrency(totals.pag, cur)}</div></div>
+            <div style={{ textAlign: "right", whiteSpace: "nowrap" }}><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>{t("Pendiente")}</div><div style={{ font: "700 13px Poppins", color: "#D83E7C" }}>{getCurrency(totals.pen, cur)}</div></div>
+          </div>
+        </div>
+
+        {/* Contraer / expandir todo */}
+        <div style={{ display: "flex", justifyContent: "flex-end", padding: "8px 22px", borderBottom: "1px solid #f2f2f4" }}>
+          <button className="pd-collapse" onClick={toggleAll} style={{ display: "inline-flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", font: "600 12px Poppins", color: "#8a8a90", padding: "4px 8px", borderRadius: 8 }}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round"><path d="M7 8l5-5 5 5M7 16l5 5 5-5" /></svg>
+            {allOpen ? t("Contraer todo") : t("Expandir todo")}
+          </button>
+        </div>
+
+        {/* Tabla */}
+        <div className="pd-scrollx">
+          <div style={{ minWidth: 880 }}>
+            <div style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, padding: "14px 30px 14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
+              <div>{t("Partida de gasto")}</div><div>{t("Unidad")}</div><div style={{ textAlign: "center" }}>{t("Cantidad")}</div><div style={{ textAlign: "right" }}>{t("Valor unit.")}</div><div style={{ textAlign: "right" }}>{t("Coste total")}</div><div style={{ textAlign: "right" }}>{t("Estimado")}</div><div style={{ textAlign: "right" }}>{t("Pagado")}</div><div style={{ textAlign: "right" }}>{t("Pendiente")}</div><div />
+            </div>
+
+            {filtered.length === 0 && (
+              <div style={{ padding: "34px 22px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{t("Sin resultados")}</div>
+            )}
+
+            {filtered.map(({ c, gastos }) => {
+              const tot = gastos.reduce((a: number, g: any) => a + (g.coste_final || 0), 0);
+              const abierto = isOpen(c._id);
+              return (
+                <div key={c._id}>
+                  <div className="pd-ghead" onClick={() => setOpen((o) => ({ ...o, [c._id]: !abierto }))} style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 22px", background: "#faf9fb", borderBottom: "1px solid #f6f6f8", cursor: "pointer" }}>
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8a8a90" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ transform: abierto ? "none" : "rotate(-90deg)", transition: "transform .15s" }}><path d="M6 9l6 6 6-6" /></svg>
+                    <span style={{ font: "500 14px Poppins", color: "#5a5a62" }}>{cap1(c.nombre)}</span>
+                    <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", minWidth: 20, height: 20, padding: "0 6px", borderRadius: 999, background: "#ecebef", color: "#6b6b72", font: "700 11px Poppins" }}>{gastos.length}</span>
+                    <span style={{ marginLeft: "auto", display: "inline-flex", alignItems: "baseline", gap: 7, whiteSpace: "nowrap" }}><span style={{ font: "500 10.5px Poppins", color: "#a0a0a8", textTransform: "uppercase", letterSpacing: ".4px" }}>{t("Coste total")}</span><span style={{ font: "600 13px Poppins", color: "#3A3A42" }}>{getCurrency(tot, cur)}</span></span>
+                  </div>
+                  {abierto && gastos.map((g: any) => {
+                    const it = (g.items_array || [])[0];
+                    const ct = g.coste_final || 0;
+                    const pag = g.pagado || 0;
+                    const pen = ct - pag;
+                    const key = c._id + "|" + g._id;
+                    return (
+                      <div key={g._id} className="pd-row" style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, alignItems: "center", padding: "11px 30px 11px 22px", borderBottom: "1px solid #f4f4f6" }}>
+                        <div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={g.nombre}>{g.nombre}</div>
+                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{it?.unidad || "—"}</div>
+                        <div style={{ textAlign: "center", font: "500 12.5px Poppins", color: "#6b6b72" }}>{it?.cantidad ?? "—"}</div>
+                        <div style={{ textAlign: "right", font: "500 12.5px Poppins", color: "#6b6b72" }}>{it ? getCurrency(it.valor_unitario || 0, cur) : "—"}</div>
+                        <div style={{ textAlign: "right", font: "700 12.5px Poppins", color: "#3A3A42" }}>{getCurrency(ct, cur)}</div>
+                        <div style={{ textAlign: "right", font: "500 12.5px Poppins", color: "#6b6b72" }}>{getCurrency(g.coste_estimado || 0, cur)}</div>
+                        <div style={{ textAlign: "right", font: "600 12.5px Poppins", color: "#2FB37E" }}>{getCurrency(pag, cur)}</div>
+                        <div style={{ textAlign: "right", font: "700 12.5px Poppins", color: pen > 0 ? "#D83E7C" : "#8a8a90" }}>{getCurrency(pen, cur)}</div>
+                        <div style={{ display: "flex", justifyContent: "center", position: "relative" }}>
+                          <button className="pd-dots" onClick={(e) => { e.stopPropagation(); setMenuAt(menuAt === key ? null : key); }} style={{ width: 28, height: 28, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.7" /><circle cx="12" cy="12" r="1.7" /><circle cx="12" cy="19" r="1.7" /></svg></button>
+                          {menuAt === key && (
+                            <ClickAwayListener onClickAway={() => setMenuAt(null)}>
+                              <div className="pd-menu" onClick={(e) => e.stopPropagation()} style={{ position: "absolute", top: -8, right: "calc(100% + 6px)", zIndex: 45, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, boxShadow: "0 14px 36px rgba(0,0,0,.16)", padding: 14, width: 210, textAlign: "left" }}>
+                                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+                                  <span style={{ font: "700 13px Poppins", color: "#3A3A42", whiteSpace: "nowrap" }}>{t("Opciones disponibles")}</span>
+                                  <button onClick={() => setMenuAt(null)} style={{ width: 22, height: 22, borderRadius: 6, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer", padding: 0 }}><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+                                </div>
+                                <div style={{ font: "600 11px Poppins", color: "#a0a0a8", textTransform: "uppercase", letterSpacing: ".5px", marginBottom: 4 }}>{t("Agregar")}</div>
+                                <button style={btn} onClick={() => { setMenuAt(null); onAddCategoria(); }}>{t("Categoría")}</button>
+                                <button style={btn} onClick={() => { setMenuAt(null); addPartida(c); }}>{t("Partida")}</button>
+                                <button style={btn} onClick={() => { setMenuAt(null); addItem(c, g); }}>{t("Item")}</button>
+                                <div style={{ height: 1, background: "#f2f2f4", margin: "8px 0" }} />
+                                <button style={btn} onClick={() => { setMenuAt(null); if (!isAllowed()) { ht(); return; } setPagoTarget({ cat: c._id, gasto: g._id }); }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><ellipse cx="12" cy="6" rx="7" ry="3" /><path d="M5 6v6c0 1.7 3.1 3 7 3s7-1.3 7-3V6" /><path d="M5 12v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6" /></svg>{t("Relacionar pago")}</button>
+                                <button className="pd-del" style={{ ...btn, color: "#D83E7C" }} onClick={() => { setMenuAt(null); delGasto(c, g); }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg>{t("Borrar")}</button>
+                              </div>
+                            </ClickAwayListener>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const btn: any = { display: "flex", alignItems: "center", gap: 9, padding: "8px 10px", borderRadius: 8, background: "none", border: "none", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42", textAlign: "left", width: "100%" };
+
+export default PresupuestoDetalladoStudio;

--- a/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
@@ -7,11 +7,16 @@ import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
 import ClickAwayListener from "react-click-away-listener";
 import ModalAddPagoStudio from "./ModalAddPagoStudio";
+import { FiltersModal } from "./PresupuestoV2/modals/FiltersModal";
+import { EventInfoModal } from "./PresupuestoV2/modals/EventInfoModal";
+import { ColumnsConfigModal } from "./PresupuestoV2/modals/ColumnsConfigModal";
 
 const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
-const COLS = "minmax(230px,2.2fr) 70px 76px 96px 110px 110px 100px 110px 44px";
+const parseEs = (s: string) => { const n = parseFloat(String(s).replace(/[^\d.,]/g, "").replace(/\./g, "").replace(",", ".")); return Number.isNaN(n) ? 0 : n; };
 
 interface Props { categorias: any[]; onAddCategoria: () => void; }
+
+const menuBtn: any = { display: "flex", alignItems: "center", gap: 9, padding: "8px 10px", borderRadius: 8, background: "none", border: "none", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42", textAlign: "left", width: "100%" };
 
 const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) => {
   const { t } = useTranslation();
@@ -24,46 +29,92 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
   const [open, setOpen] = useState<Record<string, boolean>>({});
   const [menuAt, setMenuAt] = useState<string | null>(null);
   const [pagoTarget, setPagoTarget] = useState<{ cat: string; gasto: string } | null>(null);
+  const [panel, setPanel] = useState<"filtros" | "info" | "columnas" | null>(null);
+  const [columnConfig, setColumnConfig] = useState<any>({ categoria: { visible: true }, gasto: { visible: true }, unidad: { visible: true }, cantidad: { visible: true }, nombre: { visible: true }, valor_unitario: { visible: true }, coste_final: { visible: true }, coste_estimado: { visible: true }, pagado: { visible: true }, pendiente_pagar: { visible: true }, options: { visible: true } });
+  const toggleColumnVisibility = (key: any) => setColumnConfig((c: any) => ({ ...c, [key]: { visible: !c[key]?.visible } }));
+  const EMPTY_FILTERS = { categories: [], paymentStatus: "all", visibilityStatus: "all", amountRange: { min: "", max: "" } };
+  const [filters, setFilters] = useState<any>(EMPTY_FILTERS);
+  const onFilterChange = (type: any, value: any) => setFilters((f: any) => ({ ...f, [type]: value }));
+  const onClearFilters = () => setFilters(EMPTY_FILTERS);
+  const [viewLevel, setViewLevel] = useState(3);
+  const [editRow, setEditRow] = useState<string | null>(null);
+  const [editVals, setEditVals] = useState<{ nombre: string; coste_estimado: string; coste_final: string }>({ nombre: "", coste_estimado: "", coste_final: "" });
 
   const cats = Array.isArray(categorias) ? categorias : [];
-  const isOpen = (id: string) => open[id] !== false; // default abierto
+  const isOpen = (id: string) => open[id] !== false;
+
+  // Columnas (algunas ocultables desde "Columnas")
+  const ALL_COLS = [
+    { key: "partida", label: t("Partida de gasto"), w: "minmax(230px,2.2fr)", always: true, align: "left" },
+    { key: "unidad", label: t("Unidad"), w: "80px", align: "center" },
+    { key: "cantidad", label: t("Cantidad"), w: "86px", align: "center" },
+    { key: "valor", label: t("Valor unit."), w: "106px", align: "center" },
+    { key: "coste", label: t("Coste total"), w: "116px", always: true, align: "center" },
+    { key: "estimado", label: t("Estimado"), w: "110px", align: "center" },
+    { key: "pagado", label: t("Pagado"), w: "104px", always: true, align: "center" },
+    { key: "pendiente", label: t("Pendiente"), w: "114px", always: true, align: "center" },
+    { key: "menu", label: "", w: "44px", always: true, align: "center" },
+  ];
+  const COLMAP: any = { partida: "gasto", unidad: "unidad", cantidad: "cantidad", valor: "valor_unitario", coste: "coste_final", estimado: "coste_estimado", pagado: "pagado", pendiente: "pendiente_pagar", menu: "options" };
+  const visibleCols = ALL_COLS.filter((c) => columnConfig[COLMAP[c.key]]?.visible !== false);
+  const gridTemplate = visibleCols.map((c) => c.w).join(" ");
 
   const totals = useMemo(() => {
-    let tot = 0, pag = 0;
-    cats.forEach((c) => (c.gastos_array || []).filter((g: any) => g?.estatus !== false).forEach((g: any) => { tot += g.coste_final || 0; pag += g.pagado || 0; }));
-    return { tot, pag, pen: tot - pag };
+    let tot = 0, pag = 0, est = 0, nP = 0;
+    cats.forEach((c) => (c.gastos_array || []).filter((g: any) => g?.estatus !== false).forEach((g: any) => { tot += g.coste_final || 0; pag += g.pagado || 0; est += g.coste_estimado || 0; nP++; }));
+    return { tot, pag, est, pen: tot - pag, nCat: cats.length, nPart: nP };
   }, [cats]);
+  const tableTotals = { estimado: totals.est, total: totals.tot, pagado: totals.pag };
+  const noFilters = filters.categories.length === 0 && filters.paymentStatus === "all";
 
   const ql = q.trim().toLowerCase();
   const filtered = cats.map((c) => {
+    if (filters.categories.length && !filters.categories.includes(c._id)) return { c, gastos: [] as any[] };
     const catMatch = String(c.nombre || "").toLowerCase().includes(ql);
-    const gastos = (c.gastos_array || []).filter((g: any) => g?.estatus !== false).filter((g: any) => !ql || catMatch || String(g.nombre || "").toLowerCase().includes(ql));
+    let gastos = (c.gastos_array || []).filter((g: any) => g?.estatus !== false);
+    gastos = gastos.filter((g: any) => {
+      const ct = g.coste_final || 0, pag = g.pagado || 0, pen = ct - pag;
+      if (filters.paymentStatus === "paid") return ct > 0 && pen <= 0;
+      if (filters.paymentStatus === "pending") return pen > 0 && pag <= 0;
+      if (filters.paymentStatus === "partial") return pag > 0 && pen > 0;
+      return true;
+    });
+    gastos = gastos.filter((g: any) => !ql || catMatch || String(g.nombre || "").toLowerCase().includes(ql));
     return { c, gastos };
-  }).filter((x) => !ql || String(x.c.nombre || "").toLowerCase().includes(ql) || x.gastos.length > 0);
+  }).filter((x) => x.gastos.length > 0 || (!ql && noFilters));
 
   const allOpen = cats.every((c) => isOpen(c._id));
   const toggleAll = () => { const next: Record<string, boolean> = {}; cats.forEach((c) => (next[c._id] = !allOpen)); setOpen(next); };
-
   const applyPO = (result: any) => { const po = result?.evento?.presupuesto_objeto; if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po })); };
 
-  const addPartida = async (cat: any) => {
-    if (!isAllowed()) { ht(); return; }
-    try { applyPO(await fetchApiEventos({ query: queries.nuevoGasto, variables: { evento_id: event._id, categoria_id: cat._id, nombre: t("Nueva partida de gasto") } })); }
-    catch { toast("error", t("Ha ocurrido un error")); }
-  };
-  const addItem = async (cat: any, gasto: any) => {
-    if (!isAllowed()) { ht(); return; }
-    try { applyPO(await fetchApiEventos({ query: queries.nuevoItemGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id, itemGasto: { nombre: t("Nuevo item"), cantidad: 1, unidad: "unidad", valor_unitario: 0, total: 0 } } })); }
-    catch { toast("error", t("Ha ocurrido un error")); }
-  };
-  const delGasto = async (cat: any, gasto: any) => {
-    if (!isAllowed()) { ht(); return; }
-    try { applyPO(await fetchApiEventos({ query: queries.borrarGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id } })); toast("success", t("Partida eliminada")); }
-    catch { toast("error", t("Ha ocurrido un error")); }
+  const addPartida = async (cat: any) => { if (!isAllowed()) { ht(); return; } try { applyPO(await fetchApiEventos({ query: queries.nuevoGasto, variables: { evento_id: event._id, categoria_id: cat._id, nombre: t("Nueva partida de gasto") } })); } catch { toast("error", t("Ha ocurrido un error")); } };
+  const addItem = async (cat: any, gasto: any) => { if (!isAllowed()) { ht(); return; } try { applyPO(await fetchApiEventos({ query: queries.nuevoItemGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id, itemGasto: { nombre: t("Nuevo item"), cantidad: 1, unidad: "unidad", valor_unitario: 0, total: 0 } } })); } catch { toast("error", t("Ha ocurrido un error")); } };
+  const delGasto = async (cat: any, gasto: any) => { if (!isAllowed()) { ht(); return; } try { applyPO(await fetchApiEventos({ query: queries.borrarGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: gasto._id } })); toast("success", t("Partida eliminada")); } catch { toast("error", t("Ha ocurrido un error")); } };
+
+  const startEdit = (cat: any, g: any, key: string) => { if (!isAllowed()) { ht(); return; } setMenuAt(null); setEditRow(key); setEditVals({ nombre: g.nombre || "", coste_estimado: String(g.coste_estimado || 0), coste_final: String(g.coste_final || 0) }); };
+  const saveEdit = async (cat: any, g: any) => {
+    try {
+      const changes: [string, string][] = [];
+      if (editVals.nombre.trim() && editVals.nombre.trim() !== (g.nombre || "")) changes.push(["nombre", editVals.nombre.trim()]);
+      const est = parseEs(editVals.coste_estimado); if (est !== (g.coste_estimado || 0)) changes.push(["coste_estimado", String(est)]);
+      const fin = parseEs(editVals.coste_final); if (fin !== (g.coste_final || 0)) changes.push(["coste_final", String(fin)]);
+      let last: any = null;
+      for (const [variable, valor] of changes) {
+        last = await fetchApiEventos({ query: queries.editGasto, variables: { evento_id: event._id, categoria_id: cat._id, gasto_id: g._id, variable_reemplazar: variable, valor_reemplazar: valor } });
+      }
+      if (last) applyPO(last);
+      setEditRow(null);
+      if (changes.length) toast("success", t("Cambios guardados"));
+    } catch { toast("error", t("Ha ocurrido un error")); }
   };
 
+  const cellStyle = (align: string): any => ({ textAlign: align === "left" ? "left" : align, minWidth: 0 });
+  const editInput: any = { width: "100%", padding: "5px 7px", borderRadius: 7, border: "1.5px solid #EF5B94", font: "500 12px Poppins", color: "#3A3A42", outline: "none", boxSizing: "border-box" };
+  const filtersActive = filters.categories.length > 0 || filters.paymentStatus !== "all";
+  const formatNumber = (v: number) => getCurrency(v, cur);
+
   return (
-    <div>
+    <div style={{ position: "relative" }}>
       <style dangerouslySetInnerHTML={{ __html: `
         .pd-tool:hover{color:#EF5B94!important;}
         .pd-row:hover{background:#faf9fb;}
@@ -74,6 +125,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         .pd-collapse:hover{color:#EF5B94!important;background:#faf9fb!important;}
         .pd-scrollx{overflow-x:auto;scrollbar-width:none;-ms-overflow-style:none;}
         .pd-scrollx::-webkit-scrollbar{display:none;}
+        .pd-pop label:hover{background:#faf9fb;}
       `}} />
 
       {pagoTarget && <ModalAddPagoStudio categoriaId={pagoTarget.cat} gastoId={pagoTarget.gasto} onClose={() => setPagoTarget(null)} />}
@@ -81,10 +133,15 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
       <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
         {/* Toolbar */}
         <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "14px 18px", borderBottom: "1px solid #f2f2f4", flexWrap: "wrap" }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 180, maxWidth: 300, border: "1.5px solid #E7E7EA", borderRadius: 999, padding: "9px 15px", color: "#a0a0a8" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flex: "0 1 260px", minWidth: 160, maxWidth: 260, border: "1.5px solid #E7E7EA", borderRadius: 999, padding: "8px 14px", color: "#a0a0a8" }}>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></svg>
             <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={t("Buscar…") as string} style={{ border: "none", background: "none", flex: 1, minWidth: 0, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
           </div>
+
+          <button className="pd-tool" onClick={() => setPanel(panel === "filtros" ? null : "filtros")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: filtersActive ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M3 5h18l-7 8v6l-4 2v-8z" /></svg>{t("Filtros")}</button>
+          <button className="pd-tool" onClick={() => setPanel(panel === "info" ? null : "info")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: panel === "info" ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><circle cx="12" cy="12" r="9" /><path d="M12 11v5M12 8h0" /></svg>{t("Info evento")}</button>
+          <button className="pd-tool" onClick={() => setPanel(panel === "columnas" ? null : "columnas")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: panel === "columnas" ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="4" y="4" width="16" height="16" rx="2" /><path d="M10 4v16M14 4v16" /></svg>{t("Columnas")}</button>
+
           <div style={{ display: "flex", alignItems: "center", gap: 28, marginLeft: "auto" }}>
             <div style={{ textAlign: "right", whiteSpace: "nowrap" }}><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>{t("Total")}</div><div style={{ font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(totals.tot, cur)}</div></div>
             <div style={{ textAlign: "right", whiteSpace: "nowrap" }}><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>{t("Pagado")}</div><div style={{ font: "700 13px Poppins", color: "#2FB37E" }}>{getCurrency(totals.pag, cur)}</div></div>
@@ -103,13 +160,11 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         {/* Tabla */}
         <div className="pd-scrollx">
           <div style={{ minWidth: 880 }}>
-            <div style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, padding: "14px 30px 14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
-              <div>{t("Partida de gasto")}</div><div>{t("Unidad")}</div><div style={{ textAlign: "center" }}>{t("Cantidad")}</div><div style={{ textAlign: "right" }}>{t("Valor unit.")}</div><div style={{ textAlign: "right" }}>{t("Coste total")}</div><div style={{ textAlign: "right" }}>{t("Estimado")}</div><div style={{ textAlign: "right" }}>{t("Pagado")}</div><div style={{ textAlign: "right" }}>{t("Pendiente")}</div><div />
+            <div style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: 8, padding: "14px 30px 14px 22px", background: "#faf9fb", borderBottom: "1px solid #f2f2f4", font: "700 10.5px Poppins", color: "#5a5a62", letterSpacing: ".5px", textTransform: "uppercase" }}>
+              {visibleCols.map((c) => <div key={c.key} style={{ textAlign: c.align === "left" ? "left" : c.align } as any}>{c.label}</div>)}
             </div>
 
-            {filtered.length === 0 && (
-              <div style={{ padding: "34px 22px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{t("Sin resultados")}</div>
-            )}
+            {filtered.length === 0 && <div style={{ padding: "34px 22px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{t("Sin resultados")}</div>}
 
             {filtered.map(({ c, gastos }) => {
               const tot = gastos.reduce((a: number, g: any) => a + (g.coste_final || 0), 0);
@@ -124,20 +179,30 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
                   </div>
                   {abierto && gastos.map((g: any) => {
                     const it = (g.items_array || [])[0];
-                    const ct = g.coste_final || 0;
-                    const pag = g.pagado || 0;
-                    const pen = ct - pag;
+                    const ct = g.coste_final || 0, pag = g.pagado || 0, pen = ct - pag;
                     const key = c._id + "|" + g._id;
-                    return (
-                      <div key={g._id} className="pd-row" style={{ display: "grid", gridTemplateColumns: COLS, gap: 8, alignItems: "center", padding: "11px 30px 11px 22px", borderBottom: "1px solid #f4f4f6" }}>
-                        <div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={g.nombre}>{g.nombre}</div>
-                        <div style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{it?.unidad || "—"}</div>
-                        <div style={{ textAlign: "center", font: "500 12.5px Poppins", color: "#6b6b72" }}>{it?.cantidad ?? "—"}</div>
-                        <div style={{ textAlign: "right", font: "500 12.5px Poppins", color: "#6b6b72" }}>{it ? getCurrency(it.valor_unitario || 0, cur) : "—"}</div>
-                        <div style={{ textAlign: "right", font: "700 12.5px Poppins", color: "#3A3A42" }}>{getCurrency(ct, cur)}</div>
-                        <div style={{ textAlign: "right", font: "500 12.5px Poppins", color: "#6b6b72" }}>{getCurrency(g.coste_estimado || 0, cur)}</div>
-                        <div style={{ textAlign: "right", font: "600 12.5px Poppins", color: "#2FB37E" }}>{getCurrency(pag, cur)}</div>
-                        <div style={{ textAlign: "right", font: "700 12.5px Poppins", color: pen > 0 ? "#D83E7C" : "#8a8a90" }}>{getCurrency(pen, cur)}</div>
+                    const editing = editRow === key;
+                    const render: Record<string, any> = {
+                      partida: editing
+                        ? <input autoFocus value={editVals.nombre} onChange={(e) => setEditVals((v) => ({ ...v, nombre: e.target.value }))} style={editInput} />
+                        : <div style={{ font: "600 13.5px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }} title={g.nombre}>{g.nombre}</div>,
+                      unidad: <span style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{it?.unidad || "—"}</span>,
+                      cantidad: <span style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{it?.cantidad ?? "—"}</span>,
+                      valor: <span style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{it ? getCurrency(it.valor_unitario || 0, cur) : "—"}</span>,
+                      coste: editing
+                        ? <input value={editVals.coste_final} onChange={(e) => setEditVals((v) => ({ ...v, coste_final: e.target.value }))} style={{ ...editInput, textAlign: "right" }} />
+                        : <span style={{ font: "700 12.5px Poppins", color: "#3A3A42" }}>{getCurrency(ct, cur)}</span>,
+                      estimado: editing
+                        ? <input value={editVals.coste_estimado} onChange={(e) => setEditVals((v) => ({ ...v, coste_estimado: e.target.value }))} style={{ ...editInput, textAlign: "right" }} />
+                        : <span style={{ font: "500 12.5px Poppins", color: "#6b6b72" }}>{getCurrency(g.coste_estimado || 0, cur)}</span>,
+                      pagado: <span style={{ font: "600 12.5px Poppins", color: "#2FB37E" }}>{getCurrency(pag, cur)}</span>,
+                      pendiente: <span style={{ font: "700 12.5px Poppins", color: pen > 0 ? "#D83E7C" : "#8a8a90" }}>{getCurrency(pen, cur)}</span>,
+                      menu: editing ? (
+                        <div style={{ display: "flex", gap: 4, justifyContent: "center" }}>
+                          <button title={t("Guardar")} onClick={() => saveEdit(c, g)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#2FB37E", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round"><path d="M20 6L9 17l-5-5" /></svg></button>
+                          <button title={t("Cancelar")} onClick={() => setEditRow(null)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
+                        </div>
+                      ) : (
                         <div style={{ display: "flex", justifyContent: "center", position: "relative" }}>
                           <button className="pd-dots" onClick={(e) => { e.stopPropagation(); setMenuAt(menuAt === key ? null : key); }} style={{ width: 28, height: 28, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.7" /><circle cx="12" cy="12" r="1.7" /><circle cx="12" cy="19" r="1.7" /></svg></button>
                           {menuAt === key && (
@@ -147,17 +212,24 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
                                   <span style={{ font: "700 13px Poppins", color: "#3A3A42", whiteSpace: "nowrap" }}>{t("Opciones disponibles")}</span>
                                   <button onClick={() => setMenuAt(null)} style={{ width: 22, height: 22, borderRadius: 6, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer", padding: 0 }}><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
                                 </div>
-                                <div style={{ font: "600 11px Poppins", color: "#a0a0a8", textTransform: "uppercase", letterSpacing: ".5px", marginBottom: 4 }}>{t("Agregar")}</div>
-                                <button style={btn} onClick={() => { setMenuAt(null); onAddCategoria(); }}>{t("Categoría")}</button>
-                                <button style={btn} onClick={() => { setMenuAt(null); addPartida(c); }}>{t("Partida")}</button>
-                                <button style={btn} onClick={() => { setMenuAt(null); addItem(c, g); }}>{t("Item")}</button>
+                                <button style={menuBtn} onClick={() => startEdit(c, g, key)}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><path d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z" /></svg>{t("Editar")}</button>
                                 <div style={{ height: 1, background: "#f2f2f4", margin: "8px 0" }} />
-                                <button style={btn} onClick={() => { setMenuAt(null); if (!isAllowed()) { ht(); return; } setPagoTarget({ cat: c._id, gasto: g._id }); }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><ellipse cx="12" cy="6" rx="7" ry="3" /><path d="M5 6v6c0 1.7 3.1 3 7 3s7-1.3 7-3V6" /><path d="M5 12v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6" /></svg>{t("Relacionar pago")}</button>
-                                <button className="pd-del" style={{ ...btn, color: "#D83E7C" }} onClick={() => { setMenuAt(null); delGasto(c, g); }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg>{t("Borrar")}</button>
+                                <div style={{ font: "600 11px Poppins", color: "#a0a0a8", textTransform: "uppercase", letterSpacing: ".5px", marginBottom: 4 }}>{t("Agregar")}</div>
+                                <button style={menuBtn} onClick={() => { setMenuAt(null); onAddCategoria(); }}>{t("Categoría")}</button>
+                                <button style={menuBtn} onClick={() => { setMenuAt(null); addPartida(c); }}>{t("Partida")}</button>
+                                <button style={menuBtn} onClick={() => { setMenuAt(null); addItem(c, g); }}>{t("Item")}</button>
+                                <div style={{ height: 1, background: "#f2f2f4", margin: "8px 0" }} />
+                                <button style={menuBtn} onClick={() => { setMenuAt(null); if (!isAllowed()) { ht(); return; } setPagoTarget({ cat: c._id, gasto: g._id }); }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><ellipse cx="12" cy="6" rx="7" ry="3" /><path d="M5 6v6c0 1.7 3.1 3 7 3s7-1.3 7-3V6" /><path d="M5 12v6c0 1.7 3.1 3 7 3s7-1.3 7-3v-6" /></svg>{t("Relacionar pago")}</button>
+                                <button className="pd-del" style={{ ...menuBtn, color: "#D83E7C" }} onClick={() => { setMenuAt(null); delGasto(c, g); }}><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg>{t("Borrar")}</button>
                               </div>
                             </ClickAwayListener>
                           )}
                         </div>
+                      ),
+                    };
+                    return (
+                      <div key={g._id} className="pd-row" style={{ display: "grid", gridTemplateColumns: gridTemplate, gap: 8, alignItems: "center", padding: "11px 30px 11px 22px", borderBottom: "1px solid #f4f4f6" }}>
+                        {visibleCols.map((col) => <div key={col.key} style={cellStyle(col.align)}>{render[col.key]}</div>)}
                       </div>
                     );
                   })}
@@ -167,10 +239,19 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
           </div>
         </div>
       </div>
+
+      {/* Modales (fuera del overflow del card; se posicionan absolute top-12 left-3) */}
+      {panel === "filtros" && (
+        <FiltersModal filters={filters} onFilterChange={onFilterChange} onClose={() => setPanel(null)} onClearFilters={onClearFilters} categorias_array={cats} viewLevel={viewLevel} setViewLevel={setViewLevel} />
+      )}
+      {panel === "info" && (
+        <EventInfoModal event={event} currency={cur} categorias_array={cats} totalStimatedGuests={event?.presupuesto_objeto?.totalStimatedGuests ?? { adults: 0, children: 0 }} totals={tableTotals} formatNumber={formatNumber} onClose={() => setPanel(null)} />
+      )}
+      {panel === "columnas" && (
+        <ColumnsConfigModal columnConfig={columnConfig} toggleColumnVisibility={toggleColumnVisibility} onClose={() => setPanel(null)} />
+      )}
     </div>
   );
 };
-
-const btn: any = { display: "flex", alignItems: "center", gap: 9, padding: "8px 10px", borderRadius: 8, background: "none", border: "none", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42", textAlign: "left", width: "100%" };
 
 export default PresupuestoDetalladoStudio;

--- a/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useMemo, useRef, useState } from "react";
 import { EventContextProvider } from "../../context";
 import { useTranslation } from "react-i18next";
 import { fetchApiEventos, queries } from "../../utils/Fetching";
@@ -37,9 +37,22 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
   const [guestMode, setGuestMode] = useState<"conf" | "est">("conf");
   const [editRow, setEditRow] = useState<string | null>(null);
   const [editVals, setEditVals] = useState<{ nombre: string; coste_estimado: string; coste_final: string }>({ nombre: "", coste_estimado: "", coste_final: "" });
+  const filRef = useRef<HTMLButtonElement>(null);
+  const infRef = useRef<HTMLButtonElement>(null);
+  const colRef = useRef<HTMLButtonElement>(null);
+  // Ancla un panel debajo de su botón (relativo al contenedor position:relative del componente).
+  const anchorPos = (ref: any, w: number, alignRight = false) => {
+    const b = ref.current;
+    if (!b) return { top: 48, left: 12 };
+    const top = b.offsetTop + b.offsetHeight + 10;
+    const left = alignRight ? Math.max(8, b.offsetLeft + b.offsetWidth - w) : Math.max(8, b.offsetLeft);
+    return { top, left };
+  };
 
   const cats = Array.isArray(categorias) ? categorias : [];
   const isOpen = (id: string) => open[id] !== false;
+  // Checkbox custom (rosa garantizado, sin depender de accent-color del navegador)
+  const chkBox = (on: boolean): any => ({ width: 16, height: 16, borderRadius: 5, display: "inline-flex", alignItems: "center", justifyContent: "center", background: on ? "#EF5B94" : "#fff", border: `1.5px solid ${on ? "#EF5B94" : "#d8d8dd"}`, color: "#fff", fontSize: 11, flex: "none" });
 
   // Columnas (algunas ocultables desde "Columnas")
   const ALL_COLS = [
@@ -158,9 +171,9 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
             <input className="pd-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder={t("Buscar…") as string} style={{ border: "none", background: "none", flex: 1, minWidth: 0, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
           </div>
 
-          <button className="pd-tool" onClick={() => setPanel(panel === "filtros" ? null : "filtros")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: filtersActive ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M3 5h18l-7 8v6l-4 2v-8z" /></svg>{t("Filtros")}</button>
-          <button className="pd-tool" onClick={() => setPanel(panel === "info" ? null : "info")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: panel === "info" ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><circle cx="12" cy="12" r="9" /><path d="M12 11v5M12 8h0" /></svg>{t("Info evento")}</button>
-          <button className="pd-tool" onClick={() => setPanel(panel === "columnas" ? null : "columnas")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: panel === "columnas" ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="4" y="4" width="16" height="16" rx="2" /><path d="M10 4v16M14 4v16" /></svg>{t("Columnas")}</button>
+          <button ref={filRef} className="pd-tool" onClick={() => setPanel(panel === "filtros" ? null : "filtros")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: filtersActive ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M3 5h18l-7 8v6l-4 2v-8z" /></svg>{t("Filtros")}</button>
+          <button ref={infRef} className="pd-tool" onClick={() => setPanel(panel === "info" ? null : "info")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: panel === "info" ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><circle cx="12" cy="12" r="9" /><path d="M12 11v5M12 8h0" /></svg>{t("Info evento")}</button>
+          <button ref={colRef} className="pd-tool" onClick={() => setPanel(panel === "columnas" ? null : "columnas")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: panel === "columnas" ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="4" y="4" width="16" height="16" rx="2" /><path d="M10 4v16M14 4v16" /></svg>{t("Columnas")}</button>
 
           <div style={{ display: "flex", alignItems: "center", gap: 28, marginLeft: "auto" }}>
             <div style={{ textAlign: "right", whiteSpace: "nowrap" }}><div style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>{t("Total")}</div><div style={{ font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(totals.tot, cur)}</div></div>
@@ -267,7 +280,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         const lblTxt: any = { font: "600 13px Poppins", color: "#3A3A42", marginBottom: 7 };
         const allChecked = cats.length > 0 && filters.categories.length === cats.length;
         return (
-          <div style={{ position: "absolute", top: 48, left: 12, zIndex: 50, width: 320, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+          <div style={{ position: "absolute", ...anchorPos(filRef, 320), zIndex: 50, width: 320, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
             <div style={{ display: "flex", alignItems: "center", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
               <div style={{ font: "700 15px Poppins", color: "#3A3A42", flex: 1 }}>{t("Filtros")}</div>
               <button className="pd-limpiar" onClick={() => { onClearFilters(); setViewLevel(3); }} style={{ font: "600 12.5px Poppins", color: "#EF5B94", background: "none", border: "none", cursor: "pointer", padding: "4px 8px" }}>{t("Limpiar")}</button>
@@ -286,14 +299,14 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
               <div>
                 <div style={lblTxt}>{t("Filtrar por categorías")} ({filters.categories.length} {t("seleccionadas")})</div>
                 <div className="pd-scrollx" style={{ border: "1.5px solid #E7E7EA", borderRadius: 10, maxHeight: 150, overflowY: "auto" }}>
-                  <label style={{ display: "flex", alignItems: "center", gap: 9, padding: "9px 12px", borderBottom: "1px solid #f4f4f6", cursor: "pointer", font: "600 12.5px Poppins", color: "#EF5B94" }}>
-                    <input type="checkbox" checked={allChecked} onChange={(e) => onFilterChange("categories", e.target.checked ? cats.map((c) => c._id) : [])} style={{ accentColor: "#EF5B94", width: 15, height: 15 }} />{t("Seleccionar todas")}
+                  <label onClick={() => onFilterChange("categories", allChecked ? [] : cats.map((c) => c._id))} style={{ display: "flex", alignItems: "center", gap: 9, padding: "9px 12px", borderBottom: "1px solid #f4f4f6", cursor: "pointer", font: "600 12.5px Poppins", color: "#EF5B94" }}>
+                    <span style={chkBox(allChecked)}>{allChecked ? "✓" : ""}</span>{t("Seleccionar todas")}
                   </label>
                   {cats.map((c) => {
                     const checked = filters.categories.includes(c._id);
                     return (
-                      <label key={c._id} className="pd-cat" style={{ display: "flex", alignItems: "center", gap: 9, padding: "8px 12px", borderBottom: "1px solid #f8f8fa", cursor: "pointer", font: "500 12.5px Poppins", color: "#6b6b72" }}>
-                        <input type="checkbox" checked={checked} onChange={(e) => onFilterChange("categories", e.target.checked ? [...filters.categories, c._id] : filters.categories.filter((id: string) => id !== c._id))} style={{ accentColor: "#EF5B94", width: 15, height: 15 }} />{cap1(c.nombre)}
+                      <label key={c._id} className="pd-cat" onClick={() => onFilterChange("categories", checked ? filters.categories.filter((id: string) => id !== c._id) : [...filters.categories, c._id])} style={{ display: "flex", alignItems: "center", gap: 9, padding: "8px 12px", borderBottom: "1px solid #f8f8fa", cursor: "pointer", font: "500 12.5px Poppins", color: "#6b6b72" }}>
+                        <span style={chkBox(checked)}>{checked ? "✓" : ""}</span>{cap1(c.nombre)}
                       </label>
                     );
                   })}
@@ -330,7 +343,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         );
       })()}
       {panel === "info" && (
-        <div style={{ position: "absolute", top: 48, left: 12, zIndex: 50, width: 340, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+        <div style={{ position: "absolute", ...anchorPos(infRef, 340), zIndex: 50, width: 340, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
           <div style={{ display: "flex", alignItems: "center", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
             <div style={{ font: "700 15px Poppins", color: "#3A3A42", flex: 1 }}>{t("Información del evento")}</div>
             <button className="pd-x" onClick={() => setPanel(null)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
@@ -389,20 +402,23 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
       {panel === "columnas" && (() => {
         const allChecked = COLUMNAS.every((c) => columnConfig[c.k]?.visible !== false);
         return (
-          <div style={{ position: "absolute", top: 48, right: 12, zIndex: 50, width: 280, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
+          <div style={{ position: "absolute", ...anchorPos(colRef, 280, true), zIndex: 50, width: 280, background: "#fff", border: "1px solid #ececef", borderRadius: 16, boxShadow: "0 16px 40px rgba(0,0,0,.14)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
             <div style={{ display: "flex", alignItems: "center", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
               <div style={{ font: "700 15px Poppins", color: "#3A3A42", flex: 1 }}>{t("Columnas")}</div>
               <button className="pd-x" onClick={() => setPanel(null)} style={{ width: 26, height: 26, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg></button>
             </div>
-            <label className="pd-cat" style={{ display: "flex", alignItems: "center", gap: 11, padding: "12px 18px", borderBottom: "1px solid #f2f2f4", cursor: "pointer", font: "600 13px Poppins", color: "#3A3A42" }}>
-              <input type="checkbox" checked={allChecked} onChange={(e) => setColumnConfig((cc: any) => { const next = { ...cc }; COLUMNAS.forEach((c) => (next[c.k] = { visible: e.target.checked })); return next; })} style={{ accentColor: "#EF5B94", width: 16, height: 16 }} />{t("Seleccionar todo")}
+            <label className="pd-cat" onClick={() => setColumnConfig((cc: any) => { const next = { ...cc }; COLUMNAS.forEach((c) => (next[c.k] = { visible: !allChecked })); return next; })} style={{ display: "flex", alignItems: "center", gap: 11, padding: "12px 18px", borderBottom: "1px solid #f2f2f4", cursor: "pointer", font: "600 13px Poppins", color: "#3A3A42" }}>
+              <span style={chkBox(allChecked)}>{allChecked ? "✓" : ""}</span>{t("Seleccionar todo")}
             </label>
             <div className="pd-scrollx" style={{ maxHeight: 400, overflowY: "auto", padding: "4px 0" }}>
-              {COLUMNAS.map((c) => (
-                <label key={c.k} className="pd-cat" style={{ display: "flex", alignItems: "center", gap: 11, padding: "10px 18px", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42" }}>
-                  <input type="checkbox" checked={columnConfig[c.k]?.visible !== false} onChange={() => toggleColumnVisibility(c.k)} style={{ accentColor: "#EF5B94", width: 16, height: 16 }} />{c.l}
-                </label>
-              ))}
+              {COLUMNAS.map((c) => {
+                const vis = columnConfig[c.k]?.visible !== false;
+                return (
+                  <label key={c.k} className="pd-cat" onClick={() => toggleColumnVisibility(c.k)} style={{ display: "flex", alignItems: "center", gap: 11, padding: "10px 18px", cursor: "pointer", font: "500 12.5px Poppins", color: "#3A3A42" }}>
+                    <span style={chkBox(vis)}>{vis ? "✓" : ""}</span>{c.l}
+                  </label>
+                );
+              })}
             </div>
           </div>
         );

--- a/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoDetalladoStudio.tsx
@@ -126,6 +126,7 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
         .pd-scrollx{overflow-x:auto;scrollbar-width:none;-ms-overflow-style:none;}
         .pd-scrollx::-webkit-scrollbar{display:none;}
         .pd-pop label:hover{background:#faf9fb;}
+        .pd-search:focus,.pd-search:focus-visible{outline:none!important;box-shadow:none!important;border:none!important;}
       `}} />
 
       {pagoTarget && <ModalAddPagoStudio categoriaId={pagoTarget.cat} gastoId={pagoTarget.gasto} onClose={() => setPagoTarget(null)} />}
@@ -133,9 +134,9 @@ const PresupuestoDetalladoStudio: FC<Props> = ({ categorias, onAddCategoria }) =
       <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
         {/* Toolbar */}
         <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "14px 18px", borderBottom: "1px solid #f2f2f4", flexWrap: "wrap" }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flex: "0 1 260px", minWidth: 160, maxWidth: 260, border: "1.5px solid #E7E7EA", borderRadius: 999, padding: "8px 14px", color: "#a0a0a8" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flex: "0 1 250px", minWidth: 150, maxWidth: 250, border: "1px solid #E7E7EA", borderRadius: 999, padding: "5px 13px", color: "#a0a0a8" }}>
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#b3b3ba" strokeWidth={2}><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></svg>
-            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder={t("Buscar…") as string} style={{ border: "none", background: "none", flex: 1, minWidth: 0, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
+            <input className="pd-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder={t("Buscar…") as string} style={{ border: "none", background: "none", flex: 1, minWidth: 0, font: "500 12.5px Poppins", color: "#3A3A42", outline: "none" }} />
           </div>
 
           <button className="pd-tool" onClick={() => setPanel(panel === "filtros" ? null : "filtros")} style={{ display: "flex", alignItems: "center", gap: 6, font: "600 12.5px Poppins", color: filtersActive ? "#EF5B94" : "#6b6b72", cursor: "pointer", background: "none", border: "none", padding: 0 }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M3 5h18l-7 8v6l-4 2v-8z" /></svg>{t("Filtros")}</button>

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -10,7 +10,7 @@ import { useToast } from "../../hooks/useToast";
 import ClickAwayListener from "react-click-away-listener";
 import BlockTitle from "../Utils/BlockTitle";
 import DetalleCategoriaStudio from "./DetalleCategoriaStudio";
-import BlockPagos from "./BlockPagos";
+import PagosStudio from "./PagosStudio";
 import PresupuestoDetalladoStudio from "./PresupuestoDetalladoStudio";
 import WeddingFinanceManager from "./TableroPresupuesto/WeddingFinanceManager";
 import ExportExcelPresupuesto from "./ExportExcelPresupuesto";
@@ -470,8 +470,8 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
 
         {/* ===== OTRAS VISTAS (existentes, se rediseñan en fases siguientes) ===== */}
         {active === "excelView" && <PresupuestoDetalladoStudio categorias={cats} onAddCategoria={() => setShowCreateCat(true)} />}
-        {active === "pagos" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pagado"} />}
-        {active === "pendiente" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pendiente"} />}
+        {active === "pagos" && <PagosStudio categorias={cats} estado="pagado" />}
+        {active === "pendiente" && <PagosStudio categorias={cats} estado="pendiente" />}
         {active === "dashboard" && isOwner && <WeddingFinanceManager />}
       </div>
       </div>

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -97,7 +97,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
   const tabs = [
     { key: "resumen", label: t("budget") },
     { key: "excelView", label: t("budgetdetails") },
-    { key: "pagos", label: t("payments") },
+    { key: "pagos", label: t("Pagos") },
     { key: "pendiente", label: t("pendingpayments") },
     ...(isOwner ? [{ key: "dashboard", label: t("dashboard") }] : []),
   ];

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -11,7 +11,7 @@ import ClickAwayListener from "react-click-away-listener";
 import BlockTitle from "../Utils/BlockTitle";
 import DetalleCategoriaStudio from "./DetalleCategoriaStudio";
 import BlockPagos from "./BlockPagos";
-import { ExcelView } from "./ExcelView";
+import PresupuestoDetalladoStudio from "./PresupuestoDetalladoStudio";
 import WeddingFinanceManager from "./TableroPresupuesto/WeddingFinanceManager";
 import ExportExcelPresupuesto from "./ExportExcelPresupuesto";
 import { DuplicatePresupuesto } from "./DuplicatePesupuesto";
@@ -469,7 +469,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
         )}
 
         {/* ===== OTRAS VISTAS (existentes, se rediseñan en fases siguientes) ===== */}
-        {active === "excelView" && <ExcelView setShowCategoria={setShowCategoria} categorias_array={cats} showCategoria={showCategoria} />}
+        {active === "excelView" && <PresupuestoDetalladoStudio categorias={cats} onAddCategoria={() => setShowCreateCat(true)} />}
         {active === "pagos" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pagado"} />}
         {active === "pendiente" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pendiente"} />}
         {active === "dashboard" && isOwner && <WeddingFinanceManager />}

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -215,7 +215,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
           {tabs.map((tb) => {
             const on = active === tb.key;
             return (
-              <button key={tb.key} className="ps-seg" onClick={() => { setActive(tb.key); setShowCategoria({ state: false, _id: "" }); }} style={{ flex: 1, textAlign: "center", padding: "10px 8px", borderRadius: 10, font: "600 13px Poppins", cursor: "pointer", background: "transparent", color: on ? "#EF5B94" : "#6b6b72", border: "none", whiteSpace: "nowrap", transition: "all .15s" }}>
+              <button key={tb.key} className="ps-seg" onClick={() => { setActive(tb.key); setShowCategoria({ state: false, _id: "" }); }} style={{ flex: 1, textAlign: "center", padding: "10px 8px", borderRadius: 10, font: "600 13px Poppins", cursor: "pointer", background: "transparent", color: on ? "#EF5B94" : "#6b6b72", border: "none", whiteSpace: "nowrap", textTransform: "capitalize", transition: "all .15s" }}>
                 {tb.label}
               </button>
             );

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -12,7 +12,7 @@ import BlockTitle from "../Utils/BlockTitle";
 import DetalleCategoriaStudio from "./DetalleCategoriaStudio";
 import PagosStudio from "./PagosStudio";
 import PresupuestoDetalladoStudio from "./PresupuestoDetalladoStudio";
-import WeddingFinanceManager from "./TableroPresupuesto/WeddingFinanceManager";
+import DashboardStudio from "./DashboardStudio";
 import ExportExcelPresupuesto from "./ExportExcelPresupuesto";
 import { DuplicatePresupuesto } from "./DuplicatePesupuesto";
 
@@ -472,7 +472,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
         {active === "excelView" && <PresupuestoDetalladoStudio categorias={cats} onAddCategoria={() => setShowCreateCat(true)} />}
         {active === "pagos" && <PagosStudio categorias={cats} estado="pagado" />}
         {active === "pendiente" && <PagosStudio categorias={cats} estado="pendiente" />}
-        {active === "dashboard" && isOwner && <WeddingFinanceManager />}
+        {active === "dashboard" && isOwner && <DashboardStudio categorias={cats} />}
       </div>
       </div>
     </div>

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -120,7 +120,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
   const selectCat = (c: any) => setShowCategoria({ state: true, _id: c._id });
 
   const CATSTYLE = `
-    .ps-tab{background:none;border:none;cursor:pointer;padding:10px 2px;font:600 13.5px Poppins;white-space:nowrap;position:relative;transition:color .15s;}
+    .ps-seg:hover{background:#faf9fb!important;}
     .ps-row:hover{background:#faf9fb!important;}
     .ps-del:hover{background:#FBE4EF!important;color:#D83E7C!important;}
     .ps-btn2:hover{background:#faf9fb!important;color:#3A3A42!important;}
@@ -184,14 +184,13 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
       {/* Contenedor centrado */}
       <div className="mx-auto w-full ps-scroll" style={{ maxWidth: 1080, padding: "8px 16px 40px", overflowY: "auto", flex: 1 }}>
 
-        {/* TABS sin recuadro */}
-        <div className="ps-scroll" style={{ display: "flex", gap: 24, overflowX: "auto", borderBottom: "1px solid #f0f0f2", marginBottom: 20 }}>
+        {/* BARRA DE SECCIONES (tarjeta blanca, fiel al HTML) */}
+        <div className="ps-scroll" style={{ display: "flex", gap: 6, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: 6, boxShadow: "0 4px 14px rgba(0,0,0,.05)", marginBottom: 18, overflowX: "auto" }}>
           {tabs.map((tb) => {
             const on = active === tb.key;
             return (
-              <button key={tb.key} className="ps-tab" onClick={() => { setActive(tb.key); setShowCategoria({ state: false, _id: "" }); }} style={{ color: on ? "#EF5B94" : "#6b6b72" }}>
+              <button key={tb.key} className="ps-seg" onClick={() => { setActive(tb.key); setShowCategoria({ state: false, _id: "" }); }} style={{ flex: 1, textAlign: "center", padding: "10px 8px", borderRadius: 10, font: "600 13px Poppins", cursor: "pointer", background: "transparent", color: on ? "#EF5B94" : "#6b6b72", border: "none", whiteSpace: "nowrap", transition: "all .15s" }}>
                 {tb.label}
-                {on && <span style={{ position: "absolute", left: 0, right: 0, bottom: -1, height: 2.5, borderRadius: 3, background: "#EF5B94" }} />}
               </button>
             );
           })}
@@ -227,7 +226,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
                 </div>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }}>
                   <button className="ps-btn2" onClick={() => { if (!isAllowed()) { ht(); return; } setShowDup(true); }} style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 14px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer", whiteSpace: "nowrap" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v12M7 10l5 5 5-5M4 21h16" /></svg>{t("import")}</button>
-                  <ExportExcelPresupuesto />
+                  <ExportExcelPresupuesto studio />
                 </div>
               </div>
 

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -12,7 +12,6 @@ import ClickAwayListener from "react-click-away-listener";
 import BlockTitle from "../Utils/BlockTitle";
 import FormCrearCategoria from "../Forms/FormCrearCategoria";
 import BlockCategoria from "./BlockCategoria";
-import Grafico from "./Grafico";
 import BlockPagos from "./BlockPagos";
 import { ExcelView } from "./ExcelView";
 import WeddingFinanceManager from "./TableroPresupuesto/WeddingFinanceManager";
@@ -39,6 +38,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
   const [totDraft, setTotDraft] = useState("");
   const [showZero, setShowZero] = useState(false);
   const [curOpen, setCurOpen] = useState(false);
+  const [donutOpen, setDonutOpen] = useState(false);
   const [confirmCat, setConfirmCat] = useState<any>(null);
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -61,6 +61,23 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     const sumFinal = cats.reduce((s, c) => s + (c.coste_final || 0), 0);
     return { total, pagado, costeFinal, porPagar, disponible, paidW, dueW, catsActive: active, catsZero: zero, sumEst, sumFinal };
   }, [p, cats]);
+
+  // Donut "¿Cuánto cuesta mi evento?" — distribución del gasto real (coste_final) por categoría.
+  const donut = useMemo(() => {
+    const COLORS = ["#EF5B94", "#5FBE8E", "#F4A26B", "#5EC0C4", "#8E8CE0", "#C58BD8", "#E7C24B", "#7BC67E", "#F0885A", "#6AA9E0", "#E0728F", "#9BD07B"];
+    const CIRC = 490.09; // 2·π·78
+    const data = cats.filter((c) => (c.coste_final || 0) > 0).map((c) => ({ nombre: c.nombre, val: c.coste_final || 0 })).sort((a, b) => b.val - a.val);
+    const totalG = data.reduce((s, d) => s + d.val, 0);
+    let off = 0;
+    const segs = data.map((d, i) => {
+      const frac = totalG > 0 ? d.val / totalG : 0;
+      const arc = frac * CIRC;
+      const seg = { color: COLORS[i % COLORS.length], arc, offset: -off, pct: Math.round(frac * 100), val: d.val, nombre: d.nombre };
+      off += arc;
+      return seg;
+    });
+    return { segs, totalG, CIRC };
+  }, [cats]);
 
   const excedido = disponible < 0;
   const frMsgBg = total === 0 ? "#FBF0DA" : excedido ? "#FBF0DA" : "#E4F5EE";
@@ -150,6 +167,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     .ps-mod:hover{color:#EF5B94!important;}
     .ps-scroll{scrollbar-width:none;-ms-overflow-style:none;}
     .ps-scroll::-webkit-scrollbar{display:none;}
+    @keyframes grow{from{opacity:0;transform:scale(.96);}to{opacity:1;transform:scale(1);}}
   `;
 
   const catRow = (c: any, faded = false) => {
@@ -338,10 +356,44 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
                 {showCategoria.state ? (
                   <BlockCategoria showCategoria={showCategoria} setShowCategoria={setShowCategoria} setGetId={setGetId} categorias_array={cats} />
                 ) : (
-                  <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: "18px 20px" }}>
-                    <div style={{ font: "700 15px Poppins", color: "#3A3A42", marginBottom: 4 }}>{t("Distribución por categoría")}</div>
-                    <div style={{ font: "500 11.5px Poppins", color: "#a0a0a8", marginBottom: 8 }}>{t("Toca una categoría para ver sus gastos")}</div>
-                    <Grafico categorias={cats} />
+                  <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: 20 }}>
+                    {/* Cabecera clicable → alterna abierto/cerrado */}
+                    <div onClick={() => setDonutOpen((v) => !v)} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer", gap: 10 }}>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ font: "700 15px Poppins", color: "#3A3A42" }}>{t("¿Cuánto cuesta mi evento?")}</div>
+                        <div style={{ font: "500 11.5px Poppins", color: "#a0a0a8", marginTop: 2 }}>{t("Distribución del gasto real por categoría")}</div>
+                      </div>
+                      <span style={{ font: "600 12px Poppins", color: "#EF5B94", whiteSpace: "nowrap", textDecoration: "underline", textUnderlineOffset: 3, flex: "none" }}>{donutOpen ? t("Ocultar") : t("Ver distribución")}</span>
+                    </div>
+
+                    {donutOpen && (donut.totalG > 0 ? (
+                      <>
+                        <div style={{ position: "relative", display: "flex", justifyContent: "center", alignItems: "center", height: 220, animation: "grow .5s ease" }}>
+                          <svg width="200" height="200" viewBox="0 0 200 200">
+                            <circle cx="100" cy="100" r="78" fill="none" stroke="#f2f2f4" strokeWidth="26" />
+                            {donut.segs.map((s, i) => (
+                              <circle key={i} cx="100" cy="100" r="78" fill="none" stroke={s.color} strokeWidth="26" strokeDasharray={`${s.arc} ${donut.CIRC}`} strokeDashoffset={s.offset} transform="rotate(-90 100 100)" />
+                            ))}
+                          </svg>
+                          <div style={{ position: "absolute", textAlign: "center" }}>
+                            <div style={{ font: "600 10.5px Poppins", color: "#a0a0a8" }}>{t("Gastado")}</div>
+                            <div style={{ font: "700 20px Poppins", color: "#3A3A42" }}>{getCurrency(donut.totalG, cur)}</div>
+                          </div>
+                        </div>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 9, marginTop: 14 }}>
+                          {donut.segs.map((s, i) => (
+                            <div key={i} style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                              <span style={{ width: 10, height: 10, borderRadius: 3, flex: "none", background: s.color }} />
+                              <div style={{ flex: 1, font: "600 12px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", minWidth: 0 }}>{s.nombre}</div>
+                              <div style={{ font: "600 11.5px Poppins", color: "#a0a0a8" }}>{s.pct}%</div>
+                              <div style={{ font: "700 12px Poppins", color: "#3A3A42", width: 64, textAlign: "right" }}>{getCurrency(s.val, cur)}</div>
+                            </div>
+                          ))}
+                        </div>
+                      </>
+                    ) : (
+                      <div style={{ padding: "26px 6px 6px", textAlign: "center", font: "500 12px Poppins", color: "#a0a0a8" }}>{t("Aún no hay gasto registrado")}</div>
+                    ))}
                   </div>
                 )}
               </div>

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -7,10 +7,8 @@ import { fetchApiEventos, queries } from "../../utils/Fetching";
 import { getCurrency } from "../../utils/Funciones";
 import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
-import ModalLeft from "../Utils/ModalLeft";
 import ClickAwayListener from "react-click-away-listener";
 import BlockTitle from "../Utils/BlockTitle";
-import FormCrearCategoria from "../Forms/FormCrearCategoria";
 import BlockCategoria from "./BlockCategoria";
 import BlockPagos from "./BlockPagos";
 import { ExcelView } from "./ExcelView";
@@ -21,6 +19,9 @@ import { DuplicatePresupuesto } from "./DuplicatePesupuesto";
 interface Props {
   categorias: any[];
 }
+
+// Nombre de categoría: iniciar SIEMPRE con mayúscula (solo la primera letra, resto tal cual).
+const cap1 = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s || "");
 
 const PresupuestoStudio: FC<Props> = ({ categorias }) => {
   const { t } = useTranslation();
@@ -33,6 +34,9 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
   const [showCategoria, setShowCategoria] = useState<{ state: boolean; _id: string }>({ state: false, _id: "" });
   const [getId, setGetId] = useState<any>();
   const [showCreateCat, setShowCreateCat] = useState(false);
+  const [ncName, setNcName] = useState("");
+  const [ncEst, setNcEst] = useState("");
+  const [ncSaving, setNcSaving] = useState(false);
   const [showDup, setShowDup] = useState(false);
   const [totOpen, setTotOpen] = useState(false);
   const [totDraft, setTotDraft] = useState("");
@@ -133,6 +137,53 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     }).catch(() => { });
   };
 
+  // Parseo de importe en formato español: "1.500" -> 1500, "1500,50" -> 1500.5
+  const parseEs = (s: string) => {
+    const n = parseFloat(String(s).replace(/[^\d.,]/g, "").replace(/\./g, "").replace(",", "."));
+    return Number.isNaN(n) ? 0 : n;
+  };
+
+  const closeCreateCat = () => { setShowCreateCat(false); setNcName(""); setNcEst(""); };
+
+  const createCategoria = async () => {
+    const nombre = ncName.trim();
+    if (!nombre || ncSaving) return;
+    if (!isAllowed()) { ht(); return; }
+    setNcSaving(true);
+    try {
+      const prevIds = new Set((event?.presupuesto_objeto?.categorias_array || []).map((c: any) => c._id));
+      const result: any = await fetchApiEventos({
+        query: queries.nuevoCategoria,
+        variables: { evento_id: event._id, nombre },
+      });
+      if (result?.success === false && Array.isArray(result?.errors) && result.errors.length) {
+        setNcSaving(false);
+        toast("error", t("Ha ocurrido un error"));
+        return;
+      }
+      let po = result?.evento?.presupuesto_objeto;
+      const est = parseEs(ncEst);
+      if (est > 0 && Array.isArray(po?.categorias_array)) {
+        const nueva = po.categorias_array.find((c: any) => !prevIds.has(c._id))
+          || [...po.categorias_array].reverse().find((c: any) => String(c.nombre || "").toLowerCase() === nombre.toLowerCase());
+        if (nueva?._id) {
+          const r2: any = await fetchApiEventos({
+            query: queries.editCategoria,
+            variables: { evento_id: event._id, categoria_id: nueva._id, updates: { coste_estimado: est } },
+          });
+          if (r2?.evento?.presupuesto_objeto) po = r2.evento.presupuesto_objeto;
+        }
+      }
+      if (po) setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po }));
+      closeCreateCat();
+      toast("success", t("Categoría creada"));
+    } catch (e) {
+      toast("error", t("Ha ocurrido un error"));
+    } finally {
+      setNcSaving(false);
+    }
+  };
+
   const deleteCat = async (categoria: any) => {
     try {
       await fetchApiEventos({
@@ -165,6 +216,8 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     .ps-del:hover{background:#FBE4EF!important;color:#D83E7C!important;}
     .ps-btn2:hover{background:#faf9fb!important;color:#3A3A42!important;}
     .ps-mod:hover{color:#EF5B94!important;}
+    .ps-ncinput:focus{border-color:#EF5B94!important;}
+    .ps-close:hover{background:#faf9fb!important;color:#3A3A42!important;}
     .ps-scroll{scrollbar-width:none;-ms-overflow-style:none;}
     .ps-scroll::-webkit-scrollbar{display:none;}
     @keyframes grow{from{opacity:0;transform:scale(.96);}to{opacity:1;transform:scale(1);}}
@@ -178,10 +231,10 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     const stTitle = fin === 0 ? t("Sin gasto") : fin > est ? t("Excedido") : t("Dentro del estimado");
     const totCol = fin > est && fin > 0 ? "#D83E7C" : "#3A3A42";
     return (
-      <div key={c._id} className="ps-row" onClick={() => selectCat(c)} style={{ display: "grid", gridTemplateColumns: "minmax(120px,1fr) 76px 76px 18px 32px", gap: 8, alignItems: "center", padding: faded ? "9px 18px" : "12px 18px", borderBottom: "1px solid #f6f6f8", cursor: "pointer", background: showCategoria._id === c._id ? "#FCF4F8" : "#fff" }}>
+      <div key={c._id} className="ps-row" onClick={() => selectCat(c)} style={{ display: "grid", gridTemplateColumns: "minmax(120px,1fr) 76px 76px 18px 32px", gap: 8, alignItems: "center", padding: faded ? "9px 18px" : "12px 18px", borderBottom: "1px solid #f6f6f8", cursor: "pointer", background: showCategoria._id === c._id ? "#FCE7F0" : "#fff" }}>
         <div style={{ minWidth: 0 }}>
-          <div style={{ font: faded ? "500 12.5px Poppins" : "600 13px Poppins", color: faded ? "#a0a0a8" : "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{c.nombre}</div>
-          {!faded && <div style={{ height: 4, borderRadius: 4, background: "#f0f0f2", marginTop: 5, overflow: "hidden" }}><div style={{ height: "100%", width: `${barW}%`, background: "#EF5B94", borderRadius: 4, transition: "width .8s cubic-bezier(.2,.7,.2,1)" }} /></div>}
+          <div style={{ font: faded ? "500 12.5px Poppins" : "600 13px Poppins", color: faded ? "#a0a0a8" : "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{cap1(c.nombre)}</div>
+          {!faded && <div style={{ height: 4, borderRadius: 4, background: "#f0f0f2", marginTop: 5, overflow: "hidden" }}><div style={{ height: "100%", width: `${barW}%`, background: fin > est ? "#D83E7C" : "#EF5B94", borderRadius: 4, transition: "width .8s cubic-bezier(.2,.7,.2,1)" }} /></div>}
         </div>
         <div style={{ textAlign: "right", font: faded ? "500 12px Poppins" : "600 12.5px Poppins", color: faded ? "#b3b3ba" : "#8a8a90" }}>{getCurrency(est, cur)}</div>
         <div style={{ textAlign: "right", font: faded ? "500 12px Poppins" : "700 12.5px Poppins", color: faded ? "#c0c0c8" : totCol }}>{getCurrency(fin, cur)}</div>
@@ -195,10 +248,29 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     <div className="w-full h-full flex flex-col" style={{ background: "#faf9fb", fontFamily: "'Poppins',sans-serif" }}>
       <style dangerouslySetInnerHTML={{ __html: CATSTYLE }} />
 
-      {showCreateCat && (
-        <ModalLeft state={showCreateCat} set={setShowCreateCat}>
-          <FormCrearCategoria state={showCreateCat} set={setShowCreateCat} />
-        </ModalLeft>
+      {showCreateCat && mounted && typeof document !== "undefined" && createPortal(
+        <div onClick={closeCreateCat} style={{ position: "fixed", inset: 0, background: "rgba(30,30,40,.38)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9999, padding: 20, fontFamily: "'Poppins',sans-serif" }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ background: "#fff", borderRadius: 16, boxShadow: "0 20px 50px rgba(0,0,0,.2)", width: "min(420px,92vw)", padding: "26px 28px", animation: "grow .25s ease" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
+              <div style={{ font: "700 17px Poppins", color: "#3A3A42" }}>{t("Nueva categoría")}</div>
+              <button className="ps-close" title={t("Cerrar")} onClick={closeCreateCat} style={{ width: 30, height: 30, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M18 6L6 18M6 6l12 12" /></svg></button>
+            </div>
+            <div style={{ font: "500 12px Poppins", color: "#8a8a90", marginBottom: 18 }}>{t("Crea una categoría para organizar los gastos de tu evento.")}</div>
+            <div style={{ marginBottom: 14 }}>
+              <div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Nombre de la categoría")}</div>
+              <input className="ps-ncinput" autoFocus value={ncName} onChange={(e) => setNcName(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") createCategoria(); }} placeholder={t("Ej. Transporte") as string} style={{ width: "100%", padding: "11px 14px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 13.5px Poppins", color: "#3A3A42", outline: "none" }} />
+            </div>
+            <div style={{ marginBottom: 22 }}>
+              <div style={{ font: "600 12px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Presupuesto estimado")} <span style={{ fontWeight: 500, color: "#a0a0a8" }}>({t("opcional")})</span></div>
+              <input className="ps-ncinput" value={ncEst} onChange={(e) => setNcEst(e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") createCategoria(); }} placeholder="0 €" style={{ width: "100%", padding: "11px 14px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "500 13.5px Poppins", color: "#3A3A42", outline: "none" }} />
+            </div>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button className="ps-btn2" onClick={closeCreateCat} style={{ padding: "10px 18px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12.5px Poppins", cursor: "pointer" }}>{t("Cancelar")}</button>
+              <button onClick={createCategoria} disabled={!ncName.trim() || ncSaving} style={{ padding: "10px 20px", borderRadius: 10, background: ncName.trim() ? "#EF5B94" : "#c8c8ce", border: "none", color: "#fff", font: "600 12.5px Poppins", cursor: ncName.trim() ? "pointer" : "default", boxShadow: "0 6px 16px rgba(239,91,148,.25)", transition: "background .15s" }}>{t("createcategory")}</button>
+            </div>
+          </div>
+        </div>,
+        document.body
       )}
       {showDup && (
         <div className="absolute z-50 flex justify-center w-full">
@@ -333,7 +405,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
                   <>
                     <div className="ps-row" onClick={() => setShowZero((v) => !v)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 18px", borderBottom: "1px solid #f6f6f8", cursor: "pointer", font: "600 12.5px Poppins", color: "#8a8a90" }}>
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ transform: showZero ? "rotate(180deg)" : "none", transition: "transform .15s" }}><path d="M6 9l6 6 6-6" /></svg>
-                      {showZero ? t("Ocultar categorías sin gasto") : `${t("Ver categorías sin gasto")} (${catsZero.length})`}
+                      {showZero ? t("Ocultar categorías sin gasto") : `${t("Ver")} ${catsZero.length} ${catsZero.length === 1 ? t("categoría sin gasto") : t("categorías sin gasto")}`}
                     </div>
                     {showZero && catsZero.map((c) => catRow(c, true))}
                   </>
@@ -343,11 +415,6 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
                   <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(sumEst, cur)}</div>
                   <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#EF5B94" }}>{getCurrency(sumFinal, cur)}</div>
                   <div /><div />
-                </div>
-                <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 18px 14px", font: "500 10.5px Poppins", color: "#a0a0a8", flexWrap: "wrap" }}>
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#2FB37E" }} />{t("Dentro del estimado")}</span>
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#D83E7C" }} />{t("Excedido")}</span>
-                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#d6d6dc" }} />{t("Sin gasto")}</span>
                 </div>
               </div>
 
@@ -384,7 +451,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
                           {donut.segs.map((s, i) => (
                             <div key={i} style={{ display: "flex", alignItems: "center", gap: 10 }}>
                               <span style={{ width: 10, height: 10, borderRadius: 3, flex: "none", background: s.color }} />
-                              <div style={{ flex: 1, font: "600 12px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", minWidth: 0 }}>{s.nombre}</div>
+                              <div style={{ flex: 1, font: "600 12px Poppins", color: "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", minWidth: 0 }}>{cap1(s.nombre)}</div>
                               <div style={{ font: "600 11.5px Poppins", color: "#a0a0a8" }}>{s.pct}%</div>
                               <div style={{ font: "700 12px Poppins", color: "#3A3A42", width: 64, textAlign: "right" }}>{getCurrency(s.val, cur)}</div>
                             </div>

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -9,7 +9,7 @@ import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
 import ClickAwayListener from "react-click-away-listener";
 import BlockTitle from "../Utils/BlockTitle";
-import BlockCategoria from "./BlockCategoria";
+import DetalleCategoriaStudio from "./DetalleCategoriaStudio";
 import BlockPagos from "./BlockPagos";
 import { ExcelView } from "./ExcelView";
 import WeddingFinanceManager from "./TableroPresupuesto/WeddingFinanceManager";
@@ -421,7 +421,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
               {/* DERECHA: DETALLE o DONUT */}
               <div className="min-w-0">
                 {showCategoria.state ? (
-                  <BlockCategoria showCategoria={showCategoria} setShowCategoria={setShowCategoria} setGetId={setGetId} categorias_array={cats} />
+                  <DetalleCategoriaStudio categoriaId={showCategoria._id} onClose={() => setShowCategoria({ state: false, _id: "" })} />
                 ) : (
                   <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: 20 }}>
                     {/* Cabecera clicable → alterna abierto/cerrado */}

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -1,0 +1,322 @@
+import { FC, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useEffect } from "react";
+import { AuthContextProvider, EventContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+import { fetchApiEventos, queries } from "../../utils/Fetching";
+import { getCurrency } from "../../utils/Funciones";
+import { useAllowed } from "../../hooks/useAllowed";
+import { useToast } from "../../hooks/useToast";
+import ModalLeft from "../Utils/ModalLeft";
+import FormCrearCategoria from "../Forms/FormCrearCategoria";
+import BlockCategoria from "./BlockCategoria";
+import Grafico from "./Grafico";
+import BlockPagos from "./BlockPagos";
+import { ExcelView } from "./ExcelView";
+import WeddingFinanceManager from "./TableroPresupuesto/WeddingFinanceManager";
+import ExportExcelPresupuesto from "./ExportExcelPresupuesto";
+import { DuplicatePresupuesto } from "./DuplicatePesupuesto";
+
+interface Props {
+  categorias: any[];
+}
+
+const PresupuestoStudio: FC<Props> = ({ categorias }) => {
+  const { t } = useTranslation();
+  const { event, setEvent } = EventContextProvider() as any;
+  const { user } = AuthContextProvider() as any;
+  const [isAllowed, ht] = useAllowed();
+  const toast = useToast();
+
+  const [active, setActive] = useState("resumen");
+  const [showCategoria, setShowCategoria] = useState<{ state: boolean; _id: string }>({ state: false, _id: "" });
+  const [getId, setGetId] = useState<any>();
+  const [showCreateCat, setShowCreateCat] = useState(false);
+  const [showDup, setShowDup] = useState(false);
+  const [totOpen, setTotOpen] = useState(false);
+  const [totDraft, setTotDraft] = useState("");
+  const [showZero, setShowZero] = useState(false);
+  const [confirmCat, setConfirmCat] = useState<any>(null);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const p = event?.presupuesto_objeto || {};
+  const cur = p.currency;
+  const cats = Array.isArray(categorias) ? categorias : [];
+
+  const { total, pagado, costeFinal, porPagar, disponible, paidW, dueW, catsActive, catsZero, sumEst, sumFinal } = useMemo(() => {
+    const total = typeof p.presupuesto_total === "number" ? p.presupuesto_total : (p.coste_estimado || 0);
+    const pagado = p.pagado || 0;
+    const costeFinal = p.coste_final || 0;
+    const porPagar = Math.max(0, costeFinal - pagado);
+    const disponible = total - costeFinal;
+    const paidW = total > 0 ? Math.min(100, (pagado / total) * 100) : 0;
+    const dueW = total > 0 ? Math.min(100 - paidW, (porPagar / total) * 100) : 0;
+    const active = cats.filter((c) => (c.coste_final || 0) > 0 || (c.coste_estimado || 0) > 0);
+    const zero = cats.filter((c) => !((c.coste_final || 0) > 0 || (c.coste_estimado || 0) > 0));
+    const sumEst = cats.reduce((s, c) => s + (c.coste_estimado || 0), 0);
+    const sumFinal = cats.reduce((s, c) => s + (c.coste_final || 0), 0);
+    return { total, pagado, costeFinal, porPagar, disponible, paidW, dueW, catsActive: active, catsZero: zero, sumEst, sumFinal };
+  }, [p, cats]);
+
+  const excedido = disponible < 0;
+  const frMsgBg = total === 0 ? "#FBF0DA" : excedido ? "#FBF0DA" : "#E4F5EE";
+  const frMsgFg = total === 0 ? "#B4801F" : excedido ? "#B4801F" : "#2FB37E";
+  const fraseResumen = total === 0
+    ? t("Define tu presupuesto total para empezar")
+    : excedido
+      ? `${t("Te has excedido")} ${getCurrency(Math.abs(disponible), cur)}`
+      : `${t("Vas por buen camino")} · ${getCurrency(disponible, cur)} ${t("disponibles")}`;
+
+  const isOwner = event?.usuario_id === user?.uid;
+
+  const tabs = [
+    { key: "resumen", label: t("budget") },
+    { key: "excelView", label: t("budgetdetails") },
+    { key: "pagos", label: t("payments") },
+    { key: "pendiente", label: t("pendingpayments") },
+    ...(isOwner ? [{ key: "dashboard", label: t("dashboard") }] : []),
+  ];
+
+  const saveTotal = async () => {
+    if (!isAllowed()) { ht(); return; }
+    const val = parseFloat(String(totDraft).replace(/[^0-9.,]/g, "").replace(",", "."));
+    if (Number.isNaN(val)) { setTotOpen(false); return; }
+    try {
+      const result: any = await fetchApiEventos({
+        query: queries.editPresupuesto,
+        variables: { evento_id: event._id, datos: { presupuesto_total: val } },
+      });
+      const po = result?.evento?.presupuesto_objeto;
+      setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po || { ...prev.presupuesto_objeto, presupuesto_total: val } }));
+      setTotOpen(false);
+    } catch (e) {
+      toast("error", t("Ha ocurrido un error"));
+    }
+  };
+
+  const deleteCat = async (categoria: any) => {
+    try {
+      await fetchApiEventos({
+        query: queries.borraCategoria,
+        variables: { evento_id: event._id, categoria_id: categoria._id },
+      });
+      setEvent((prev: any) => ({
+        ...prev,
+        presupuesto_objeto: {
+          ...prev.presupuesto_objeto,
+          categorias_array: (prev.presupuesto_objeto?.categorias_array || []).filter((c: any) => c._id !== categoria._id),
+        },
+      }));
+      if (showCategoria._id === categoria._id) setShowCategoria({ state: false, _id: "" });
+      toast("success", t("Categoría eliminada"));
+    } catch (e) {
+      toast("error", t("Ha ocurrido un error"));
+    } finally {
+      setConfirmCat(null);
+    }
+  };
+
+  const selectCat = (c: any) => setShowCategoria({ state: true, _id: c._id });
+
+  const CATSTYLE = `
+    .ps-tab{background:none;border:none;cursor:pointer;padding:10px 2px;font:600 13.5px Poppins;white-space:nowrap;position:relative;transition:color .15s;}
+    .ps-row:hover{background:#faf9fb!important;}
+    .ps-del:hover{background:#FBE4EF!important;color:#D83E7C!important;}
+    .ps-btn2:hover{background:#faf9fb!important;color:#3A3A42!important;}
+    .ps-mod:hover{color:#EF5B94!important;}
+    .ps-scroll{scrollbar-width:none;-ms-overflow-style:none;}
+    .ps-scroll::-webkit-scrollbar{display:none;}
+  `;
+
+  const catRow = (c: any, faded = false) => {
+    const est = c.coste_estimado || 0;
+    const fin = c.coste_final || 0;
+    const barW = est > 0 ? Math.min(100, (fin / est) * 100) : (fin > 0 ? 100 : 0);
+    const stColor = fin === 0 ? "#d6d6dc" : fin > est ? "#D83E7C" : "#2FB37E";
+    const stTitle = fin === 0 ? t("Sin gasto") : fin > est ? t("Excedido") : t("Dentro del estimado");
+    const totCol = fin > est && fin > 0 ? "#D83E7C" : "#3A3A42";
+    return (
+      <div key={c._id} className="ps-row" onClick={() => selectCat(c)} style={{ display: "grid", gridTemplateColumns: "minmax(120px,1fr) 76px 76px 18px 32px", gap: 8, alignItems: "center", padding: faded ? "9px 18px" : "12px 18px", borderBottom: "1px solid #f6f6f8", cursor: "pointer", background: showCategoria._id === c._id ? "#FCF4F8" : "#fff" }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ font: faded ? "500 12.5px Poppins" : "600 13px Poppins", color: faded ? "#a0a0a8" : "#3A3A42", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{c.nombre}</div>
+          {!faded && <div style={{ height: 4, borderRadius: 4, background: "#f0f0f2", marginTop: 5, overflow: "hidden" }}><div style={{ height: "100%", width: `${barW}%`, background: "#EF5B94", borderRadius: 4, transition: "width .8s cubic-bezier(.2,.7,.2,1)" }} /></div>}
+        </div>
+        <div style={{ textAlign: "right", font: faded ? "500 12px Poppins" : "600 12.5px Poppins", color: faded ? "#b3b3ba" : "#8a8a90" }}>{getCurrency(est, cur)}</div>
+        <div style={{ textAlign: "right", font: faded ? "500 12px Poppins" : "700 12.5px Poppins", color: faded ? "#c0c0c8" : totCol }}>{getCurrency(fin, cur)}</div>
+        <div style={{ display: "flex", justifyContent: "center" }} title={stTitle}><span style={{ width: 9, height: 9, borderRadius: "50%", background: stColor }} /></div>
+        <button className="ps-del" onClick={(e) => { e.stopPropagation(); if (!isAllowed()) { ht(); return; } setConfirmCat(c); }} style={{ width: 30, height: 30, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#c8c8ce", background: "none", border: "none", cursor: "pointer" }}><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13" /></svg></button>
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-full h-full flex flex-col" style={{ background: "#faf9fb", fontFamily: "'Poppins',sans-serif" }}>
+      <style dangerouslySetInnerHTML={{ __html: CATSTYLE }} />
+
+      {showCreateCat && (
+        <ModalLeft state={showCreateCat} set={setShowCreateCat}>
+          <FormCrearCategoria state={showCreateCat} set={setShowCreateCat} />
+        </ModalLeft>
+      )}
+      {showDup && (
+        <div className="absolute z-50 flex justify-center w-full">
+          <DuplicatePresupuesto showModalDuplicate={showDup} setModal={setShowDup} />
+        </div>
+      )}
+
+      {/* Confirmación borrar categoría */}
+      {confirmCat && mounted && typeof document !== "undefined" && createPortal(
+        <div onClick={() => setConfirmCat(null)} style={{ position: "fixed", inset: 0, zIndex: 9999, background: "rgba(43,43,48,.5)", display: "flex", alignItems: "center", justifyContent: "center", padding: 20, fontFamily: "'Poppins',sans-serif" }}>
+          <div onClick={(e) => e.stopPropagation()} style={{ width: "100%", maxWidth: 320, background: "#fff", borderRadius: 16, boxShadow: "0 30px 80px rgba(0,0,0,.3)", padding: "22px 22px 18px", textAlign: "center" }}>
+            <div style={{ width: 42, height: 42, borderRadius: "50%", background: "#FBE4EF", display: "flex", alignItems: "center", justifyContent: "center", color: "#D83E7C", margin: "0 auto 12px" }}><svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.9}><path d="M4 7h16M9 7V5.5A1.5 1.5 0 0 1 10.5 4h3A1.5 1.5 0 0 1 15 5.5V7m3 0v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7" /></svg></div>
+            <div style={{ font: "600 14.5px Poppins", color: "#3A3A42", marginBottom: 6 }}>{t("¿Borrar")} "{confirmCat.nombre}"?</div>
+            <div style={{ font: "400 12px/1.55 Poppins", color: "#8a8a90", marginBottom: 18 }}>{t("Se eliminará la categoría y sus gastos.")} <b style={{ color: "#D83E7C", fontWeight: 600 }}>{t("Es definitivo")}</b>.</div>
+            <div style={{ display: "flex", gap: 9, justifyContent: "center" }}>
+              <button onClick={() => setConfirmCat(null)} style={{ flex: 1, padding: 10, borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer" }}>{t("Cancelar")}</button>
+              <button onClick={() => deleteCat(confirmCat)} style={{ flex: 1, padding: 10, borderRadius: 10, background: "#D83E7C", border: "none", color: "#fff", font: "600 12px Poppins", cursor: "pointer", boxShadow: "0 6px 16px rgba(216,62,124,.3)" }}>{t("Borrar")}</button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {/* Contenedor centrado */}
+      <div className="mx-auto w-full ps-scroll" style={{ maxWidth: 1080, padding: "8px 16px 40px", overflowY: "auto", flex: 1 }}>
+
+        {/* TABS sin recuadro */}
+        <div className="ps-scroll" style={{ display: "flex", gap: 24, overflowX: "auto", borderBottom: "1px solid #f0f0f2", marginBottom: 20 }}>
+          {tabs.map((tb) => {
+            const on = active === tb.key;
+            return (
+              <button key={tb.key} className="ps-tab" onClick={() => { setActive(tb.key); setShowCategoria({ state: false, _id: "" }); }} style={{ color: on ? "#EF5B94" : "#6b6b72" }}>
+                {tb.label}
+                {on && <span style={{ position: "absolute", left: 0, right: 0, bottom: -1, height: 2.5, borderRadius: 3, background: "#EF5B94" }} />}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* ===== RESUMEN ===== */}
+        {active === "resumen" && (
+          <div>
+            {/* SUMMARY CARD */}
+            <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, padding: "22px 24px", boxShadow: "0 4px 14px rgba(0,0,0,.05)", marginBottom: 18 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+                <div style={{ width: 44, height: 44, borderRadius: 12, background: "#FCE7F0", display: "flex", alignItems: "center", justifyContent: "center", color: "#EF5B94", flex: "none" }}>
+                  <svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.7} strokeLinecap="round" strokeLinejoin="round"><path d="M19 5c-1.5 0-2.8 1.4-3 2-3.5-1.5-11-.3-11 5 0 1.8 0 3 2 4.5V20h4v-2h3v2h4v-4c1-.5 1.7-1 2-2h2v-4h-2c0-1-.5-1.5-1-2V5z" /><path d="M2 9v1c0 1.1.9 2 2 2h1" /></svg>
+                </div>
+                <div style={{ flex: 1, minWidth: 180 }}>
+                  <div style={{ font: "600 12px Poppins", color: "#8a8a90" }}>{t("Presupuesto total")}</div>
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 10, flexWrap: "wrap" }}>
+                    <div style={{ font: "700 28px Poppins", color: "#3A3A42" }}>{getCurrency(total, cur)}</div>
+                    <span style={{ position: "relative", display: "inline-block" }}>
+                      <button className="ps-mod" onClick={() => { if (!isAllowed()) { ht(); return; } setTotDraft(String(total || "")); setTotOpen((v) => !v); }} style={{ font: "600 12px Poppins", color: "#6b6b72", textDecoration: "underline", textUnderlineOffset: 3, background: "none", border: "none", cursor: "pointer", padding: 0 }}>{t("Modificar")}</button>
+                      {totOpen && (
+                        <div style={{ position: "absolute", top: 22, left: 0, zIndex: 40, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 12, boxShadow: "0 12px 32px rgba(0,0,0,.14)", padding: 14, width: 230 }}>
+                          <div style={{ font: "600 11.5px Poppins", color: "#6b6b72", marginBottom: 6 }}>{t("Nuevo presupuesto total")}</div>
+                          <input value={totDraft} onChange={(e) => setTotDraft(e.target.value)} placeholder="42000" style={{ width: "100%", boxSizing: "border-box", padding: "9px 11px", borderRadius: 10, border: "1.5px solid #E7E7EA", font: "600 13px Poppins", color: "#3A3A42", outline: "none" }} />
+                          <div style={{ display: "flex", gap: 8, marginTop: 10, justifyContent: "flex-end" }}>
+                            <button onClick={() => setTotOpen(false)} style={{ padding: "8px 12px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer" }}>{t("Cancelar")}</button>
+                            <button onClick={saveTotal} style={{ padding: "8px 14px", borderRadius: 10, background: "#EF5B94", border: "none", color: "#fff", font: "600 12px Poppins", cursor: "pointer" }}>{t("Guardar")}</button>
+                          </div>
+                        </div>
+                      )}
+                    </span>
+                  </div>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }}>
+                  <button className="ps-btn2" onClick={() => { if (!isAllowed()) { ht(); return; } setShowDup(true); }} style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 14px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer", whiteSpace: "nowrap" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v12M7 10l5 5 5-5M4 21h16" /></svg>{t("import")}</button>
+                  <ExportExcelPresupuesto />
+                </div>
+              </div>
+
+              {/* Aviso + progreso */}
+              <div style={{ marginTop: 16 }}>
+                <div style={{ display: "inline-flex", alignItems: "center", gap: 9, background: frMsgBg, borderRadius: 999, padding: "9px 16px", font: "500 12.5px Poppins", color: frMsgFg, marginBottom: 14, maxWidth: "100%" }}>
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" style={{ flex: "none" }}><path d="M20 6L9 17l-5-5" /></svg>
+                  <span>{fraseResumen}</span>
+                </div>
+                <div style={{ height: 14, borderRadius: 999, background: "#f0f0f2", overflow: "hidden", display: "flex" }}>
+                  <div style={{ width: `${paidW}%`, background: "#EF5B94", transition: "width .8s cubic-bezier(.2,.7,.2,1)" }} />
+                  <div style={{ width: `${dueW}%`, background: "#F8A9C6", transition: "width .8s cubic-bezier(.2,.7,.2,1)" }} />
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 22, marginTop: 12, flexWrap: "wrap" }}>
+                  {[
+                    { c: "#EF5B94", l: t("Ya pagado"), v: getCurrency(pagado, cur), col: "#3A3A42" },
+                    { c: "#F8A9C6", l: t("Comprometido sin pagar"), v: getCurrency(porPagar, cur), col: "#3A3A42" },
+                    { c: "#e4e4e8", l: t("Aún libre"), v: getCurrency(disponible, cur), col: excedido ? "#D83E7C" : "#2FB37E" },
+                  ].map((it, i) => (
+                    <div key={i} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ width: 10, height: 10, borderRadius: 3, background: it.c, flex: "none" }} />
+                      <div><div style={{ font: "600 11px Poppins", color: "#8a8a90" }}>{it.l}</div><div style={{ font: "700 14px Poppins", color: it.col }}>{it.v}</div></div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* CATEGORÍAS + DONUT/DETALLE */}
+            <div style={{ display: "grid", gridTemplateColumns: "minmax(0,1fr) 1.15fr", gap: 18, alignItems: "start" }} className="ps-grid">
+              {/* TABLA CATEGORÍAS */}
+              <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", overflow: "hidden" }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "16px 18px", borderBottom: "1px solid #f2f2f4" }}>
+                  <div style={{ font: "700 15px Poppins", color: "#3A3A42" }}>{t("Categorías")}</div>
+                  <button className="ps-btn2" onClick={() => { if (!isAllowed()) { ht(); return; } setShowCreateCat(true); }} style={{ display: "flex", alignItems: "center", gap: 7, padding: "10px 16px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12.5px Poppins", whiteSpace: "nowrap", cursor: "pointer" }}><span style={{ fontSize: 14, lineHeight: 1 }}>＋</span>{t("newcategory")}</button>
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "minmax(120px,1fr) 76px 76px 18px 32px", gap: 8, padding: "11px 18px", font: "700 10.5px Poppins", color: "#b3b3ba", letterSpacing: ".6px", textTransform: "uppercase", borderBottom: "1px solid #f2f2f4" }}>
+                  <div>{t("category")}</div><div style={{ textAlign: "right" }}>{t("Presupuesté")}</div><div style={{ textAlign: "right" }}>{t("Gastado")}</div><div /><div />
+                </div>
+                {catsActive.length === 0 && catsZero.length === 0 && (
+                  <div style={{ padding: "34px 18px", textAlign: "center", font: "500 12.5px Poppins", color: "#a0a0a8" }}>{t("Aún no hay categorías")}</div>
+                )}
+                {catsActive.map((c) => catRow(c))}
+                {catsZero.length > 0 && (
+                  <>
+                    <div className="ps-row" onClick={() => setShowZero((v) => !v)} style={{ display: "flex", alignItems: "center", gap: 8, padding: "12px 18px", borderBottom: "1px solid #f6f6f8", cursor: "pointer", font: "600 12.5px Poppins", color: "#8a8a90" }}>
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ transform: showZero ? "rotate(180deg)" : "none", transition: "transform .15s" }}><path d="M6 9l6 6 6-6" /></svg>
+                      {showZero ? t("Ocultar categorías sin gasto") : `${t("Ver categorías sin gasto")} (${catsZero.length})`}
+                    </div>
+                    {showZero && catsZero.map((c) => catRow(c, true))}
+                  </>
+                )}
+                <div style={{ display: "grid", gridTemplateColumns: "minmax(120px,1fr) 76px 76px 18px 32px", gap: 8, padding: "14px 18px", background: "#faf9fb" }}>
+                  <div style={{ font: "700 13px Poppins", color: "#3A3A42" }}>{t("Total")}</div>
+                  <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#3A3A42" }}>{getCurrency(sumEst, cur)}</div>
+                  <div style={{ textAlign: "right", font: "700 13px Poppins", color: "#EF5B94" }}>{getCurrency(sumFinal, cur)}</div>
+                  <div /><div />
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 18px 14px", font: "500 10.5px Poppins", color: "#a0a0a8", flexWrap: "wrap" }}>
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#2FB37E" }} />{t("Dentro del estimado")}</span>
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#D83E7C" }} />{t("Excedido")}</span>
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}><span style={{ width: 8, height: 8, borderRadius: "50%", background: "#d6d6dc" }} />{t("Sin gasto")}</span>
+                </div>
+              </div>
+
+              {/* DERECHA: DETALLE o DONUT */}
+              <div className="min-w-0">
+                {showCategoria.state ? (
+                  <BlockCategoria showCategoria={showCategoria} setShowCategoria={setShowCategoria} setGetId={setGetId} categorias_array={cats} />
+                ) : (
+                  <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: "18px 20px" }}>
+                    <div style={{ font: "700 15px Poppins", color: "#3A3A42", marginBottom: 4 }}>{t("Distribución por categoría")}</div>
+                    <div style={{ font: "500 11.5px Poppins", color: "#a0a0a8", marginBottom: 8 }}>{t("Toca una categoría para ver sus gastos")}</div>
+                    <Grafico categorias={cats} />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ===== OTRAS VISTAS (existentes, se rediseñan en fases siguientes) ===== */}
+        {active === "excelView" && <ExcelView setShowCategoria={setShowCategoria} categorias_array={cats} showCategoria={showCategoria} />}
+        {active === "pagos" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pagado"} />}
+        {active === "pendiente" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pendiente"} />}
+        {active === "dashboard" && isOwner && <WeddingFinanceManager />}
+      </div>
+    </div>
+  );
+};
+
+export default PresupuestoStudio;

--- a/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
+++ b/apps/appEventos/components/Presupuesto/PresupuestoStudio.tsx
@@ -8,6 +8,8 @@ import { getCurrency } from "../../utils/Funciones";
 import { useAllowed } from "../../hooks/useAllowed";
 import { useToast } from "../../hooks/useToast";
 import ModalLeft from "../Utils/ModalLeft";
+import ClickAwayListener from "react-click-away-listener";
+import BlockTitle from "../Utils/BlockTitle";
 import FormCrearCategoria from "../Forms/FormCrearCategoria";
 import BlockCategoria from "./BlockCategoria";
 import Grafico from "./Grafico";
@@ -36,6 +38,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
   const [totOpen, setTotOpen] = useState(false);
   const [totDraft, setTotDraft] = useState("");
   const [showZero, setShowZero] = useState(false);
+  const [curOpen, setCurOpen] = useState(false);
   const [confirmCat, setConfirmCat] = useState<any>(null);
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -95,6 +98,24 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
     }
   };
 
+  const CURRENCIES = [
+    { v: "eur", l: "EUR" }, { v: "usd", l: "USD" }, { v: "mxn", l: "MXN" },
+    { v: "cop", l: "COP" }, { v: "ars", l: "ARS" }, { v: "ves", l: "VES" }, { v: "uyu", l: "UYU" },
+  ];
+
+  const changeCurrency = (moneda: string) => {
+    setCurOpen(false);
+    if (!isAllowed()) { ht(); return; }
+    if (!event?._id) return;
+    fetchApiEventos({
+      query: `mutation($evento_id:ID!,$moneda:String!){ editCurrency(evento_id:$evento_id, moneda:$moneda){ success errors{ field message code } evento{ _id presupuesto_objeto } } }`,
+      variables: { evento_id: event._id, moneda },
+    }).then((result: any) => {
+      const po = result?.evento?.presupuesto_objeto;
+      setEvent((prev: any) => ({ ...prev, presupuesto_objeto: po || { ...prev.presupuesto_objeto, currency: moneda } }));
+    }).catch(() => { });
+  };
+
   const deleteCat = async (categoria: any) => {
     try {
       await fetchApiEventos({
@@ -121,6 +142,8 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
 
   const CATSTYLE = `
     .ps-seg:hover{background:#faf9fb!important;}
+    .ps-cur:hover{background:#faf9fb!important;color:#6b6b72!important;}
+    .ps-curtog:hover{color:#6b6b72!important;}
     .ps-row:hover{background:#faf9fb!important;}
     .ps-del:hover{background:#FBE4EF!important;color:#D83E7C!important;}
     .ps-btn2:hover{background:#faf9fb!important;color:#3A3A42!important;}
@@ -181,11 +204,14 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
         document.body
       )}
 
-      {/* Contenedor centrado */}
-      <div className="mx-auto w-full ps-scroll" style={{ maxWidth: 1080, padding: "8px 16px 40px", overflowY: "auto", flex: 1 }}>
+      {/* Scroll único: título + secciones + contenido bajan juntos, mismo ancho (max-w-screen-lg) */}
+      <div className="ps-scroll" style={{ overflowY: "auto", flex: 1 }}>
+      <div className="max-w-screen-lg mx-auto" style={{ padding: "12px 16px 40px" }}>
+
+        <BlockTitle title={"Presupuesto"} />
 
         {/* BARRA DE SECCIONES (tarjeta blanca, fiel al HTML) */}
-        <div className="ps-scroll" style={{ display: "flex", gap: 6, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: 6, boxShadow: "0 4px 14px rgba(0,0,0,.05)", marginBottom: 18, overflowX: "auto" }}>
+        <div className="ps-scroll" style={{ display: "flex", gap: 6, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 14, padding: 6, boxShadow: "0 4px 14px rgba(0,0,0,.05)", marginTop: 16, marginBottom: 16, overflowX: "auto" }}>
           {tabs.map((tb) => {
             const on = active === tb.key;
             return (
@@ -225,6 +251,21 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
                   </div>
                 </div>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, flexWrap: "wrap" }}>
+                  <div style={{ position: "relative" }}>
+                    <div className="ps-curtog" onClick={() => { if (!isAllowed()) { ht(); return; } setCurOpen((v) => !v); }} title={t("Cambiar moneda")} style={{ display: "flex", alignItems: "center", gap: 4, font: "600 11.5px Poppins", color: "#a0a0a8", cursor: "pointer" }}>
+                      {(cur || "eur").toUpperCase()}
+                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2}><path d="M6 9l6 6 6-6" /></svg>
+                    </div>
+                    {curOpen && (
+                      <ClickAwayListener onClickAway={() => setCurOpen(false)}>
+                        <div style={{ position: "absolute", top: 22, right: 0, zIndex: 40, background: "#fff", border: "1px solid #f0f0f2", borderRadius: 10, boxShadow: "0 12px 32px rgba(0,0,0,.14)", padding: 6, minWidth: 92 }}>
+                          {CURRENCIES.map((c) => (
+                            <div key={c.v} className="ps-cur" onClick={() => changeCurrency(c.v)} style={{ padding: "7px 12px", borderRadius: 8, font: "600 12px Poppins", color: (cur || "eur") === c.v ? "#EF5B94" : "#6b6b72", cursor: "pointer" }}>{c.l}</div>
+                          ))}
+                        </div>
+                      </ClickAwayListener>
+                    )}
+                  </div>
                   <button className="ps-btn2" onClick={() => { if (!isAllowed()) { ht(); return; } setShowDup(true); }} style={{ display: "flex", alignItems: "center", gap: 6, padding: "9px 14px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#6b6b72", font: "600 12px Poppins", cursor: "pointer", whiteSpace: "nowrap" }}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v12M7 10l5 5 5-5M4 21h16" /></svg>{t("import")}</button>
                   <ExportExcelPresupuesto studio />
                 </div>
@@ -313,6 +354,7 @@ const PresupuestoStudio: FC<Props> = ({ categorias }) => {
         {active === "pagos" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pagado"} />}
         {active === "pendiente" && <BlockPagos cate={showCategoria?._id} setGetId={setGetId} getId={getId} categorias_array={cats} estado={"pendiente"} />}
         {active === "dashboard" && isOwner && <WeddingFinanceManager />}
+      </div>
       </div>
     </div>
   );

--- a/apps/appEventos/components/Presupuesto/StudioNotesSection.tsx
+++ b/apps/appEventos/components/Presupuesto/StudioNotesSection.tsx
@@ -1,0 +1,76 @@
+import { FC, useState } from "react";
+import { useCRMNotes } from "@bodasdehoy/shared/crm-ui";
+import { EventContextProvider } from "../../context";
+import { useTranslation } from "react-i18next";
+
+// Notas internas fiel al HTML (Detalle_Categoria.html), reusando el backend real (useCRMNotes).
+interface Props { entityId: string; entityName: string; }
+
+const fmtFecha = (iso?: string) => {
+  if (!iso) return "";
+  try { return new Date(iso).toLocaleDateString("es-ES", { day: "numeric", month: "short", year: "numeric" }); } catch { return ""; }
+};
+
+// Cuerpo (monta el hook solo cuando el acordeón está abierto → no fetch en cerrado).
+const NotesBody: FC<Props> = ({ entityId, entityName }) => {
+  const { t } = useTranslation();
+  const { event } = EventContextProvider() as any;
+  const [text, setText] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const entity: any = { entityId, entityName, entityType: "ENTITY" };
+  const alsoShow: any = event?._id ? [{ entityId: event._id, entityName: event.nombre ?? "Evento", entityType: "EVENTO" }] : [];
+  const { notes, createNote, deleteNote } = useCRMNotes({ entity, alsoShow } as any);
+
+  const save = async () => {
+    const content = text.trim();
+    if (!content || saving) return;
+    setSaving(true);
+    try { await createNote({ content } as any); setText(""); } finally { setSaving(false); }
+  };
+
+  const canSave = !!text.trim() && !saving;
+
+  return (
+    <div style={{ marginTop: 14 }}>
+      {Array.isArray(notes) && notes.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 10, marginBottom: 14 }}>
+          {notes.map((n: any) => (
+            <div key={n.id} style={{ background: "#faf9fb", border: "1px solid #f0f0f2", borderRadius: 12, padding: "12px 14px" }}>
+              <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 10 }}>
+                <div style={{ font: "500 13px Poppins", color: "#3A3A42", lineHeight: 1.5, flex: 1, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{n.content}</div>
+                <button className="sn-x" title={t("Eliminar")} onClick={() => deleteNote(n.id)} style={{ flex: "none", width: 24, height: 24, borderRadius: 7, color: "#c0c0c8", fontSize: 14, background: "none", border: "none", cursor: "pointer" }}>✕</button>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 8 }}>
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 5, font: "600 10.5px Poppins", color: "#EF5B94", background: "#FCE7F0", padding: "3px 10px", borderRadius: 999 }}>{n.author?.name || t("Tú")}</span>
+                <span style={{ font: "500 10.5px Poppins", color: "#a0a0a8", marginLeft: "auto" }}>{fmtFecha(n.createdAt)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <textarea className="sn-ta" value={text} onChange={(e) => setText(e.target.value)} placeholder={t("Escribe una nota interna sobre esta categoría…") as string} style={{ width: "100%", minHeight: 80, resize: "vertical", padding: "12px 14px", borderRadius: 12, border: "1.5px solid #E7E7EA", font: "500 13px Poppins", color: "#3A3A42", outline: "none" }} />
+      <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 12 }}>
+        <button className={canSave ? "sn-save" : ""} onClick={save} disabled={!canSave} style={{ background: canSave ? "#EF5B94" : "#c8c8ce", color: "#fff", border: "none", borderRadius: 12, padding: "10px 22px", font: "600 13px Poppins", cursor: canSave ? "pointer" : "default", whiteSpace: "nowrap" }}>{t("Guardar nota")}</button>
+      </div>
+    </div>
+  );
+};
+
+export const StudioNotesSection: FC<Props> = ({ entityId, entityName }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  if (!entityId) return null;
+  return (
+    <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 16, boxShadow: "0 4px 14px rgba(0,0,0,.05)", padding: "16px 20px", fontFamily: "'Poppins',sans-serif" }}>
+      <style dangerouslySetInnerHTML={{ __html: ".sn-ta:focus{border-color:#EF5B94!important;}.sn-save:hover{background:#D83E7C!important;}.sn-x:hover{background:#FBE4EF!important;color:#D83E7C!important;}" }} />
+      <div onClick={() => setOpen((v) => !v)} style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}>
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#8a8a90" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ transform: open ? "rotate(90deg)" : "none", transition: "transform .18s" }}><path d="M9 6l6 6-6 6" /></svg>
+        <span style={{ font: "600 16px Poppins", color: "#6b6b72" }}>{t("Notas internas")}</span>
+      </div>
+      {open && <NotesBody entityId={entityId} entityName={entityName} />}
+    </div>
+  );
+};
+
+export default StudioNotesSection;

--- a/apps/appEventos/components/Presupuesto/TableroPresupuesto/DepositFormSection.jsx
+++ b/apps/appEventos/components/Presupuesto/TableroPresupuesto/DepositFormSection.jsx
@@ -35,7 +35,7 @@ const DepositFormSection = ({
         query: queries.addWeddingPlannerIngreso,
         variables: {
           evento_id: event?._id,
-          weddingPlannerIngreso: {
+          ingreso: {
             fecha: new Date(),
             monto: values.monto,
             metodo: values.metodoPago,

--- a/apps/appEventos/components/Presupuesto/TableroPresupuesto/DepositsHistory.jsx
+++ b/apps/appEventos/components/Presupuesto/TableroPresupuesto/DepositsHistory.jsx
@@ -29,7 +29,7 @@ const DepositsHistory = ({ deposits, currency }) => {
         query: queries.deleteWeddingPlannerIngreso,
         variables: {
           evento_id: event?._id,
-          weddingPlannerIngreso_id: depositId,
+          ingreso_id: depositId,
         },
       });
 

--- a/apps/appEventos/pages/presupuesto.tsx
+++ b/apps/appEventos/pages/presupuesto.tsx
@@ -100,7 +100,7 @@ const Presupuesto = () => {
     if (!event) return <EventLoadingOrError skeleton={<SkeletonBudget categories={5} />} />
     if (studio) {
       return (
-        <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-[100vh] top-0 left-4" : "w-full h-full"} style={{ background: "#faf9fb" }}>
+        <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-[100vh] top-0 left-4" : "w-full h-full flex flex-col"} style={{ background: "#faf9fb" }}>
           {showInitModal && isAllowed() && (
             <PresupuestoInitModal onClose={() => setShowInitModal(false)} onDuplicate={() => setShowModalDuplicate(true)} />
           )}
@@ -109,10 +109,15 @@ const Presupuesto = () => {
               <DuplicatePresupuesto showModalDuplicate={showModalDuplicate} setModal={setShowModalDuplicate} />
             </div>
           )}
-          <CopilotFilterBar entity="budget_items" />
-          <ModuleErrorBoundary label="Presupuesto">
-            <PresupuestoStudio categorias={categoriasToShow} />
-          </ModuleErrorBoundary>
+          <div className="shrink-0 px-2 md:px-4 pt-2 md:pt-3">
+            <BlockTitle title={"Presupuesto"} />
+          </div>
+          <CopilotFilterBar entity="budget_items" className="shrink-0 mx-2 md:mx-4 mt-2" />
+          <div className="flex-1 min-h-0">
+            <ModuleErrorBoundary label="Presupuesto">
+              <PresupuestoStudio categorias={categoriasToShow} />
+            </ModuleErrorBoundary>
+          </div>
         </section>
       );
     }

--- a/apps/appEventos/pages/presupuesto.tsx
+++ b/apps/appEventos/pages/presupuesto.tsx
@@ -24,9 +24,13 @@ import { DuplicatePresupuesto } from "../components/Presupuesto/DuplicatePesupue
 import { useAllowed } from "../hooks/useAllowed";
 import WeddingFinanceManager from "../components/Presupuesto/TableroPresupuesto/WeddingFinanceManager";
 import { PresupuestoInitModal } from "../components/Presupuesto/PresupuestoInitModal";
+import { useSearchParams } from "next/navigation";
+import PresupuestoStudio from "../components/Presupuesto/PresupuestoStudio";
 
 const Presupuesto = () => {
   useMounted()
+  const searchParams = useSearchParams();
+  const studio = searchParams?.get("studio") !== "legacy";
   useEventSyncWithUrl()  // BUG-12: sincronizar event activo con ?event= de URL
   const { t } = useTranslation();
   const { user, verificationDone, forCms } = AuthContextProvider() as any;
@@ -94,6 +98,24 @@ const Presupuesto = () => {
       )
     }
     if (!event) return <EventLoadingOrError skeleton={<SkeletonBudget categories={5} />} />
+    if (studio) {
+      return (
+        <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-[100vh] top-0 left-4" : "w-full h-full"} style={{ background: "#faf9fb" }}>
+          {showInitModal && isAllowed() && (
+            <PresupuestoInitModal onClose={() => setShowInitModal(false)} onDuplicate={() => setShowModalDuplicate(true)} />
+          )}
+          {showModalDuplicate && (
+            <div className="absolute z-50 flex justify-center w-full">
+              <DuplicatePresupuesto showModalDuplicate={showModalDuplicate} setModal={setShowModalDuplicate} />
+            </div>
+          )}
+          <CopilotFilterBar entity="budget_items" />
+          <ModuleErrorBoundary label="Presupuesto">
+            <PresupuestoStudio categorias={categoriasToShow} />
+          </ModuleErrorBoundary>
+        </section>
+      );
+    }
     return (
       <>
         {event &&

--- a/apps/appEventos/pages/presupuesto.tsx
+++ b/apps/appEventos/pages/presupuesto.tsx
@@ -100,7 +100,7 @@ const Presupuesto = () => {
     if (!event) return <EventLoadingOrError skeleton={<SkeletonBudget categories={5} />} />
     if (studio) {
       return (
-        <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-[100vh] top-0 left-4" : "w-full h-full flex flex-col"} style={{ background: "#faf9fb" }}>
+        <section className={forCms ? "absolute z-[50] w-[calc(100vw-40px)] h-[100vh] top-0 left-4" : "w-full h-full"} style={{ background: "#faf9fb" }}>
           {showInitModal && isAllowed() && (
             <PresupuestoInitModal onClose={() => setShowInitModal(false)} onDuplicate={() => setShowModalDuplicate(true)} />
           )}
@@ -109,15 +109,9 @@ const Presupuesto = () => {
               <DuplicatePresupuesto showModalDuplicate={showModalDuplicate} setModal={setShowModalDuplicate} />
             </div>
           )}
-          <div className="shrink-0 px-2 md:px-4 pt-2 md:pt-3">
-            <BlockTitle title={"Presupuesto"} />
-          </div>
-          <CopilotFilterBar entity="budget_items" className="shrink-0 mx-2 md:mx-4 mt-2" />
-          <div className="flex-1 min-h-0">
-            <ModuleErrorBoundary label="Presupuesto">
-              <PresupuestoStudio categorias={categoriasToShow} />
-            </ModuleErrorBoundary>
-          </div>
+          <ModuleErrorBoundary label="Presupuesto">
+            <PresupuestoStudio categorias={categoriasToShow} />
+          </ModuleErrorBoundary>
         </section>
       );
     }

--- a/apps/appEventos/utils/Fetching.ts
+++ b/apps/appEventos/utils/Fetching.ts
@@ -1344,6 +1344,24 @@ export const queries = {
       evento{ _id presupuesto_objeto }
     }
   }`,
+  // Depósitos Wedding Planner (Dashboard). El backend expone estas mutaciones (verificado por
+  // introspección api-mcp): addWeddingPlannerIngreso(evento_id:ID!, ingreso:JSON!):EventoResponse!
+  // y deleteWeddingPlannerIngreso(evento_id:ID!, ingreso_id:ID!):EventoResponse!. Antes faltaban
+  // en el front (se enviaba query:undefined) → registrar/borrar depósito estaba roto.
+  addWeddingPlannerIngreso: `mutation($evento_id:ID!, $ingreso:JSON!){
+    addWeddingPlannerIngreso(evento_id:$evento_id, ingreso:$ingreso){
+      success
+      errors{ field message code }
+      evento{ _id presupuesto_objeto }
+    }
+  }`,
+  deleteWeddingPlannerIngreso: `mutation($evento_id:ID!, $ingreso_id:ID!){
+    deleteWeddingPlannerIngreso(evento_id:$evento_id, ingreso_id:$ingreso_id){
+      success
+      errors{ field message code }
+      evento{ _id presupuesto_objeto }
+    }
+  }`,
   guardarListaRegalos: `mutation($evento_id: String!, $variable_reemplazar: String, $valor_reemplazar: String){
     editEvento(
       evento_id:$evento_id


### PR DESCRIPTION
Rediseño completo del módulo **Presupuesto** gated `?studio` (rollback `?studio=legacy`), solo front, reusando el backend existente (auditado). 5 vistas fieles a los HTML:

- **Presupuesto (resumen)**: BlockTitle + barra de secciones (tarjeta blanca) + tarjeta resumen (total editable `editPresupuesto` + progreso + pagado/comprometido/libre + moneda `editCurrency` + Importar/Exportar) + tabla de categorías (crear `nuevoCategoria` con modal, borrar `borraCategoria`) + **donut** '¿Cuánto cuesta mi evento?' colapsable + **detalle de categoría** (partidas: `nuevoGasto`/`editGasto`/`borrarGasto`, `nuevoItemGasto`) + **notas internas** (`useCRMNotes`) + **modal Añadir/Editar pago** (`nuevoPago`/`editPago`, 2 modos).
- **Presupuesto detallado**: tabla agrupada + buscador + paneles **Filtros/Info evento/Columnas** propios (fieles al HTML) + editar inline + menú ⋮.
- **Pago** y **Pagos pendientes**: tablas propias (layout por estado) + chip Pagado/Pendiente + Editar/Eliminar (`editPago`/`deletepayment`).
- **Dashboard**: 5 KPIs + registrar depósito (`addWeddingPlannerIngreso`) + Dashboard principal (pagos directos/WP + resumen + distribución) + Historial (`deleteWeddingPlannerIngreso`).

**Fix backend-query (front):** `addWeddingPlannerIngreso`/`deleteWeddingPlannerIngreso` faltaban en `Fetching.ts` (+ args mal en callers legacy) → depósitos rotos → arreglado (mutaciones ya existen en api-mcp, verificado por introspección).

Verificado en app-dev (build kD-L9Z9GVFlOu-w7L0Sgb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)