### PR TITLE
🐛 fix(sesión): cookie SSO en fast-path + /agentes fetch + limpia rail (QA tZBM)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/BottomActions.tsx
@@ -22,6 +22,12 @@ const ICON_SIZE: ActionIconProps['size'] = {
   strokeWidth: 1.5,
 };
 
+// Rediseño nav (QA 15-ago, caso 6): GitHub y Laboratorio son entradas del fork
+// LobeChat fuera del objetivo del producto — llenaban el rail de opciones. Se ocultan
+// (rutas siguen accesibles por URL). Reversible poniendo esto a true. Mismo patrón que
+// SHOW_LOBECHAT_EXTRAS en TopActions.
+const SHOW_LOBECHAT_EXTRAS = false;
+
 /** Plan tier badge — nudges FREE/TRIAL users to upgrade */
 const PlanBadge = memo(() => {
   const { tier, isTrial, trialDaysLeft, loading, isFreePlan } = usePlanLimits();
@@ -160,7 +166,7 @@ const BottomActions = memo(() => {
           />
         </Link>
       )}
-      {!hideGitHub && (
+      {SHOW_LOBECHAT_EXTRAS && !hideGitHub && (
         <Link aria-label={'GitHub'} href={GITHUB} target={'_blank'}>
           <ActionIcon
             icon={Github}
@@ -170,14 +176,16 @@ const BottomActions = memo(() => {
           />
         </Link>
       )}
-      <Link aria-label={t('labs')} href={'/labs'} suppressHydrationWarning>
-        <ActionIcon
-          icon={FlaskConical}
-          size={ICON_SIZE}
-          title={t('labs')}
-          tooltipProps={{ placement: 'right' }}
-        />
-      </Link>
+      {SHOW_LOBECHAT_EXTRAS && (
+        <Link aria-label={t('labs')} href={'/labs'} suppressHydrationWarning>
+          <ActionIcon
+            icon={FlaskConical}
+            size={ICON_SIZE}
+            title={t('labs')}
+            tooltipProps={{ placement: 'right' }}
+          />
+        </Link>
+      )}
     </Flexbox>
   );
 });

--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/SessionsBootstrap.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/SessionsBootstrap.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Suspense } from 'react';
+
+import { useFetchSessions } from '@/hooks/useFetchSessions';
+
+/**
+ * SessionsBootstrap — dispara el fetch de sesiones en /agentes (fix QA 15-ago).
+ *
+ * BUG: AgentsCoworkView se bloquea en "Cargando tus agentes…" hasta que
+ * `isSessionListInit` (= isSessionsFirstFetchFinished) sea true, pero ese flag
+ * SOLO lo pone `useFetchSessions`, que hasta ahora únicamente se invocaba en el
+ * Asistente (DefaultMode). Al promover /agentes a entrada de primer nivel del rail
+ * (Fase A), entrar DIRECTO a /agentes sin pasar antes por /asistente dejaba la
+ * vista colgada para siempre (repro QA confirmado).
+ *
+ * Fix: replicar el MISMO trigger canónico aquí. useFetchSessions usa un SWR con
+ * `suspense: true`, así que se aísla en su propio <Suspense> con un hijo que solo
+ * suspende y no pinta nada (fallback null) — no afecta al render de la vista. SWR
+ * deduplica por clave, así que si el Asistente ya lo pidió, aquí no hay doble fetch.
+ */
+const Fetcher = () => {
+  useFetchSessions();
+  return null;
+};
+
+const SessionsBootstrap = () => (
+  <Suspense fallback={null}>
+    <Fetcher />
+  </Suspense>
+);
+
+export default SessionsBootstrap;

--- a/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/agentes/page.tsx
@@ -30,6 +30,16 @@ const AgentsCoworkView = dynamic(() => import('./AgentsCoworkView'), {
   ssr: false,
 });
 
+// Fix QA 15-ago: dispara el fetch de sesiones al entrar DIRECTO a /agentes (si no,
+// isSessionListInit nunca se pone → "Cargando tus agentes…" infinito). ssr:false
+// para que el SWR con suspense sea client-only, igual que la vista. Ver SessionsBootstrap.
+const SessionsBootstrap = dynamic(() => import('./SessionsBootstrap'), { ssr: false });
+
 export default function AgentesPage() {
-  return <AgentsCoworkView />;
+  return (
+    <>
+      <SessionsBootstrap />
+      <AgentsCoworkView />
+    </>
+  );
 }

--- a/apps/chat-ia/src/app/[variants]/(main)/bandeja/layout.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/bandeja/layout.tsx
@@ -48,6 +48,21 @@ function hasLocalJwt(): boolean {
   } catch {
     /* ignore */
   }
+  // P0 coherencia de sesión (QA 15-ago): la llegada por SSO trae la sesión en cookies
+  // (idTokenV0.1.0 / mcp_jwt / sessionBodas) con localStorage aún vacío → sin esto,
+  // /bandeja mostraba "Acceso requerido" a usuarios YA autenticados. Un visitante real
+  // no tiene estas cookies. Ver el mismo fix en hooks/useDomainGuestUser.
+  try {
+    const hasCookie = document.cookie.split(';').some((part) => {
+      const idx = part.indexOf('=');
+      const k = (idx === -1 ? part : part.slice(0, idx)).trim();
+      const v = idx === -1 ? '' : part.slice(idx + 1).trim();
+      return (k === 'idTokenV0.1.0' || k === 'mcp_jwt' || k === 'sessionBodas') && v.length > 20;
+    });
+    if (hasCookie) return true;
+  } catch {
+    /* ignore */
+  }
   return false;
 }
 

--- a/apps/chat-ia/src/hooks/useDomainGuestUser.ts
+++ b/apps/chat-ia/src/hooks/useDomainGuestUser.ts
@@ -22,6 +22,27 @@ function hasLocalJwt(): boolean {
   }
 }
 
