### PR TITLE
✨ feat(login): registro studio (role-picker + formulario) fiel al HTML

### DIFF
--- a/apps/appEventos/components/Forms/Login/LoginStudio.tsx
+++ b/apps/appEventos/components/Forms/Login/LoginStudio.tsx
@@ -1,16 +1,28 @@
 import { FC, ReactNode, useState } from "react";
 import { AuthContextProvider } from "../../../context";
-import { useAuthentication } from "../../../utils/Authentication";
+import { phoneUtil, useAuthentication } from "../../../utils/Authentication";
 import { GoogleProvider, FacebookProvider } from "../../../firebase";
-import { getAuth, signOut } from "firebase/auth";
+import { getAuth, signOut, createUserWithEmailAndPassword, signInWithCustomToken, updateProfile, UserCredential } from "firebase/auth";
+import { fetchApiBodas, queries } from "../../../utils/Fetching";
+import { setCrossAppIdToken } from "@bodasdehoy/shared/auth";
+import { useToast } from "../../../hooks/useToast";
+import { useActivity } from "../../../hooks/useActivity";
+import { useTranslation } from "react-i18next";
 
 /**
  * LoginStudio — rediseño visual (gate `?studio`) fiel a Login.dc.html.
- * SOLO cambia el aspecto: reusa el MISMO backend de auth que el login legacy
- * (`useAuthentication().signIn` para email/Google/Facebook y `resetPassword`
- * para recuperar). La auth "demo" del HTML (setTimeout) se sustituye por las
- * llamadas reales. El registro delega al flujo existente (`setStage('register')`)
- * para no tocar su backend.
+ * SOLO cambia el aspecto: reusa EXACTAMENTE el mismo backend que el flujo legacy.
+ *  - Login (email/Google/Facebook) → `useAuthentication().signIn`
+ *  - Recuperar contraseña → `useAuthentication().resetPassword`
+ *  - Registro → mismo backend que `FormRegister`: `createUserWithEmailAndPassword`
+ *    (+ fallback `createUserWithPassword`/`signInWithCustomToken` si el email ya existe)
+ *    → `updateProfile(displayName)` → `createUser({role,uid,email,phoneNumber})`.
+ * La auth "demo" del HTML (setTimeout) se sustituye por las llamadas reales.
+ *
+ * NOTA (validación backend): el HTML define 3 perfiles nuevos (Wedding planner /
+ * Organizador / Novios) distintos de los legacy (novia/novio/otro). `createUser`
+ * acepta `role:[String]` libre y ningún flujo de negocio ramifica por ese valor
+ * (solo se compara con 'admin'), así que se guardan tal cual, sin romper nada.
  */
 
 interface Props {
@@ -20,6 +32,8 @@ interface Props {
   setStage: (s: string) => void;
   onClose: () => void;
 }
+
+type View = "login" | "forgot" | "sent" | "register" | "regform";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -39,11 +53,31 @@ const eye = (open: boolean) => (
   </svg>
 );
 
-const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) => {
-  const { SetWihtProvider, setIsStartingRegisterOrLogin } = AuthContextProvider() as any;
-  const { signIn, resetPassword } = useAuthentication();
+// Iconos de perfil (SVG inline, sin assets externos). Pintados en rosa;
+// el filtro grayscale del contenedor los apaga cuando no están seleccionados.
+const ROLES: { key: string; label: string; icon: ReactNode }[] = [
+  {
+    key: "wedding planner", label: "Wedding planner",
+    icon: <svg width="44" height="44" viewBox="0 0 24 24" fill="#EF5B94"><path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.6l-1-1a5.5 5.5 0 1 0-7.8 7.8L12 21l8.8-8.6a5.5 5.5 0 0 0 0-7.8z" /></svg>,
+  },
+  {
+    key: "organizador", label: "Organizador de eventos",
+    icon: <svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round"><rect x="4" y="5" width="16" height="16" rx="2" /><path d="M8 3v4M16 3v4M4 10h16M8 14h5M8 17h8" /></svg>,
+  },
+  {
+    key: "novios", label: "Novios",
+    icon: <svg width="46" height="46" viewBox="0 0 24 24" fill="none" stroke="#EF5B94" strokeWidth={1.8}><circle cx="9" cy="14" r="5" /><circle cx="15" cy="14" r="5" /><path d="M7.5 5.2 9 3l1.5 2.2M13.5 5.2 15 3l1.5 2.2" strokeLinecap="round" strokeLinejoin="round" /></svg>,
+  },
+];
 
-  const [view, setView] = useState<"login" | "forgot" | "sent">("login");
+const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) => {
+  const { SetWihtProvider, setIsStartingRegisterOrLogin, setUser, setVerificationDone, geoInfo, linkMedia, preregister } = AuthContextProvider() as any;
+  const { signIn, resetPassword, getSessionCookie } = useAuthentication();
+  const toast = useToast();
+  const { t } = useTranslation();
+  const [updateActivity, updateActivityLink] = useActivity() as any;
+
+  const [view, setView] = useState<View>("login");
   const [email, setEmail] = useState("");
   const [pw, setPw] = useState("");
   const [showPw, setShowPw] = useState(false);
@@ -58,21 +92,34 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
   const [fLoading, setFLoading] = useState(false);
   const [resent, setResent] = useState(false);
 
+  // Registro
+  const [role, setRole] = useState<string>("");
+  const [rName, setRName] = useState("");
+  const [rEmail, setREmail] = useState("");
+  const [rPw, setRPw] = useState("");
+  const [rShowPw, setRShowPw] = useState(false);
+  const [rPhone, setRPhone] = useState("");
+  const [rLoading, setRLoading] = useState(false);
+  const [rNameErr, setRNameErr] = useState("");
+  const [rEmailErr, setREmailErr] = useState("");
+  const [rPwErr, setRPwErr] = useState("");
+  const [rAuthErr, setRAuthErr] = useState("");
+
+  const ccNum = phoneUtil?.getCountryCodeForRegion(geoInfo?.ipcountry);
+  const countryCode = "+" + (ccNum ? ccNum : "58");
+
   const translateError = (err: any): string => {
     const code = err?.code || "";
     if (
-      code === "auth/wrong-password" ||
-      code === "auth/invalid-credential" ||
-      code === "auth/invalid-login-credentials" ||
-      code === "auth/user-not-found" ||
-      code === "auth/invalid-email"
-    )
-      return "Usuario o contraseña inválida";
+      code === "auth/wrong-password" || code === "auth/invalid-credential" ||
+      code === "auth/invalid-login-credentials" || code === "auth/user-not-found" || code === "auth/invalid-email"
+    ) return "Usuario o contraseña inválida";
     if (code === "auth/too-many-requests") return "Demasiados intentos fallidos. Intenta de nuevo más tarde.";
     if (code === "auth/user-disabled") return "Esta cuenta está deshabilitada. Contacta con soporte.";
+    if (code === "auth/weak-password") return "La contraseña es demasiado débil (mínimo 6 caracteres).";
     if (err?.message?.includes("Timeout Mongo") || err?.message?.includes("Mongo save user"))
       return "El servidor tardó demasiado. Reintenta en unos segundos.";
-    return err?.message || "No se pudo iniciar sesión. Reintenta.";
+    return err?.message || "No se pudo completar. Reintenta.";
   };
 
   const submit = async () => {
@@ -80,9 +127,7 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
     const em = email.trim();
     const emErr = em === "" ? "Escribe tu email" : EMAIL_RE.test(em) ? "" : "Ese email no parece válido";
     const pErr = pw === "" ? "Escribe tu contraseña" : "";
-    setEmailErr(emErr);
-    setPwErr(pErr);
-    setAuthErr("");
+    setEmailErr(emErr); setPwErr(pErr); setAuthErr("");
     if (emErr || pErr) return;
     setLoading(true);
     try {
@@ -95,21 +140,17 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
   };
 
   const google = async () => {
-    setAuthErr("");
+    setAuthErr(""); setRAuthErr("");
     try {
-      await signIn({ type: "provider", payload: GoogleProvider(), setStage, whoYouAre, setIsStartingRegisterOrLogin });
-    } catch (err: any) {
-      setAuthErr(translateError(err));
-    }
+      await signIn({ type: "provider", payload: GoogleProvider(), setStage, whoYouAre: role || whoYouAre, setIsStartingRegisterOrLogin });
+    } catch (err: any) { view === "regform" ? setRAuthErr(translateError(err)) : setAuthErr(translateError(err)); }
   };
 
   const facebook = async () => {
-    setAuthErr("");
+    setAuthErr(""); setRAuthErr("");
     try {
-      await signIn({ type: "provider", payload: FacebookProvider, setStage, whoYouAre, setIsStartingRegisterOrLogin });
-    } catch (err: any) {
-      setAuthErr(translateError(err));
-    }
+      await signIn({ type: "provider", payload: FacebookProvider, setStage, whoYouAre: role || whoYouAre, setIsStartingRegisterOrLogin });
+    } catch (err: any) { view === "regform" ? setRAuthErr(translateError(err)) : setAuthErr(translateError(err)); }
   };
 
   const sendLink = async () => {
@@ -118,20 +159,78 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
     const err = em === "" ? "Escribe tu email" : EMAIL_RE.test(em) ? "" : "Ese email no parece válido";
     setFErr(err);
     if (err) return;
-    setFLoading(true);
-    setResent(false);
+    setFLoading(true); setResent(false);
     try {
-      // resetPassword(values, setStage): en éxito llama al 2º arg → mostramos "enviado".
       await resetPassword({ identifier: em }, () => setView("sent"));
-    } finally {
-      setFLoading(false);
-    }
+    } finally { setFLoading(false); }
   };
 
   const goRegister = () => {
-    setStage("register");
-    SetWihtProvider(false);
-    try { signOut(getAuth()); } catch { }
+    // Flujos especiales (invitación media / preregistro) siguen usando el legacy.
+    if (linkMedia != null || preregister) {
+      setStage("register"); SetWihtProvider(false);
+      try { signOut(getAuth()); } catch { }
+      return;
+    }
+    setRAuthErr(""); setRNameErr(""); setREmailErr(""); setRPwErr("");
+    setView("register");
+  };
+
+  // Crear cuenta — MISMO backend que FormRegister (camino estándar linkMedia==null).
+  const handleRegister = async () => {
+    if (rLoading) return;
+    const nm = rName.trim(), em = rEmail.trim();
+    const e1 = nm === "" ? "Escribe tu nombre" : "";
+    const e2 = em === "" ? "Escribe tu email" : EMAIL_RE.test(em) ? "" : "Ese email no parece válido";
+    const e3 = rPw === "" ? "Escribe una contraseña" : rPw.length < 6 ? "Mínimo 6 caracteres" : "";
+    setRNameErr(e1); setREmailErr(e2); setRPwErr(e3); setRAuthErr("");
+    if (e1 || e2 || e3) return;
+    setRLoading(true);
+    let UserFirebase: any = null;
+    try {
+      setIsStartingRegisterOrLogin(true);
+      try {
+        const cred: UserCredential = await createUserWithEmailAndPassword(getAuth(), em, rPw);
+        UserFirebase = cred.user;
+        const idToken = await cred.user.getIdToken();
+        if (idToken) setCrossAppIdToken(idToken);
+      } catch (error: any) {
+        if (error?.code === "auth/email-already-in-use") {
+          const result = await fetchApiBodas({ query: queries.createUserWithPassword, variables: { email: em, password: rPw }, development: config?.development });
+          if (result === "apiBodas/email-already-in-use") {
+            setRAuthErr("Ese email ya está registrado. Inicia sesión.");
+            setRLoading(false);
+            return;
+          }
+          const cred: UserCredential = await signInWithCustomToken(getAuth(), result);
+          UserFirebase = cred.user;
+          const idToken = await cred.user.getIdToken();
+          if (idToken) setCrossAppIdToken(idToken);
+          await getSessionCookie(idToken);
+        } else {
+          setRAuthErr(translateError(error));
+          setRLoading(false);
+          return;
+        }
+      }
+      const digits = rPhone.replace(/\D/g, "");
+      const phone = digits ? `${countryCode}${digits}` : countryCode;
+      await updateProfile(UserFirebase, { displayName: nm });
+      const moreInfo: any = await fetchApiBodas({
+        query: queries.createUser,
+        variables: { role, uid: UserFirebase.uid, email: UserFirebase?.email, phoneNumber: phone.length < 5 ? undefined : phone },
+        development: config?.development,
+      });
+      setUser({ ...UserFirebase, ...(moreInfo || {}), displayName: UserFirebase?.reloadUserInfo?.displayName ?? nm });
+      toast("success", t("successfulsessionregistration"));
+      try { updateActivity("registered"); updateActivityLink("registered"); } catch { }
+      setVerificationDone(true);
+      // El redirect lo hace el useEffect de pages/login.tsx (user + verificationDone).
+    } catch (err: any) {
+      setRAuthErr(translateError(err));
+    } finally {
+      setRLoading(false);
+    }
   };
 
   const brandHost = (() => {
@@ -143,9 +242,11 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
   const brandHref = brandHost.startsWith("http") ? brandHost : "https://" + brandHost;
 
   const canSubmit = email.trim() !== "" && pw !== "" && !loading;
+  const canCreate = rName.trim() !== "" && rEmail.trim() !== "" && rPw !== "";
   const inSt: any = { width: "100%", padding: "11px 15px", borderRadius: 10, font: "500 13.5px Poppins", color: "#3A3A42", outline: "none", background: "#fff" };
   const provBtn: any = { display: "flex", alignItems: "center", justifyContent: "center", gap: 10, width: "100%", padding: "10px 16px", borderRadius: 10, background: "#fff", border: "1.5px solid #E7E7EA", color: "#3A3A42", font: "600 13px Poppins", cursor: "pointer" };
   const lbl: any = { display: "block", font: "600 12px Poppins", color: "#6b6b72", marginBottom: 5 };
+  const iconWrap: any = { position: "absolute", left: 14, top: "50%", transform: "translateY(-50%)" };
 
   const GoogleIcon = (
     <svg width="16" height="16" viewBox="0 0 24 24"><path fill="#4285F4" d="M23.5 12.3c0-.9-.1-1.5-.3-2.2H12v4.3h6.5c-.1 1.1-.8 2.7-2.4 3.8l3.7 2.9c2.3-2.1 3.7-5.2 3.7-8.8z" /><path fill="#34A853" d="M12 24c3.2 0 6-1.1 8-2.9l-3.8-2.9c-1 .7-2.4 1.2-4.2 1.2-3.2 0-6-2.1-6.9-5.1L1.2 17.2C3.2 21.2 7.3 24 12 24z" /><path fill="#FBBC05" d="M5.1 14.3c-.2-.7-.4-1.5-.4-2.3s.1-1.6.4-2.3L1.2 6.8C.4 8.4 0 10.1 0 12s.4 3.6 1.2 5.2l3.9-2.9z" /><path fill="#EA4335" d="M12 4.7c1.8 0 3 .8 3.7 1.4l3.4-3.3C17 1.1 15.2 0 12 0 7.3 0 3.2 2.8 1.2 6.8l3.9 2.9C6 6.7 8.8 4.7 12 4.7z" /></svg>
@@ -154,7 +255,18 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
     <svg width="16" height="16" viewBox="0 0 24 24" fill="#1877F2"><path d="M24 12a12 12 0 1 0-13.9 11.9v-8.4h-3V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.4l-.5 3.5h-2.9v8.4A12 12 0 0 0 24 12z" /></svg>
   );
 
-  const headSub = view === "login" ? "Inicia sesión para seguir organizando tus eventos" : view === "forgot" ? "Te enviaremos un enlace para restablecerla" : "Un paso más y recuperas el acceso";
+  const showHeader = view !== "register";
+  const headSub =
+    view === "login" ? "Inicia sesión para seguir organizando tus eventos" :
+    view === "forgot" ? "Te enviaremos un enlace para restablecerla" :
+    view === "regform" ? "Completa tus datos para crear tu cuenta" :
+    view === "sent" ? "Un paso más y recuperas el acceso" : "";
+
+  const topBack = () => {
+    if (view === "regform") { setView("register"); return; }
+    if (view !== "login") { setView("login"); return; }
+    onClose();
+  };
 
   return (
     <div style={{ height: "100vh", minHeight: 640, display: "flex", background: "#fff", overflow: "hidden", fontFamily: "'Poppins',sans-serif" }}>
@@ -168,6 +280,7 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
         .ls-link:hover{color:#D83E7C;}
         .ls-eye:hover{background:#faf9fb;color:#6b6b72;}
         .ls-topback:hover{color:#3A3A42 !important;}
+        .ls-role:hover{filter:none !important;transform:scale(1.04);}
         @media(max-width:820px){.ls-left{display:none !important;}}
       ` }} />
 
@@ -188,7 +301,7 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
       {/* PANEL DERECHO · formulario */}
       <div style={{ flex: 1, display: "flex", flexDirection: "column", background: "#faf9fb", minWidth: 0 }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "16px 30px", flex: "none" }}>
-          <button type="button" onClick={() => { if (view !== "login") setView("login"); else onClose(); }} className="ls-topback" style={{ display: "inline-flex", alignItems: "center", gap: 8, font: "600 13px Poppins", color: "#6b6b72", textDecoration: "none", background: "none", border: "none", cursor: "pointer", padding: 0 }}>
+          <button type="button" onClick={topBack} className="ls-topback" style={{ display: "inline-flex", alignItems: "center", gap: 8, font: "600 13px Poppins", color: "#6b6b72", textDecoration: "none", background: "none", border: "none", cursor: "pointer", padding: 0 }}>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>Volver
           </button>
           <a href={brandHref} style={{ display: "inline-flex", alignItems: "center", gap: 6, font: "500 12.5px Poppins", color: "#6b6b72", textDecoration: "none", border: "1.5px solid #E7E7EA", borderRadius: 10, padding: "7px 14px", background: "#fff" }}>Ir a <b style={{ color: "#3A3A42" }}>{brandHost}</b><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round"><path d="M7 17L17 7M9 7h8v8" /></svg></a>
@@ -196,10 +309,12 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
 
         <div style={{ flex: 1, display: "flex", justifyContent: "center", overflow: "auto", padding: "0 20px 16px", minHeight: 0 }}>
           <div style={{ width: 400, maxWidth: "100%", margin: "auto", padding: "16px 0", animation: "ls-fadein .4s ease" }}>
-            <div style={{ textAlign: "center", marginBottom: 18 }}>
-              {logo ? <div style={{ display: "flex", justifyContent: "center", maxWidth: 225, margin: "0 auto" }}>{logo}</div> : <div style={{ font: "800 24px Poppins", color: "#EF5B94" }}>{config?.brand || "Bodas de Hoy"}</div>}
-              <div style={{ font: "500 12.5px Poppins", color: "#8a8a90", marginTop: 8 }}>{headSub}</div>
-            </div>
+            {showHeader && (
+              <div style={{ textAlign: "center", marginBottom: 18 }}>
+                {logo ? <div style={{ display: "flex", justifyContent: "center", maxWidth: 225, margin: "0 auto" }}>{logo}</div> : <div style={{ font: "800 24px Poppins", color: "#EF5B94" }}>{config?.brand || "Bodas de Hoy"}</div>}
+                {!!headSub && <div style={{ font: "500 12.5px Poppins", color: "#8a8a90", marginTop: 8 }}>{headSub}</div>}
+              </div>
+            )}
 
             {view === "login" && (
               <>
@@ -256,6 +371,91 @@ const LoginStudio: FC<Props> = ({ logo, config, whoYouAre, setStage, onClose }) 
                 </div>
                 <div style={{ textAlign: "center", font: "500 12.5px Poppins", color: "#6b6b72", marginTop: 14 }}>¿Aún no tienes cuenta? <a href="#" className="ls-link" onClick={(e) => { e.preventDefault(); goRegister(); }} style={{ fontWeight: 600 }}>Regístrate gratis</a></div>
               </>
+            )}
+
+            {view === "register" && (
+              <div style={{ textAlign: "center" }}>
+                <div style={{ font: "600 24px Poppins", color: "#EF5B94", marginBottom: 34 }}>¿Quién eres?</div>
+                <div style={{ display: "flex", justifyContent: "center", gap: 30, marginBottom: 36, flexWrap: "wrap" }}>
+                  {ROLES.map((r) => {
+                    const sel = role === r.key;
+                    return (
+                      <button key={r.key} type="button" onClick={() => setRole(r.key)} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12, background: "none", border: "none", cursor: "pointer", padding: 0 }}>
+                        <span className="ls-role" style={{ width: 96, height: 96, borderRadius: "50%", background: "#f0f0f2", display: "flex", alignItems: "center", justifyContent: "center", filter: sel ? "none" : "grayscale(1) opacity(.55)", transition: "filter .2s, transform .2s", boxShadow: sel ? "0 8px 20px rgba(239,91,148,.28)" : "none" }}>{r.icon}</span>
+                        <span style={{ font: "500 15px Poppins", color: sel ? "#EF5B94" : "#6b6b72" }}>{r.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                <button type="button" className="ls-primary" onClick={() => { if (role) setView("regform"); }} disabled={!role} style={{ padding: "13px 48px", borderRadius: 12, background: role ? "#EF5B94" : "#f2c9d9", border: "none", color: "#fff", font: "600 14px Poppins", cursor: role ? "pointer" : "default", boxShadow: role ? "0 6px 16px rgba(239,91,148,.3)" : "none" }}>Siguiente</button>
+                <div style={{ font: "500 12.5px Poppins", color: "#6b6b72", marginTop: 22 }}>¿Ya tienes cuenta? <a href="#" className="ls-link" onClick={(e) => { e.preventDefault(); setView("login"); }} style={{ fontWeight: 600 }}>Inicia sesión</a></div>
+              </div>
+            )}
+
+            {view === "regform" && (
+              <div style={{ background: "#fff", border: "1px solid #f0f0f2", borderRadius: 20, padding: "24px 28px 22px", boxShadow: "0 10px 30px rgba(0,0,0,.06)" }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: 9, marginBottom: 16 }}>
+                  <button type="button" className="ls-prov" style={provBtn} onClick={google}>{GoogleIcon}Continúa con Google</button>
+                  <button type="button" className="ls-prov" style={provBtn} onClick={facebook}>{FbIcon}Continúa con Facebook</button>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 16 }}>
+                  <div style={{ flex: 1, height: 1, background: "#ececef" }} />
+                  <span style={{ font: "500 11.5px Poppins", color: "#a0a0a8" }}>o con tu email</span>
+                  <div style={{ flex: 1, height: 1, background: "#ececef" }} />
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  <div>
+                    <label htmlFor="ls-rname" style={lbl}>Nombre y apellido</label>
+                    <div style={{ position: "relative" }}>
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a0a0a8" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" style={iconWrap}><circle cx="12" cy="8" r="4" /><path d="M4 21c0-4 3.6-6.5 8-6.5s8 2.5 8 6.5" /></svg>
+                      <input id="ls-rname" className="ls-in" autoComplete="name" value={rName} placeholder="María González"
+                        onChange={(e) => { setRName(e.target.value); setRNameErr(""); }}
+                        style={{ ...inSt, padding: "11px 15px 11px 38px", border: `1.5px solid ${rNameErr ? "#D83E7C" : "#E7E7EA"}` }} />
+                    </div>
+                    {rNameErr && <div style={{ font: "500 11.5px Poppins", color: "#D83E7C", marginTop: 5 }}>{rNameErr}</div>}
+                  </div>
+                  <div>
+                    <label htmlFor="ls-remail" style={lbl}>Correo electrónico</label>
+                    <div style={{ position: "relative" }}>
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a0a0a8" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" style={iconWrap}><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 7l9 6 9-6" /></svg>
+                      <input id="ls-remail" className="ls-in" type="email" autoComplete="email" value={rEmail} placeholder="nombre@correo.com"
+                        onChange={(e) => { setREmail(e.target.value); setREmailErr(""); setRAuthErr(""); }}
+                        style={{ ...inSt, padding: "11px 15px 11px 38px", border: `1.5px solid ${rEmailErr ? "#D83E7C" : "#E7E7EA"}` }} />
+                    </div>
+                    {rEmailErr && <div style={{ font: "500 11.5px Poppins", color: "#D83E7C", marginTop: 5 }}>{rEmailErr}</div>}
+                  </div>
+                  <div>
+                    <label htmlFor="ls-rpw" style={lbl}>Contraseña</label>
+                    <div style={{ position: "relative" }}>
+                      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#a0a0a8" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" style={iconWrap}><rect x="4" y="11" width="16" height="9" rx="2" /><path d="M8 11V7a4 4 0 0 1 8 0v4" /></svg>
+                      <input id="ls-rpw" className="ls-in" type={rShowPw ? "text" : "password"} autoComplete="new-password" value={rPw} placeholder="Mínimo 8 caracteres"
+                        onChange={(e) => { setRPw(e.target.value); setRPwErr(""); }}
+                        style={{ ...inSt, padding: "11px 42px 11px 38px", border: `1.5px solid ${rPwErr ? "#D83E7C" : "#E7E7EA"}` }} />
+                      <button type="button" className="ls-eye" title="Mostrar u ocultar contraseña" onClick={() => setRShowPw(!rShowPw)} style={{ position: "absolute", right: 6, top: "50%", transform: "translateY(-50%)", width: 32, height: 32, borderRadius: 8, display: "flex", alignItems: "center", justifyContent: "center", color: "#a0a0a8", background: "none", border: "none", cursor: "pointer" }}>{eye(rShowPw)}</button>
+                    </div>
+                    {rPwErr && <div style={{ font: "500 11.5px Poppins", color: "#D83E7C", marginTop: 5 }}>{rPwErr}</div>}
+                  </div>
+                  <div>
+                    <label htmlFor="ls-rphone" style={lbl}>Número de teléfono <span style={{ font: "500 11px Poppins", color: "#b3b3ba" }}>(opcional)</span></label>
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <span style={{ flex: "none", display: "flex", alignItems: "center", gap: 6, padding: "11px 12px", borderRadius: 10, border: "1.5px solid #E7E7EA", background: "#faf9fb", font: "600 12.5px Poppins", color: "#6b6b72" }}>{countryCode}</span>
+                      <input id="ls-rphone" className="ls-in" type="tel" autoComplete="tel" value={rPhone} placeholder="412 000 0000"
+                        onChange={(e) => setRPhone(e.target.value)}
+                        style={{ ...inSt, flex: 1, minWidth: 0, border: "1.5px solid #E7E7EA" }} />
+                    </div>
+                  </div>
+                  {rAuthErr && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 9, padding: "10px 15px", borderRadius: 999, background: "#FBE4EF", border: "1px solid #f2b9d3" }}>
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#D83E7C" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="9" /><path d="M12 8v4M12 16h.01" /></svg>
+                      <span style={{ font: "600 12px Poppins", color: "#D83E7C" }} role="alert">{rAuthErr}</span>
+                    </div>
+                  )}
+                  <button type="button" className="ls-primary" onClick={handleRegister} disabled={!canCreate || rLoading} style={{ width: "100%", padding: 12, borderRadius: 10, background: canCreate || rLoading ? "#EF5B94" : "#f2c9d9", border: "none", color: "#fff", font: "600 14px Poppins", cursor: canCreate ? "pointer" : "default", boxShadow: canCreate ? "0 6px 16px rgba(239,91,148,.3)" : "none", marginTop: 2, display: "flex", alignItems: "center", justifyContent: "center", gap: 9 }}>
+                    {rLoading && <span style={{ width: 15, height: 15, borderRadius: "50%", border: "2.5px solid rgba(255,255,255,.35)", borderTopColor: "#fff", animation: "ls-spin .8s linear infinite", display: "inline-block" }} />}
+                    {rLoading ? "Creando cuenta…" : "Crear cuenta"}
+                  </button>
+                </div>
+              </div>
             )}
 
             {view === "forgot" && (


### PR DESCRIPTION
## Qué
Segunda fase del login studio: añade el **registro** del HTML (`Login.dc.html`) al `LoginStudio`, gated `?studio`.

- **"¿Quién eres?"**: 3 perfiles (Wedding planner / Organizador de eventos / Novios), círculos 96px grayscale hasta seleccionar, "Siguiente".
- **Formulario**: Google/Facebook, nombre, email, contraseña (ojo), teléfono (+código país auto, opcional), "Crear cuenta".

## Backend (validado, mismo que FormRegister)
`createUserWithEmailAndPassword` → *(fallback `createUserWithPassword` + `signInWithCustomToken` si el email ya existe)* → `setCrossAppIdToken` → `updateProfile(displayName)` → `createUser({role,uid,email,phoneNumber})` → `setUser` + `setVerificationDone` (redirect vía useEffect de `login.tsx`).

**Nota validación:** `createUser` acepta `role:[String]` libre y **ningún flujo de negocio ramifica por el rol de registro** (solo se compara con `'admin'`; los `novia/novio` del código son del *tipo de evento*, no del registro). Por eso los 3 perfiles nuevos del HTML se guardan tal cual **sin romper nada**. Flujos especiales (`linkMedia`/preregistro) siguen delegando al registro **legacy**.

## Rollback
`?studio=legacy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)