### PR TITLE
🎨 feat(biblioteca): Archivos + Conocimiento con pestañas (Fase C)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/files/(content)/BibliotecaTabs.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/files/(content)/BibliotecaTabs.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { memo } from 'react';
+
+/**
+ * BibliotecaTabs — cabecera de la sección "Biblioteca" (Fase C rediseño, 15-ago).
+ *
+ * /files (Archivos) y /knowledge (Conocimiento) son dos caras del mismo material:
+ * ambos usan el mismo componente FileManager; Conocimiento añade las bases RAG.
+ * Antes eran dos entradas sueltas del rail (Conocimiento acabó OCULTO en Fase A),
+ * lo que dejaba las bases de conocimiento inalcanzables desde la navegación.
+ *
+ * Aquí se unifican bajo una sola superficie "Biblioteca" con pestañas, SIN fusionar
+ * los módulos: /knowledge es una SPA con MemoryRouter (react-router) y sus componentes
+ * crashean fuera de ese contexto (ver nota en files/page.tsx). Por eso solo se enlazan
+ * como pestañas — cada ruta mantiene su router. Se usan primitivas de Next (Link,
+ * usePathname), nunca hooks de react-router, para no romper nada.
+ *
+ * El rail sigue con UN solo icono "Biblioteca" → /files (sin clutter). Desde aquí se
+ * llega a Conocimiento. La ruta /knowledge sigue gateada por enableKnowledgeBase.
+ */
+const TABS: Array<{ href: string; key: string; label: string }> = [
+  { href: '/files', key: 'archivos', label: '📄 Archivos' },
+  { href: '/knowledge', key: 'conocimiento', label: '📚 Conocimiento' },
+];
+
+const BibliotecaTabs = memo(() => {
+  const pathname = usePathname();
+  const activeKey = pathname?.includes('/knowledge') ? 'conocimiento' : 'archivos';
+
+  return (
+    <div
+      style={{
+        alignItems: 'center',
+        background: '#FFFFFF',
+        borderBottom: '1px solid #EDEDF0',
+        display: 'flex',
+        flexShrink: 0,
+        gap: 4,
+        paddingInline: 12,
+      }}
+    >
+      {TABS.map((tab) => {
+        const active = tab.key === activeKey;
+        return (
+          <Link
+            href={tab.href}
+            key={tab.key}
+            style={{
+              // Color inline: el repo no usa variantes dark:, evita texto invisible.
+              borderBottom: active ? '2px solid #F7628C' : '2px solid transparent',
+              color: active ? '#111827' : '#6B7280',
+              fontSize: 13,
+              fontWeight: active ? 600 : 500,
+              padding: '10px 8px',
+              textDecoration: 'none',
+            }}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+});
+
+BibliotecaTabs.displayName = 'BibliotecaTabs';
+
+export default BibliotecaTabs;

--- a/apps/chat-ia/src/app/[variants]/(main)/files/(content)/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/files/(content)/page.tsx
@@ -7,6 +7,8 @@ import { Flexbox } from 'react-layout-kit';
 import FilePanel from '@/features/FileSidePanel';
 import { useShowMobileWorkspace } from '@/hooks/useShowMobileWorkspace';
 
+import BibliotecaTabs from './BibliotecaTabs';
+
 const FileManager = dynamic(() => import('@/features/FileManager'), {
   loading: () => <div style={{ padding: 24 }}>Cargando archivos...</div>,
   ssr: false,
@@ -23,16 +25,21 @@ const FilesPage = memo(() => {
   const showMobile = useShowMobileWorkspace();
 
   return (
-    <Flexbox
-      height={'100%'}
-      horizontal={!showMobile}
-      style={{ overflow: 'hidden', position: 'relative' }}
-      width={'100%'}
-    >
-      <Flexbox flex={1} style={{ overflow: 'hidden' }}>
-        <FileManager onOpenFile={setFileModalId} title="Archivos" />
+    <Flexbox height={'100%'} style={{ overflow: 'hidden' }} width={'100%'}>
+      {/* Fase C (15-ago): cabecera "Biblioteca" — Archivos + Conocimiento como una
+          sola superficie. Ver BibliotecaTabs para el porqué (no se fusionan módulos). */}
+      <BibliotecaTabs />
+      <Flexbox
+        flex={1}
+        horizontal={!showMobile}
+        style={{ overflow: 'hidden', position: 'relative' }}
+        width={'100%'}
+      >
+        <Flexbox flex={1} style={{ overflow: 'hidden' }}>
+          <FileManager onOpenFile={setFileModalId} title="Archivos" />
+        </Flexbox>
+        {fileModalId && <FilePanel id={fileModalId} />}
       </Flexbox>
-      {fileModalId && <FilePanel id={fileModalId} />}
     </Flexbox>
   );
 });


### PR DESCRIPTION
## Fase C rediseño nav — Biblioteca unificada

`/files` (Archivos) y `/knowledge` (Conocimiento) comparten el **mismo** `FileManager`; Conocimiento añade las bases RAG. Eran dos entradas sueltas del rail y Conocimiento acabó **oculto** en Fase A → las bases de conocimiento quedaban **inalcanzables** desde la navegación.

**Solución:** una sola superficie "Biblioteca" con pestañas **Archivos | Conocimiento** en `/files`, **sin fusionar** los módulos (que es imposible sin romper: `/knowledge` es una SPA con `MemoryRouter` cuyos componentes crashean fuera de ese contexto — documentado en `files/page.tsx`). El header usa **solo primitivas de Next** (`Link`/`usePathname`), nunca hooks de react-router.

- Rail: **un** icono "Biblioteca" → `/files` (sin clutter). Desde ahí se llega a Conocimiento.
- `/knowledge` sigue gateado por `enableKnowledgeBase`.
- Espejo de las pestañas **dentro** de la SPA de knowledge = polish opcional (no se toca el módulo sensible sin poder verificar su render autenticado).

## Verificación
- `eslint` limpio en los 2 archivos.
- Solo chat-ia; appEventos intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)