### PR TITLE
🐛 fix(login): /login full-screen sin barra blanca ni scroll

### DIFF
--- a/apps/appEventos/components/DefaultLayout/Container.tsx
+++ b/apps/appEventos/components/DefaultLayout/Container.tsx
@@ -127,6 +127,15 @@ const Container = (props) => {
   const copilotOverlay = shouldMountChatSidebar && !copilotDocked;
   const copilotSlotWidth = copilotDocked ? dockedCopilotWidth + 4 : 0; // +4 px = asa de resize dentro del panel
 
+  // /login = pantalla full-screen propia (LoginStudio/SplitLoginPage gestionan su
+  // layout split a 100vh). Sin nav, sin barra de filtro, sin altura reservada de
+  // header (la de 152px) ni padding → elimina la "barra blanca" superior y el
+  // scroll; toda la info entra en una sola pantalla.
+  const isLoginScreen = (pathname?.split("/")[1] || "") === "login";
+  if (isLoginScreen) {
+    return <div className="w-screen h-screen overflow-hidden bg-base">{children}</div>;
+  }
+
   return (
     <>
       {showNavigation && <>


### PR DESCRIPTION
## Problema (reportado por owner, captura app-dev)
En `/login` studio salía una **barra blanca arriba** y el formulario **se cortaba** (requería scroll).

## Causa
`Container.tsx` ocultaba la navegación en `/login` pero **igual reservaba ~152px de altura de header** (`h-[calc(100vh-152px)]`) + `padding pt-4` + `CopilotFilterBar` + un contenedor `overflow-y-scroll`. Con `LoginStudio` a `100vh` dentro, quedaba franja blanca + overflow.

## Fix
`/login` retorna un wrapper **full-screen** directo (`w-screen h-screen`), sin nav / barra de filtro / altura reservada / padding. `LoginStudio` (y el `SplitLoginPage` legacy) gestionan su propio split a `100vh` → toda la info en una sola pantalla, sin scroll ni barra blanca. Scoped SOLO a `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)