### PR TITLE
🐛 fix(sesión): puente cookie SSO→localStorage (P0 Visitante) + cosméticos QA

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/SideBar/TopActions.tsx
@@ -202,12 +202,12 @@ const TopActions = memo<TopActionProps>(({ tab, isPinned }) => {
           (?view=esperan). Misma superficie, filtro no-leídos. Evita la percepción
           de bandejas duplicadas. La ruta /pendientes redirige aquí. */}
       {isServerMode && isLoggedIn && (
-        <Link aria-label="Pendientes para ti" href={'/bandeja?view=esperan'} suppressHydrationWarning>
+        <Link aria-label="Pendientes" href={'/bandeja?view=esperan'} suppressHydrationWarning>
           <div style={{ position: 'relative' }}>
             <ActionIcon
               icon={ListChecks}
               size={ICON_SIZE}
-              title="Pendientes para ti"
+              title="Pendientes"
               tooltipProps={{ placement: 'right' }}
             />
             {inboxUnread > 0 && (

--- a/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/index.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/_layout/Desktop/index.tsx
@@ -19,6 +19,7 @@ import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfi
 import { HotkeyScopeEnum } from '@/types/hotkey';
 
 import { resolveChatEmbedMode } from '@/utils/resolveChatEmbedMode';
+import { hydrateDomainConfigFromCookie } from '@/utils/domainSessionBridge';
 
 import DesktopLayoutContainer from './DesktopLayoutContainer';
 import RegisterHotkeys from './RegisterHotkeys';
@@ -31,6 +32,12 @@ const TitleBar = dynamic(() => import('@/features/ElectronTitlebar'), { ssr: fal
 const HotkeyHelperPanel = dynamic(() => import('@/features/HotkeyHelperPanel'), { ssr: false });
 
 const Layout = memo<PropsWithChildren>(({ children }) => {
+  // P0 sesión coherente (QA 15-ago): sembrar localStorage desde la cookie SSO ANTES
+  // de que rendericen los hijos (SideBar/UserInfo) y EventosAutoAuth, para cerrar la
+  // ventana de "Visitante"/gate-invitado en llegada por SSO. Idempotente + no-op en
+  // sesión caliente (ver domainSessionBridge). Corre en cliente (guard interno SSR).
+  hydrateDomainConfigFromCookie();
+
   const searchParams = useSearchParams();
   const isEmbed = resolveChatEmbedMode(
     searchParams,

--- a/apps/chat-ia/src/app/[variants]/(main)/settings/integrations/page.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/settings/integrations/page.tsx
@@ -23,6 +23,11 @@ import { useWhatsAppSession } from '../../bandeja/hooks/useWhatsAppSession';
 
 const { Title, Text, Paragraph } = Typography;
 
+// Normaliza el prefijo "+" de un teléfono (QA 15-ago: algunos números ya venían con
+// "+" del backend y la UI anteponía otro → "++34…"). Un solo "+" siempre.
+const withPlus = (n?: string | number | null): string =>
+  n === undefined || n === null || n === '' ? '' : `+${String(n).replace(/^\++/, '')}`;
+
 // ─── QR Modal (antd) ──────────────────────────────────────────────────────────
 
 function QRModal({
@@ -95,7 +100,7 @@ function QRModal({
           <div style={{ fontSize: 40 }}>⚠️</div>
           <div>
             <Text strong>Ya hay un WhatsApp conectado en este espacio</Text>
-            {phoneNumber && <div><Text type="secondary">+{phoneNumber}</Text></div>}
+            {phoneNumber && <div><Text type="secondary">{withPlus(phoneNumber)}</Text></div>}
           </div>
           <Alert
             message={`WhatsApp permite un número por espacio. Para vincular «${channel.name}», primero desconecta el número actual.`}
@@ -116,7 +121,7 @@ function QRModal({
           <div style={{ fontSize: 48 }}>✅</div>
           <div>
             <Text strong>WhatsApp Conectado</Text>
-            {phoneNumber && <div><Text type="secondary">+{phoneNumber}</Text></div>}
+            {phoneNumber && <div><Text type="secondary">{withPlus(phoneNumber)}</Text></div>}
             {connectedAt && (
               <div><Text style={{ fontSize: 12 }} type="secondary">Desde {new Date(connectedAt).toLocaleString('es-ES')}</Text></div>
             )}
@@ -266,7 +271,7 @@ function ChannelCard({
               <Badge status={cfg.status} text={cfg.label} />
               <Text style={{ fontSize: 12, marginLeft: 8 }} type="secondary">{TYPE_LABELS[channel.type] ?? channel.type}</Text>
             </div>
-            {channel.phoneNumber && <div><Text style={{ fontSize: 12 }} type="secondary">+{channel.phoneNumber}</Text></div>}
+            {channel.phoneNumber && <div><Text style={{ fontSize: 12 }} type="secondary">{withPlus(channel.phoneNumber)}</Text></div>}
           </div>
         </Space>
         <Space>
@@ -427,7 +432,7 @@ function WhatsAppDirectSession({ development }: { development: string }) {
       <div style={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
         <Space>
           <Badge status="success" text="Conectado" />
-          {phoneNumber && <Text type="secondary">+{phoneNumber}</Text>}
+          {phoneNumber && <Text type="secondary">{withPlus(phoneNumber)}</Text>}
           {connectedAt && (
             <Text style={{ fontSize: 12 }} type="secondary">
               desde {new Date(connectedAt).toLocaleDateString('es-ES')}

--- a/apps/chat-ia/src/utils/domainSessionBridge.ts
+++ b/apps/chat-ia/src/utils/domainSessionBridge.ts
@@ -1,0 +1,67 @@
+/**
+ * Puente de sesión SSO: cookie `dev-user-config` → localStorage.
+ *
+ * P0 coherencia de sesión (QA 15-ago, 2 informes). Un usuario que llega por SSO
+ * (primer load desde appEventos / pestaña nueva) trae la sesión en COOKIES del
+ * dominio `.bodasdehoy.com`, pero localStorage está VACÍO (es por-origen). El
+ * bootstrap de identidad (EventosAutoAuth) siembra `currentUserId`/perfil leyendo
+ * `dev-user-config` de localStorage → en ese caso no encuentra nada y cae al camino
+ * LENTO de validación contra backend. Durante esa ventana la app muestra "Visitante"
+ * y gates de invitado en rutas clave (muy visible en el túnel real por la latencia;
+ * casi invisible en localhost — por eso los repros locales no lo reproducían).
+ *
+ * Este puente copia la cookie a localStorage ANTES de que corra EventosAutoAuth, para
+ * que tome el camino RÁPIDO (sembrar desde localStorage) y la identidad resuelva de
+ * inmediato — cerrando la ventana de "Visitante" en el origen, para gates E identidad.
+ *
+ * Seguridad / no-regresión:
+ *  - NO-OP si localStorage ya tiene la config (sesión caliente) → no toca lo que ya
+ *    funciona.
+ *  - NO-OP si no hay cookie (visitante real) → no inventa sesión.
+ *  - La cookie la escribe el propio EventosAutoAuth (misma fuente, maxage 30d), y su
+ *    validación posterior descarta tokens expirados igual que si vinieran de localStorage
+ *    → 0 nueva superficie de confianza.
+ */
+
+let bridged = false;
+
+function readCookie(name: string): string | null {
+  try {
+    const prefix = `${name}=`;
+    const part = document.cookie
+      .split(';')
+      .map((s) => s.trim())
+      .find((s) => s.startsWith(prefix));
+    return part ? part.slice(prefix.length) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hydrateDomainConfigFromCookie(): void {
+  if (typeof window === 'undefined' || bridged) return;
+  try {
+    const existing = localStorage.getItem('dev-user-config');
+    if (existing && existing !== 'null' && existing !== 'undefined') {
+      bridged = true; // ya hay sesión en localStorage → nada que sembrar
+      return;
+    }
+    const raw = readCookie('dev-user-config');
+    if (!raw) return; // sin cookie → visitante real, no tocar (reintenta en próximos renders)
+    const decoded = decodeURIComponent(raw);
+    const parsed = JSON.parse(decoded);
+    const identity = parsed?.userId || parsed?.user_id || parsed?.email;
+    if (!parsed || !identity) return; // cookie sin identidad → no sembrar
+    localStorage.setItem('dev-user-config', decoded);
+    // Sembrar también los tokens que algunos gates leen directo de localStorage
+    // (hasLocalJwt, UserInfo.hasActiveSession, etc.).
+    const token = parsed.token;
+    if (token && typeof token === 'string' && token.length > 20) {
+      localStorage.setItem('jwt_token', token);
+      localStorage.setItem('mcp_jwt_token', token);
+    }
+    bridged = true;
+  } catch {
+    /* ante la duda NO sembramos (fail-safe hacia visitante) */
+  }
+}


### PR DESCRIPTION
## Coordinación de 2 informes QA sobre `7W7JRc7QuZMkLq7f1edF1`

QA1 (nav caliente por rail) vio el **P0 verde**; QA2 (hard-reload por ruta, entorno real) vio **"Visitante"/shell de invitado** en `/asistente`, `/files`, `/knowledge`, `/bandeja`. La contradicción no es un error de QA: **el P0 es intermitente y dependiente de latencia**.

### Causa raíz (por código)
La identidad (`currentUserId` + etiqueta de usuario en `UserInfo`) la siembra `EventosAutoAuth` leyendo `dev-user-config` de **localStorage**. En llegada por **SSO** la sesión viene en **cookies** (`.bodasdehoy.com`) y localStorage está **vacío** → EventosAutoAuth no encuentra nada y cae al camino **lento** de validación backend. Durante esa ventana la app muestra "Visitante". Muy visible en el túnel CF real; casi invisible en localhost (por eso los repros locales no lo pillaban — y mis needles no buscaban "Visitante": corregido).

### Fix raíz
`hydrateDomainConfigFromCookie()` copia la cookie `dev-user-config` → localStorage **antes** de que rendericen los hijos y EventosAutoAuth (montado en el layout **global** `(main)/_layout/Desktop`). EventosAutoAuth toma el camino **rápido** → identidad inmediata, cerrando la ventana para **gates e identidad** en el origen.
**No-regresión:** NO-OP si localStorage ya tiene sesión (caliente) y si no hay cookie (visitante real).

### Cosméticos QA
- Rail **"Pendientes para ti" → "Pendientes"** (caso 6).
- Teléfonos **"++34…" → "+34…"** (helper `withPlus`).

### Verificación
El beneficio de **timing no se reproduce en localhost** (latencia casi nula). El puente es correcto por construcción y no-op en caliente. **QA debe confirmar en chat-dev real** (llegada por SSO desde appEventos + hard-reload).

Solo chat-ia; appEventos intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)