### PR TITLE
🐛 fix(whatsapp): alta QR nuevo daba 400 (sessionKey = slug, no ObjectId)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/settings/integrations/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/settings/integrations/page.tsx
@@ -33,9 +33,12 @@ function QRModal({
   development: string;
   onClose: () => void;
 }) {
-  const sessionKey = channel?.id ?? development;
+  // F1 estabilización (informe técnico 13-ago): el alta del QR nuevo devolvía 400. El backend
+  // keyea la sesión de WhatsApp por el SLUG del development —igual que WhatsAppDirectSession,
+  // que SÍ funciona— NO por el ObjectId del canal. Pasar `channel.id` mandaba un sessionKey
+  // inválido (un ObjectId opaco) → 400 → modal "congelado" sin QR.
   const { connectedAt, disconnectSession, error, loading, phoneNumber, qrCode, requestPairingCode, startSession, status } =
-    useWhatsAppSession(sessionKey);
+    useWhatsAppSession(development);
 
   const [mode, setMode] = useState<'qr' | 'code'>('qr');
   const [pairingPhone, setPairingPhone] = useState('');


### PR DESCRIPTION
## Informe técnico 13-ago (F1 estabilización)
En `settings/integrations`, "Generar código QR" para un canal **nuevo** hacía `POST /whatsapp/session/<id>/start` → **400**. El `<id>` era el **ObjectId del canal** (`channel.id`) en vez del **slug del development** que espera el backend. Modal "congelado" sin QR.

## Fix
El modal usa `useWhatsAppSession(development)` —igual que `WhatsAppDirectSession`, que SÍ funciona— en vez de `channel?.id ?? development`.

El Content-Type sí lo reenvía el proxy `/api/messages/[...path]` (líneas 62-68); el síntoma "sin Content-Type" del informe era secuencial.

## Desbloquea
QA de los 5 flujos del WhatsApp-gateway (QR aparece/conecta, recibir, enviar, estado sesión, bandeja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)