### PR TITLE
🐛 fix(whatsapp): modal "Conectar" explica 1-número-por-espacio (QA caso 5)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/settings/integrations/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/settings/integrations/page.tsx
@@ -84,7 +84,34 @@ function QRModal({
         </div>
       )}
 
-      {!loading && status === 'connected' && (
+      {/* QA 15-ago (caso 5): el backend keyea la sesión de WhatsApp por SLUG del development
+          → hay UNA sola sesión por espacio. Si el usuario pulsa "Conectar" en un canal
+          DESCONECTADO mientras OTRO número ya está conectado en el espacio, antes salía el
+          bloque "✅ Conectado +34…" bajo el título "Conectar: <este canal>" → confuso (parecía
+          que ESTE canal estaba conectado a ese número). Ahora se explica la restricción real
+          en vez de mostrar ambiguo. (No se parchea la API: es límite del backend, se comunica.) */}
+      {!loading && status === 'connected' && channel && channel.status !== 'ACTIVE' && (
+        <Space direction="vertical" size="middle" style={{ textAlign: 'center', width: '100%' }}>
+          <div style={{ fontSize: 40 }}>⚠️</div>
+          <div>
+            <Text strong>Ya hay un WhatsApp conectado en este espacio</Text>
+            {phoneNumber && <div><Text type="secondary">+{phoneNumber}</Text></div>}
+          </div>
+          <Alert
+            message={`WhatsApp permite un número por espacio. Para vincular «${channel.name}», primero desconecta el número actual.`}
+            showIcon
+            type="warning"
+          />
+          <Space>
+            <Button onClick={onClose}>Cancelar</Button>
+            <Button danger onClick={async () => { await disconnectSession(); onClose(); }}>
+              Desconectar el actual
+            </Button>
+          </Space>
+        </Space>
+      )}
+
+      {!loading && status === 'connected' && (!channel || channel.status === 'ACTIVE') && (
         <Space direction="vertical" size="middle" style={{ textAlign: 'center', width: '100%' }}>
           <div style={{ fontSize: 48 }}>✅</div>
           <div>


### PR DESCRIPTION
## QA build tZBM · caso 5 — modal QR equivocado

Al pulsar **"Conectar"** en un canal QR **desconectado**, el modal mostraba "✅ Conectado +34910603622" (de OTRO número) bajo el título "Conectar: <este canal>" → confuso.

**Causa raíz (arquitectura):** el backend keyea la sesión de WhatsApp por **SLUG del development** → **una sola sesión por espacio**. `QRModal` usa `useWhatsAppSession(development)`, así que cualquier canal muestra la misma sesión.

**Fix honesto (NO se parchea la API — es límite del backend, se comunica):** cuando la sesión del espacio está `connected` pero el canal pulsado NO es el activo (`channel.status !== 'ACTIVE'`), el modal muestra un aviso claro (1 número por espacio + "Desconectar el actual") en vez del "✅ Conectado" ambiguo. El bloque conectado normal solo sale para el canal activo.

**Verificación:** compila + lógica (este estado exige un espacio con WA realmente conectado + un canal desconectado → lo confirma QA). eslint: 0 errores nuevos.

Solo chat-ia; appEventos intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)