+// P0 coherencia de sesión (QA 15-ago, repro fiel): un usuario que llega por SSO
+// (primer load desde appEventos / pestaña nueva) trae la sesión en COOKIES
+// —idTokenV0.1.0 / mcp_jwt / sessionBodas— pero localStorage AÚN vacío hasta que
+// EventosAutoAuth lo puebla. hasLocalJwt() (solo localStorage) devolvía false en esa
+// ventana → todos los gates caían a "shell de visitante" pese a haber sesión válida
+// (bandeja mostraba "Acceso requerido", /files el muro, etc.). Un visitante REAL no
+// tiene ninguna de estas cookies → 0 impacto de seguridad. Detectarla cierra la ventana.
+function hasSsoCookie(): boolean {
+  if (typeof document === 'undefined') return false;
+  try {
+    return document.cookie.split(';').some((part) => {
+      const idx = part.indexOf('=');
+      const k = (idx === -1 ? part : part.slice(0, idx)).trim();
+      const v = idx === -1 ? '' : part.slice(idx + 1).trim();
+      return (k === 'idTokenV0.1.0' || k === 'mcp_jwt' || k === 'sessionBodas') && v.length > 20;
+    });
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Invitado en dominio Bodas: combina chat store + nombre en useUserStore (Lobe),
  * por si el perfil del chat llegó inconsistente por el merge de userData.
@@ -45,7 +66,9 @@ export function useDomainGuestUser(): boolean {
   // resuelve en el consumidor mostrando un loader durante la ventana (ver /integraciones, /files).
   const [hasJwt, setHasJwt] = useState(false);
   useEffect(() => {
-    setHasJwt(hasLocalJwt());
+    // localStorage O cookie SSO: cubre tanto el login directo (LS) como la llegada
+    // por SSO con LS aún sin poblar (cookie). Ver hasSsoCookie.
+    setHasJwt(hasLocalJwt() || hasSsoCookie());
   }, []);
 
   const lobeName = (username || fullName || '').toLowerCase().trim();


### PR DESCRIPTION
## Respuesta al QA de `tZBMiD4u9EDo05nlNFGo3` — reproducido FIEL con login real

Mi verificación previa inyectaba `mcp_jwt_token` en localStorage → hacía funcionar mi propio fast-path *por construcción* y enmascaraba el P0. Esta vez reproduje con **login real por UI**.

### P0 coherencia de sesión (causa raíz real)
`hasLocalJwt()` solo leía **localStorage**, pero un usuario que llega por **SSO** (primer load desde appEventos / pestaña nueva) trae la sesión en **cookies** (`idTokenV0.1.0` / `mcp_jwt` / `sessionBodas`) con localStorage **aún vacío** hasta que EventosAutoAuth lo puebla. En esa ventana los gates caían a "Acceso requerido". **Repro:** `/bandeja` → `[LLLL…GGGG]` (shell visitante).
**Fix:** `hasSsoCookie()` — el fast-path reconoce también la cookie SSO en `useDomainGuestUser` (canónico) y `bandeja/layout`. Un visitante real no tiene esas cookies → 0 impacto de seguridad.

### /agentes atascado en "Cargando tus agentes…"
`isSessionListInit` (=`isSessionsFirstFetchFinished`) solo lo pone `useFetchSessions`, que solo corría en el Asistente. Entrar directo a `/agentes` (ahora item de rail) lo dejaba colgado.
**Fix:** `SessionsBootstrap` dispara el mismo fetch en `/agentes`, aislado en `<Suspense>` + `ssr:false`. SWR deduplica.

### Rail (caso 6)
GitHub y Laboratorio ocultos (`SHOW_LOBECHAT_EXTRAS=false`).

### Notas para QA
- **Login recorte (caso 1):** en el build tZBM servido localmente el email queda **íntegro** (repro real). El recorte visto en `.bodasdehoy.com` apunta a **asset cacheado** en el túnel/CDN → probar con hard-reload.
- **WhatsApp modal equivocado (caso 5):** queda para investigación aparte (flujo QR reusa sesión del canal conectado).

Solo chat-ia; appEventos intacto. eslint limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)