### PR TITLE
🎨 feat(bandeja): /pendientes → vista "Esperan respuesta" (?view=esperan)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/NotificationBell.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/NotificationBell.tsx
@@ -19,7 +19,7 @@ function getNotificationUrl(n: AppNotification): string | null {
   if (focused.startsWith('/bandeja') || focused.startsWith('/chat/') || focused.startsWith('/settings')) {
     return focused.split('?')[0]; // strip query params for chat-ia navigation
   }
-  if (focused.startsWith('/tasks')) return '/pendientes'; // /tasks legacy → vista unificada
+  if (focused.startsWith('/tasks')) return '/bandeja?view=esperan'; // /tasks legacy → vista "Esperan respuesta"
   if (n.type === 'whatsapp_message') return '/bandeja';
   if (n.type === 'task_reminder') return '/bandeja';
   if (n.type === 'access_revoked' || n.type === 'permission_updated') return '/settings';

--- a/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
@@ -197,8 +197,12 @@ const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
           </div>
         </Link>
       )}
+      {/* Rediseño Fase B (14-ago): "Pendientes" ya no es una segunda bandeja con
+          store propio — apunta a la vista "Esperan respuesta" DENTRO de la Bandeja
+          (?view=esperan). Misma superficie, filtro no-leídos. Evita la percepción
+          de bandejas duplicadas. La ruta /pendientes redirige aquí. */}
       {isServerMode && isLoggedIn && (
-        <Link aria-label="Pendientes para ti" href={'/pendientes'} suppressHydrationWarning>
+        <Link aria-label="Pendientes para ti" href={'/bandeja?view=esperan'} suppressHydrationWarning>
           <div style={{ position: 'relative' }}>
             <ActionIcon
               icon={ListChecks}

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BandejaTabs, useActiveBandejaTab } from './components/BandejaTabs';
@@ -17,6 +17,14 @@ import { type FeedItem, useUnifiedFeed } from './hooks/useUnifiedFeed';
 export default function MessagesPage() {
   const router = useRouter();
   const activeTab = useActiveBandejaTab();
+  const searchParams = useSearchParams();
+  // FASE B (14-ago): vista "Esperan respuesta" — absorbe la antigua /pendientes.
+  // Se activa con ?view=esperan (el rail y el redirect de /pendientes apuntan aquí).
+  // Muestra lo NO leído de AMBOS tipos (conversaciones con unreadCount>0 +
+  // notificaciones sin leer) en una sola lista, en vez de una segunda "bandeja"
+  // con su propio store (lo que se percibía como bandejas duplicadas — informe
+  // rediseño mensajería 13-ago). useUnifiedFeed ya trae ambos tipos: 0 fuente nueva.
+  const esperanOnly = searchParams?.get('view') === 'esperan';
   const { items, loading, markNotificationRead } = useUnifiedFeed();
 
   // FASE B v2.0: scope selector. 'support' = bandeja del equipo;
@@ -89,7 +97,15 @@ export default function MessagesPage() {
   };
   const filteredItems = useMemo(() => {
     let arr = items;
-    if (activeTab === 'history') arr = arr.filter((i) => i.kind === 'notification');
+    if (esperanOnly) {
+      // Vista "Esperan respuesta": no leídos de AMBOS tipos (reemplaza el filtro
+      // por-tab). Conserva scope/spam/canal/RSVP debajo (por defecto no-op).
+      arr = arr.filter(
+        (i) =>
+          (i.kind === 'conversation' && i.unreadCount > 0) ||
+          (i.kind === 'notification' && !i.isRead),
+      );
+    } else if (activeTab === 'history') arr = arr.filter((i) => i.kind === 'notification');
     else if (activeTab === 'inbox') arr = arr.filter((i) => i.kind === 'conversation');
     if (activeScope !== 'support') {
       arr = arr.filter(
@@ -131,7 +147,7 @@ export default function MessagesPage() {
       );
     }
     return arr;
-  }, [items, activeTab, activeScope, channelFilter, rsvpFilter, pendingIaActive, showSpam]);
+  }, [items, esperanOnly, activeTab, activeScope, channelFilter, rsvpFilter, pendingIaActive, showSpam]);
 
   const notifUnreadCount = useMemo(
     () => items.filter((i) => i.kind === 'notification' && !i.isRead).length,
@@ -184,6 +200,25 @@ export default function MessagesPage() {
             className="flex w-[300px] shrink-0 flex-col overflow-hidden"
             style={{ backgroundColor: '#FFFFFF', borderRight: '1px solid #EDEDF0' }}
           >
+            {/* FASE B (14-ago): cabecera de la vista "Esperan respuesta" (?view=esperan,
+                antes /pendientes). Deja claro que es un filtro de "no leídos" y permite
+                volver a la bandeja completa sin perderse. */}
+            {esperanOnly && (
+              <div className="flex items-center justify-between gap-2 border-b border-gray-100 bg-amber-50 px-3 py-2">
+                <span className="text-[12px] font-semibold" style={{ color: '#92400e' }}>
+                  🔴 Esperan respuesta
+                </span>
+                <button
+                  className="text-[11px] font-medium underline"
+                  onClick={() => router.push('/bandeja')}
+                  // Color inline: el repo no usa variantes dark:, evita texto invisible.
+                  style={{ color: '#4b5563' }}
+                  type="button"
+                >
+                  Ver toda la bandeja
+                </button>
+              </div>
+            )}
             {/* ScopeSelector + filtros solo visibles en tab 'inbox'. En 'history'
                 el feed es plano (notificaciones) sin scope ni filtros canal/RSVP. */}
             {activeTab === 'inbox' && (

--- a/apps/chat-ia/src/app/[variants]/(main)/pendientes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/pendientes/page.tsx
@@ -1,268 +1,32 @@
 'use client';
 
 /**
- * /pendientes — Vista unificada "Pendientes para mí".
+ * /pendientes — REDIRECT a la Bandeja unificada (Fase B rediseño, 14-ago).
  *
- * Agrupa los 4 sistemas de actividad del producto:
- *   1. Mensajería externa (WhatsApp/Telegram/IG/FB/Email/Web chat)
- *   2. Chat IA (menciones, errores, tasks completadas)
- *   3. Comentarios en Servicios (appEventos)
- *   4. Comentarios en Itinerario (appEventos)
+ * Antes esta ruta era una SEGUNDA bandeja con su propio store (useBandejaStore),
+ * que mostraba lo no leído de conversaciones + notificaciones agrupado por
+ * dominio. Coexistía con /bandeja (useUnifiedFeed) cubriendo lo mismo por otro
+ * camino → los usuarios lo percibían como "bandejas de mensajes duplicadas"
+ * (informe rediseño mensajería 13-ago).
  *
- * Hoy lee del useBandejaStore que ya unifica conversations + notifications.
- * Cuando api-mcp emita notifications type='service_comment' /
- * 'itinerary_comment' aparecerán aquí automáticamente.
- *
- * Diseño: lista plana ordenada por timestamp desc, badges por tipo,
- * click → navega al origen (conversación, tarea, ítem itinerario).
+ * Se fusionó dentro de /bandeja como la vista "Esperan respuesta" (?view=esperan),
+ * que filtra lo NO leído de AMBOS tipos sobre la MISMA fuente (useUnifiedFeed) —
+ * sin perder las notificaciones (Regla 0). Esta ruta ahora redirige allí para
+ * conservar enlaces/marcadores existentes. Reversible: el historial git guarda
+ * la página original con el agrupado por secciones.
  */
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
+import { useEffect } from 'react';
 
-import { useAuthCheck } from '@/hooks/useAuthCheck';
-import { useBandejaStore } from '@/store/bandeja';
-
-import { buildHeaders } from '../bandeja/utils/auth';
-
-const SECTION_META: Record<
-  string,
-  { color: string; icon: string; label: string }
-> = {
-  conversation_externa: {
-    color: '#22C55E',
-    icon: '💬',
-    label: 'Mensajería',
-  },
-  chat_ia: { color: '#A855F7', icon: '🤖', label: 'Asistente' },
-  service_comment: { color: '#F59E0B', icon: '📋', label: 'Servicios' },
-  itinerary_comment: { color: '#3B82F6', icon: '📅', label: 'Itinerario' },
-  notification_otra: { color: '#6B7280', icon: '🔔', label: 'Otras' },
-};
-
-type SectionKey = keyof typeof SECTION_META;
-
-interface PendingItem {
-  id: string;
-  section: SectionKey;
-  title: string;
-  preview: string;
-  timestamp: string;
-  unreadCount: number;
-  url?: string;
-}
-
-function timeAgo(iso: string): string {
-  if (!iso) return '';
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const m = Math.floor(diffMs / 60_000);
-  if (m < 1) return 'ahora';
-  if (m < 60) return `${m}min`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d`;
-  return new Date(iso).toLocaleDateString('es-ES', { day: 'numeric', month: 'short' });
-}
-
-function classifyNotification(type: string | undefined): SectionKey {
-  if (!type) return 'notification_otra';
-  if (type === 'whatsapp_message') return 'conversation_externa';
-  if (type.startsWith('service_') || type === 'task_reminder')
-    return 'service_comment';
-  if (type.startsWith('itinerary_')) return 'itinerary_comment';
-  if (type.startsWith('chat_ia') || type === 'agent_completed') return 'chat_ia';
-  return 'notification_otra';
-}
-
-export default function PendientesPage() {
+export default function PendientesRedirect() {
   const router = useRouter();
-  // useShallow: Object.values() crea un array nuevo en cada llamada del selector.
-  // Con Zustand 5 (useSyncExternalStore sin memoización) eso rompe la estabilidad
-  // del snapshot → bucle "Maximum update depth exceeded" (React #185) que crasheaba
-  // /pendientes al 100%. useShallow devuelve la referencia anterior si el contenido
-  // es shallow-igual, cortando el loop. (Mismo patrón que useTypingInConv en el store.)
-  const conversations = useBandejaStore(useShallow((s) => Object.values(s.conversations)));
-  const notifications = useBandejaStore((s) => s.notifications);
-  const unreadCounts = useBandejaStore((s) => s.unreadCounts);
-  const initBandeja = useBandejaStore((s) => s.initBandeja);
-  const destroyBandeja = useBandejaStore((s) => s.destroyBandeja);
-
-  // BUG QA 14-jul: /pendientes salía "en blanco" (empty state "¡Sin pendientes!")
-  // porque el store bandeja solo se inicializa desde messages/layout.tsx, y esta
-  // ruta no está bajo ese layout — nadie llamaba initBandeja, así que
-  // conversations/notifications estaban vacías siempre. Inicializar aquí también
-  // (idempotente: initBandeja se auto-cierra si ya hay SSE viva).
-  const { checkAuth, isGuest } = useAuthCheck();
   useEffect(() => {
-    if (isGuest) return;
-    const { development } = checkAuth();
-    const dev = development || 'bodasdehoy';
-    void initBandeja(dev, () => buildHeaders());
-    return () => {
-      destroyBandeja();
-    };
-  }, [isGuest, checkAuth, initBandeja, destroyBandeja]);
-
-  const items: PendingItem[] = useMemo(() => {
-    const convItems: PendingItem[] = conversations
-      .filter((c) => c.unreadCount > 0)
-      .map((c) => ({
-        id: `conv-${c.id}`,
-        preview: c.lastMessage,
-        section: 'conversation_externa',
-        timestamp: c.lastMessageAt,
-        title: c.name,
-        unreadCount: c.unreadCount,
-        url: c.channelParam
-          ? `/bandeja/${encodeURIComponent(c.channelParam)}/${encodeURIComponent(c.conversationId)}`
-          : '/bandeja',
-      }));
-
-    const notifItems: PendingItem[] = notifications
-      .filter((n) => !n.read)
-      .map((n) => ({
-        id: `notif-${n.id}`,
-        preview: n.message,
-        section: classifyNotification(n.type),
-        timestamp: n.createdAt,
-        title: n.type ?? 'Notificación',
-        unreadCount: 1,
-        url: n.focused ? n.focused.split('?')[0] : undefined,
-      }));
-
-    return [...convItems, ...notifItems].sort((a, b) => {
-      const ta = a.timestamp ? new Date(a.timestamp).getTime() : 0;
-      const tb = b.timestamp ? new Date(b.timestamp).getTime() : 0;
-      return tb - ta;
-    });
-  }, [conversations, notifications]);
-
-  // Agrupar por sección para mostrar contadores
-  const bySection: Record<SectionKey, PendingItem[]> = items.reduce(
-    (acc, item) => {
-      (acc[item.section] ??= []).push(item);
-      return acc;
-    },
-    {} as Record<SectionKey, PendingItem[]>,
-  );
+    router.replace('/bandeja?view=esperan');
+  }, [router]);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-white">
-      {/* Header */}
-      <div className="border-b border-gray-200 px-6 py-4">
-        <h1 className="text-xl font-semibold text-gray-900">Pendientes para ti</h1>
-        <p className="mt-1 text-xs text-gray-500">
-          Todo lo que requiere tu atención — mensajería, comentarios en servicios y
-          itinerario, y notificaciones del asistente.
-        </p>
-      </div>
-
-      {/* Resumen por sección */}
-      <div className="flex gap-2 overflow-x-auto border-b border-gray-100 px-6 py-3">
-        {(Object.keys(SECTION_META) as SectionKey[]).map((key) => {
-          const meta = SECTION_META[key];
-          const count = bySection[key]?.length ?? 0;
-          return (
-            <div
-              key={key}
-              className="flex shrink-0 items-center gap-2 rounded-full border border-gray-200 px-3 py-1 text-xs"
-              style={{ background: count > 0 ? `${meta.color}10` : '#fafafa' }}
-            >
-              <span style={{ fontSize: 16 }}>{meta.icon}</span>
-              <span className="font-medium text-gray-700">{meta.label}</span>
-              <span
-                className="rounded-full px-2 py-0.5 text-[10px] font-bold text-white"
-                style={{ background: count > 0 ? meta.color : '#d1d5db' }}
-              >
-                {count}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Lista plana */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        {items.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center px-6 text-center">
-            <div className="text-5xl">✨</div>
-            <h2 className="mt-4 text-lg font-semibold text-gray-800">
-              ¡Sin pendientes!
-            </h2>
-            <p className="mt-2 max-w-sm text-sm text-gray-500">
-              Cuando llegue un mensaje nuevo, alguien comente en un servicio o ítem
-              de itinerario, o el asistente termine una tarea, aparecerá aquí.
-            </p>
-            <Link
-              href="/asistente"
-              className="mt-4 rounded-lg bg-violet-600 px-4 py-2 text-sm font-semibold text-white hover:bg-violet-700"
-            >
-              Ir al asistente
-            </Link>
-          </div>
-        ) : (
-          <ul className="divide-y divide-gray-100">
-            {items.map((item) => {
-              const meta = SECTION_META[item.section];
-              return (
-                <li key={item.id}>
-                  <button
-                    className="flex w-full items-start gap-3 px-6 py-3 text-left transition-colors hover:bg-gray-50"
-                    onClick={() => {
-                      if (item.url) router.push(item.url);
-                    }}
-                    type="button"
-                  >
-                    {/* Icon section */}
-                    <div
-                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg"
-                      style={{ background: `${meta.color}15`, color: meta.color }}
-                    >
-                      {meta.icon}
-                    </div>
-
-                    {/* Contenido */}
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-baseline justify-between gap-2">
-                        <span className="truncate text-sm font-semibold text-gray-900">
-                          {item.title}
-                        </span>
-                        <span className="shrink-0 text-[11px] text-gray-400">
-                          {timeAgo(item.timestamp)}
-                        </span>
-                      </div>
-                      <p className="truncate text-xs text-gray-500">{item.preview}</p>
-                      <div className="mt-1 flex items-center gap-2">
-                        <span
-                          className="rounded-full px-2 py-0.5 text-[10px] font-semibold"
-                          style={{ background: `${meta.color}15`, color: meta.color }}
-                        >
-                          {meta.label}
-                        </span>
-                        {item.unreadCount > 1 && (
-                          <span className="rounded-full bg-green-500 px-2 py-0.5 text-[10px] font-bold text-white">
-                            {item.unreadCount}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </div>
-
-      {/* Footer hint */}
-      {items.length > 0 && (
-        <div className="border-t border-gray-100 px-6 py-2 text-center text-[11px] text-gray-400">
-          {unreadCounts.total} mensajes sin leer · {unreadCounts.notifications}{' '}
-          notificaciones
-        </div>
-      )}
+    <div className="flex h-full items-center justify-center bg-white">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-pink-500" />
     </div>
   );
 }

--- a/apps/chat-ia/src/app/[variants]/(main)/tasks/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/tasks/page.tsx
@@ -1,17 +1,18 @@
 import { redirect } from 'next/navigation';
 
 /**
- * /tasks legacy → /pendientes
+ * /tasks legacy → /bandeja?view=esperan (vista "Esperan respuesta")
  *
  * /tasks era una ruta vestigio del fork LobeChat sin uso real en Bodas
  * de Hoy. Las tareas/servicios viven en appEventos `/servicios` y los
  * comentarios sobre cada uno generan notificaciones que se ven en la
- * vista unificada /pendientes (chat-ia).
+ * vista unificada de no-leídos de la Bandeja.
  *
- * Mantenemos la ruta para compatibilidad con notificaciones históricas
- * cuyo focused empieza con /tasks/... pero ahora apunta a /pendientes
- * (antes apuntaba a /messages).
+ * Fase B (14-ago): /pendientes se fusionó en /bandeja?view=esperan, así que
+ * apuntamos directo ahí para evitar un doble redirect (antes: /tasks →
+ * /pendientes → /bandeja). Mantenemos la ruta para notificaciones históricas
+ * cuyo focused empieza con /tasks/...
  */
 export default function TasksLegacyPage() {
-  redirect('/pendientes');
+  redirect('/bandeja?view=esperan');
 }


### PR DESCRIPTION
## Fase B rediseño mensajería — una sola bandeja

**Problema (informe 13-ago):** el usuario percibía *"bandejas de mensajes duplicadas"*. `/pendientes` era una **segunda bandeja** con store propio (`useBandejaStore`) que mostraba lo no leído de conversaciones + notificaciones — solapándose con `/bandeja` (`useUnifiedFeed`), que cubre lo mismo por otro camino.

**Solución — fusión sin pérdida (Regla 0):**
- `/bandeja` gana la vista **"Esperan respuesta"** (`?view=esperan`): filtra lo **NO leído de AMBOS tipos** (`conv.unreadCount>0` + `notif !isRead`) sobre `useUnifiedFeed` — que **ya unifica** conversaciones + notificaciones → **0 fuente de datos nueva**, sin perder notificaciones.
- Banner de contexto (🔴 Esperan respuesta) + botón "Ver toda la bandeja".
- Rail **"Pendientes para ti"** → `/bandeja?view=esperan` (misma superficie, filtro no-leídos).
- `/pendientes` → **redirect** a `/bandeja?view=esperan` (conserva enlaces/marcadores; la página original con agrupado por secciones queda en el historial git, **reversible**).
- `/tasks` legacy y `NotificationBell` apuntan **directo** a `/bandeja?view=esperan` (evita doble redirect).

## Verificación
- `eslint`: **sin errores nuevos** (los de `NotificationBell`/`any` de `page.tsx` son pre-existentes).
- Rutas compilan: `/bandeja`, `/bandeja?view=esperan`, `/pendientes`, `/tasks`.
- **Solo chat-ia**; appEventos intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)