### PR TITLE
🐛 fix(sesión): elimina flash de invitado en /asistente (nav client-side, QA IQV)

### DIFF
--- a/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/ChatList/WelcomeChatItem/index.tsx
+++ b/apps/chat-ia/src/app/[variants]/(main)/asistente/(workspace)/@conversation/features/ChatList/WelcomeChatItem/index.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 
+import { useDomainGuestUser } from '@/hooks/useDomainGuestUser';
 import { sessionSelectors } from '@/store/session/selectors';
 import { useSessionStore } from '@/store/session/store';
 import { useChatStore } from '@/store/chat';
@@ -10,20 +11,15 @@ import GuestWelcomeMessage from '@/features/GuestWelcomeMessage';
 
 const WelcomeChatItem = memo(() => {
   const isGroupSession = useSessionStore(sessionSelectors.isCurrentSessionGroupSession);
-  const currentUserId = useChatStore((s) => s.currentUserId);
-  const userType = useChatStore((s) => s.userType);
   const externalChatsInit = useChatStore((s) => s.externalChatsInit);
 
-  // ✅ CORRECCIÓN: Verificar si es visitante DESPUÉS de que la sesión se haya inicializado
-  // Esto evita mostrar el mensaje de registro antes de cargar la sesión desde localStorage
-  const isVisitorUser =
-    !currentUserId ||
-    currentUserId === 'visitante@guest.local' ||
-    currentUserId === 'guest' ||
-    currentUserId === 'anonymous' ||
-    currentUserId?.startsWith('visitor_') ||
-    userType === 'guest' ||
-    userType === 'visitor';
+  // P0 coherencia de sesión (QA 15-ago): usar la detección CANÓNICA cookie-aware en vez
+  // de leer currentUserId/userType crudos. Antes, en navegación client-side a /asistente,
+  // si externalChatsInit se ponía true ANTES de que currentUserId estuviera poblado, se
+  // mostraba GuestWelcomeMessage ("Regístrate/Crear cuenta") a usuarios YA autenticados
+  // (flash de invitado que QA veía antes del hard-reload). useDomainGuestUser tiene el
+  // fast-path de sesión SSO (cookie/JWT) → devuelve false aunque currentUserId aún no llegue.
+  const isVisitorUser = useDomainGuestUser();
 
   if (isGroupSession) return <GroupWelcome />;
 

--- a/apps/chat-ia/src/features/User/UserInfo.tsx
+++ b/apps/chat-ia/src/features/User/UserInfo.tsx
@@ -135,9 +135,13 @@ const UserInfo = memo<UserInfoProps>(({ avatarProps, onClick, ...rest }) => {
           </Flexbox>
           <div className={styles.username}>
             {/* ✅ CORRECCIÓN CRÍTICA: SIEMPRE mostrar currentUserId si existe y es válido */}
+            {/* P0 (QA 15-ago): si hay sesión (no es domain-guest) pero currentUserId aún no
+                llegó (ventana SSO en nav client-side), NO mostrar "Visitante" —era el flash de
+                identidad que veía QA. Se deja neutro hasta que resuelve. Un guest real (isDomainGuest)
+                sigue viendo "Visitante". */}
             {currentUserId && currentUserId !== 'visitante@guest.local'
               ? currentUserId  // Mostrar email del usuario registrado
-              : (userEmail || 'Visitante')}  {/* Solo usar userEmail como fallback, NO username de useUserStore */}
+              : (userEmail || (isDomainGuest ? 'Visitante' : ''))}
           </div>
         </Flexbox>
       </Flexbox>


### PR DESCRIPTION
## QA sobre `IQV723l49WJQOlc5rnk2J`: P0 verde con hard-reload, pero borde en nav client-side

QA confirmó: **con hard-reload el P0 sale verde**, pero en **navegación client-side** a `/asistente` (sin recarga) todavía asomaba shell de invitado ("Regístrate/Crear cuenta" + "Visitante") a usuarios YA autenticados.

**Causa:** dos componentes leían el store **crudo** (`currentUserId`/`userType`) en vez de la detección canónica cookie-aware. Cuando `externalChatsInit` se ponía true antes de que `currentUserId` estuviera poblado (ventana SSO en nav client-side), mostraban contenido de invitado.

**Fix:**
- `WelcomeChatItem` → `useDomainGuestUser()` (fast-path cookie/JWT) en vez del check crudo.
- `UserInfo` → la línea de usuario ya no cae a "Visitante" cuando hay sesión y `currentUserId` aún no resolvió (queda neutro). Un guest **real** sigue viendo "Visitante".

El puente cookie→localStorage (build previo) cerró el caso **hard-reload**; esto cierra el borde de **nav client-side**.

Solo chat-ia; appEventos intacto. eslint limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)